### PR TITLE
Prevent @web/dev-server from injecting watch script into code samples

### DIFF
--- a/packages/lit-dev-content/web-dev-server.config.js
+++ b/packages/lit-dev-content/web-dev-server.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  plugins: [
+    {
+      // When we're using web-dev-server's --watch mode, we don't want our
+      // playground project HTML files to get the injected web socket reload
+      // script tag. This plugin reverses that transformation just for those
+      // files. See https://github.com/modernweb-dev/web/issues/761 for a
+      // feature request to make this easier.
+      name: 'remove-injected-watch-script',
+      transform(ctx) {
+        if (ctx.url.startsWith('/samples/')) {
+          return {
+            body: ctx.body.replace(
+              /<!-- injected by web-dev-server.*<\/script>/gs,
+              ''
+            ),
+          };
+        }
+      },
+    },
+  ],
+};


### PR DESCRIPTION
When we're using @web/dev-server's `--watch mode`, we don't want our playground project HTML files to get the injected web socket reload script tag. Adds a server config plugin to reverse that transformation just for those files. 

See https://github.com/modernweb-dev/web/issues/761 for feature request on @web/dev-server side.