### PR TITLE
Fix lit.dev deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@
 # https://hub.docker.com/_/node
 FROM node:14-slim
 
+# Dependencies of Playwright Chromium.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgtk-3-0 \
+  libnss3 \
+  libasound2
+
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "lerna run build",
+    "build": "lerna run build --stream",
     "start": "cd packages/lit-dev-server && npm start",
     "format": "prettier \"**/*.{ts,js,json,html,css,md}\" --write",
     "nuke": "rm -rf node_modules package-lock.json packages/*/node_modules packages/*/package-lock.json && npm install && npm run bootstrap"


### PR DESCRIPTION
- Install missing dependencies for Playwright Chromium.
- Add `--stream` to `lerna run build` command so that we see logs in the future.

Fixes https://github.com/PolymerLabs/lit.dev/issues/33