### PR TITLE
GitHub Action to display preview URL on PRs

### DIFF
--- a/.github/workflows/preview-url-comment.yml
+++ b/.github/workflows/preview-url-comment.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
-          body-includes: A preview of this PR will be available
+          body-includes: preview of this PR will be available
 
       # https://github.com/peter-evans/create-or-update-comment
       - name: Create comment (if new)


### PR DESCRIPTION
Adds a GitHub Action that creates a comment displaying the lit.dev preview URL for each PR, and updates it on each push.

Fixes https://github.com/PolymerLabs/lit.dev/issues/118