### PR TITLE
fix(home): text and link bg will visible@same time

### DIFF
--- a/packages/lit-dev-content/site/css/home/7-connect.css
+++ b/packages/lit-dev-content/site/css/home/7-connect.css
@@ -24,7 +24,7 @@
   margin-top: 0.7em;
 }
 
-#connectItems > li > a:hover {
+#connectItems > li:hover > a {
   background: white;
   color: black;
 }


### PR DESCRIPTION
With `#connectItems > li > a:hover` and `#connectItems > li:hover > p` since, `li` is physically bigger than `a`, it is possible that the blue text becomes visible when the background is made white to make that text readable. See the list to the right of the section `CONNECT WITH LIT AND THE WEB COMPONENTS COMMUNITY`:

https://pr196-87cb4e5---lit-dev-bvxw3ycs6q-uw.a.run.app/

This makes it such that they pop up at the same time, but unfortunately will make them appear when hovering over the small whitespace that is the `li` but not the `a`