### PR TITLE
Add alert styles. Fixes #9.

### DIFF
--- a/packages/lit-dev-content/site/css/main.css
+++ b/packages/lit-dev-content/site/css/main.css
@@ -268,6 +268,29 @@ section#features {
 
 /** Guide */
 
+.alert {
+  position: relative;
+  margin: 24px 0;
+  padding: 1px 20px 1px 56px;
+  box-shadow: 0 0 2px #ccc;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+
+.alert::before {
+  position: absolute;
+  top: 17px;
+  left: 17px;
+}
+
+.alert.alert-info::before {
+  content: url(/images/alerts/info.svg);
+}
+
+.alert.alert-warning::before {
+  content: url(/images/alerts/warning.svg);
+}
+
 main.wrapper {
   display: flex;
 }


### PR DESCRIPTION
This just ports the old alert styles from the LitElement site to make the text readable until we get new designs.