### PR TITLE
GitHub Action to display preview URL on PRs

### DIFF
--- a/.github/workflows/preview-url-comment.yml
+++ b/.github/workflows/preview-url-comment.yml
@@ -1,0 +1,50 @@
+# GitHub Action that creates a comment displaying the lit.dev preview URL for
+# each PR, and updates the comment on each push.
+name: Preview URL Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  preview-url-comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate preview URL
+        id: gen-url
+        run: echo "::set-output name=url::https://pr${{ github.event.number }}-$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)---lit-dev-bvxw3ycs6q-uw.a.run.app/"
+
+      # https://github.com/peter-evans/find-comment
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: preview of this PR will be available
+
+      # https://github.com/peter-evans/create-or-update-comment
+      - name: Create comment (if new)
+        if: ${{ steps.find-comment.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            A live preview of this PR will be available at the URL(s) below.
+            The latest URL will be appended to this comment on each push.
+            Each build usually takes around 7 minutes, and will 404 until finished.
+
+            ${{ steps.gen-url.outputs.url }}
+          reactions: eyes
+
+      - name: Update comment (if existing)
+        if: ${{ steps.find-comment.outputs.comment-id != 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: append
+          body: ${{ steps.gen-url.outputs.url }}


### PR DESCRIPTION
Adds a GitHub Action that creates a comment displaying the lit.dev preview URL for each PR, and updates it on each push.

Fixes https://github.com/PolymerLabs/lit.dev/issues/118