### PR TITLE
lit.dev main page sweep for mobile friendliness and general presentability

### DIFF
--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined&display=block" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,800;1,400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;1,300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{site.baseurl}}/css/main.css">
     <link rel="stylesheet" href="{{site.baseurl}}/css/theme.css">
     <link rel="stylesheet" href="{{site.baseurl}}/css/codemirror.css">
@@ -23,14 +24,15 @@
   <body>
     {% include 'topnav.html' %}
 
-    {% block content %}{{ content | safe }}{% endblock %}
+    <main>
+      {% block content %}{{ content | safe }}{% endblock %}
+    </main>
 
     <footer>
         <div class="wrapper">
           <div class="social-links">
             <a target="_blank" href="https://github.com/Polymer/lit-html" rel="noopener" aria-label="Github"><img src="/images/logos/logo_github.svg"></a>
             <a target="_blank" href="https://twitter.com/polymer" rel="noopener" aria-label="Twitter"><img src="/images/logos/logo_twitter.svg"></a>
-            <a target="_blank" href="https://groups.google.com/forum/#!forum/polymer-dev" rel="noopener" aria-label="Email"><img src="/images/logos/logo_email.svg"></a>
             <a target="_blank" href="https://www.polymer-project.org/slack-invite" rel="noopener" aria-label="Slack"><img src="/images/logos/logo_slack.svg"></a>
           </div>
           <div class="attribution">

--- a/packages/lit-dev-content/site/_includes/topnav.html
+++ b/packages/lit-dev-content/site/_includes/topnav.html
@@ -1,5 +1,5 @@
 <nav class="main-nav" markdown="0">
-  <a class="nav-title" href="{{ site.baseurl }}/">LitX</a>
+  <a class="nav-title" href="{{ site.baseurl }}/">Lit</a>
   <div class="flex"></div>
   <a class="nav-item{% if page.url == '/' %} active{% endif %}" href="{{ site.baseurl }}/">Features</a>
   <a class="nav-item{% if page.url.includes('/guide') %} active{% endif %}" href="{{ site.baseurl }}/guide/">Guide</a>

--- a/packages/lit-dev-content/site/css/main.css
+++ b/packages/lit-dev-content/site/css/main.css
@@ -52,8 +52,8 @@ h1 {
 }
 
 .main-nav .nav-title {
-  font-size: 40px;
-  font-weight: bold;
+  font-size: 34px;
+  font-weight: 400;
   /* font-style: italic; */
   text-decoration: none;
   font-family: 'Roboto', sans-serif;
@@ -106,20 +106,27 @@ h1 {
   transition: transform 0.2s;
 }
 
+/** Main content */
+
+main {
+  padding: 24px;
+}
+
 /** Hero */
 
 .hero {
   margin: 100px auto;
   max-width: 800px;
+  text-align: center;
 }
 
 .hero-title {
   position: relative;
   margin-bottom: -14px;
-  padding-right: 5%;
   font-size: 60px;
   font-weight: 400;
   line-height: 1.3em;
+  color: #1e88e5;
 }
 
 .hero-title::after {
@@ -132,31 +139,27 @@ h1 {
 }
 
 .hero-caption {
-  max-width: 640px;
-  padding-right: 10%;
-  line-height: 38px;
   font-size: 28px;
-  font-weight: 400;
+  font-weight: 300;
+  color: #808080;
 }
 
 /** Main Example */
 
-.wrapper.example pre {
-  max-width: 800px;
+.wrapper.example {
+  max-width: 660px;
   margin: 48px auto;
 }
 
-/** Use Cases */
-
-.wrapper.use-cases {
-  /* max-width: 800px; */
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: minmax(100px, auto);
-  grid-gap: 24px;
-  /* color: white; */
-  padding: 48px 24px;
+.example .CodeMirror {
+  border: 1px solid #dedede;
+  border-radius: 5px;
+  padding: 0 20px;
+  overflow-y: auto !important;
+  margin-bottom: 20px;
 }
+
+/** Use Cases */
 
 .use-case-card {
   display: flex;
@@ -164,6 +167,26 @@ h1 {
   background: linear-gradient(135deg, #a5d3ff 0%,#69b6ff 100%);
   border-radius: 8px;
   padding: 16px;
+  margin-bottom: 24px;
+}
+
+@media (min-width: 900px) {
+  #use-cases {
+    margin: 0 -24px;
+  }
+  .wrapper.use-cases {
+    /* max-width: 800px; */
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: minmax(100px, auto);
+    grid-gap: 24px;
+    /* color: white; */
+    padding: 48px 24px;
+    margin: 0 auto;
+  }
+  .use-case-card {
+    margin: 0;
+  }
 }
 
 .use-case-card h3 {
@@ -172,6 +195,8 @@ h1 {
   font-size: 1.25em;
   letter-spacing: .5px;
   margin-top: 0;
+  color: #002e5a;
+  font-weight: 400;
 }
 
 .use-case-card > p {
@@ -201,29 +226,18 @@ h1 {
 section#features {
   background: #1e88e5;
   color: white;
-  padding: 48px 12px;
-}
-
-.wrapper.features {
-  background: #1e88e5;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: minmax(100px, auto);
-  grid-gap: 12px;
-  color: white;
-  padding: 48px 12px;
+  column-width: 400px;
+  column-gap: 48px;
+  padding: 24px;
+  margin: 0 -24px;
 }
 
 
 .feature-card {
   display: flex;
   line-height: 1.4;
-}
-
-.feature-card.main {
-  display: flex;
-  grid-column: 3;
-  grid-row: 1 / 3;
+  padding-bottom: 24px;
+  break-inside: avoid;
 }
 
 .feature-card-icon {
@@ -233,7 +247,7 @@ section#features {
   --mdc-icon-font: 'Material Icons Outlined';
   border-radius: 50%;
   padding: 8px;
-  margin-right: 12px;
+  margin-right: 24px;
 }
 
 .feature-card-text h3 {
@@ -245,25 +259,30 @@ section#features {
 
 /** Used By */
 
-#used-by {
-  padding: 48px 0;
-  margin-bottom: 100px;
-}
-
 .used-by-logos {
-  display: flex;
-  overflow-y: hidden;
+  text-align: center;
 }
 
 .used-by {
+  display: inline-block;
   filter: grayscale(100%);
   opacity: 70%;
   margin: 24px;
+  zoom: 50%;
+  vertical-align: middle;
 }
 
 .used-by:hover {
   filter: none;
   opacity: unset;
+}
+
+#used-by h2 {
+  text-align: center;
+  font-weight: 400;
+  margin-top: 48px;
+  color: #4c4c4c;
+  font-size: 28px;
 }
 
 /** Guide */
@@ -384,6 +403,7 @@ main > nav.toc > div.toc > ol a:hover {
 footer {
   background: #f5f5f5;
   margin-top: 32px;
+  text-align: center;
 }
 
 footer .wrapper {
@@ -402,6 +422,7 @@ footer .group {
 }
 
 footer .attribution {
+  text-align: center;
   display: inline-block;
   vertical-align: top;
   font-size: 14px;
@@ -424,7 +445,23 @@ footer .social-links img {
   height: 24px;
 }
 
+.wrapper.example {
+  overflow-x: auto;
+}
+.wrapper.example .CodeMirror {
+   overflow: unset;
+}
+
 .CodeMirror {
   /** The default CodeMirror stylesheet fixes height to 300px. */
   height: unset !important;
+}
+
+.CodeMirror {
+   font-family: "Roboto Mono", monospace !important;
+   font-size: 13px !important;
+}
+
+.CodeMirror-line {
+  white-space: pre-wrap !important;
 }

--- a/packages/lit-dev-content/site/guide/community.md
+++ b/packages/lit-dev-content/site/guide/community.md
@@ -20,10 +20,6 @@ excellent to each other!
     of our team members can be found tweeting about lit-html, LitElement, 
     and the latest developments in the web platform.
 
-*   The <a href="https://groups.google.com/forum/?fromgroups=#!forum/polymer-dev">polymer-dev</a>
-    mailing list is great for long-form questions and discussion on any of the libraries, polyfills, or 
-    standards the the Polymer Project works on.
-
 *   On <a href="https://stackoverflow.com/tags/lit-html">StackOverflow</a> use
     the <code><a href="https://stackoverflow.com/tags/lit-html">lit-html</a></code> or <code><a href="https://stackoverflow.com/tags/lit-element">lit-element</a></code> tags when
     looking for answers. You can also find help on underlying web standards like 

--- a/packages/lit-dev-content/site/index.html
+++ b/packages/lit-dev-content/site/index.html
@@ -2,8 +2,8 @@
 
 {% block content %}
   <div class="wrapper hero">
-    <h1 class="hero-title">LitX</h1>
-    <h1 class="hero-caption">Simple, fast, and lightweight web components and design systems</h1>
+    <h1 class="hero-title">Lit</h1>
+    <h1 class="hero-caption">Simple, fast, lightweight web components</h1>
   </div>
 
   <section id="example">


### PR DESCRIPTION
An initial sweep through the main page to make it responsive for mobile layouts, and some general presentability improvements.

Before: https://pr14-551231b---lit-dev-bvxw3ycs6q-uw.a.run.app/
After: https://pr35-08703a9---lit-dev-bvxw3ycs6q-uw.a.run.app/

Changes:

- LitX -> Lit. Obviously let me know if this is not the brand we want (but it seems kinda like the obvious choice to me).

- "Simple, fast, and lightweight web components and design systems" -> "Simple, fast, lightweight web components". Just a judgment call I made, feels cleaner to me.

- Responsive layout for everything except the nav bar (will address nav bar in separate PR, I think it should probably turn into a dropdown nav menu). The multi-column layouts now collapse to a single column as needed.

- Smaller *Who's Using* images, with wrapping.

- Tweaked code example style (font, border, wrapping).

- Removed the Google Groups link because it's really not a good resource IMO.

- Some various tweaks to font colors, sizes, weights, centering, margins, etc.