### PR TITLE
Improvements for screen readers

### DIFF
--- a/packages/lit-dev-content/site/_includes/header.html
+++ b/packages/lit-dev-content/site/_includes/header.html
@@ -1,6 +1,6 @@
 <header>
   <nav>
-    <a href="{{ site.baseurl }}/">
+    <a href="{{ site.baseurl }}/" aria-label="Home">
       <img id="headerLogo" src="{{ site.baseurl }}/images/logo.svg" />
     </a>
 

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -90,6 +90,12 @@ playground-ide {
   background: var(--playground-code-background);
 }
 
+figure {
+  /* We put code snippets in figures for improved a11y semantics, but they come
+     with a default left margin. */
+  margin-left: 0;
+}
+
 /* ------------------------------------
  * Headings
  * ------------------------------------ */

--- a/packages/lit-dev-content/site/css/home.css
+++ b/packages/lit-dev-content/site/css/home.css
@@ -61,7 +61,7 @@ p {
   background: white;
 }
 
-.homeExample > h4 {
+.homeExample > figcaption {
   background: var(--color-blue);
   color: white;
   margin: 0;

--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -34,7 +34,7 @@
   position: absolute;
 }
 
-#intro > h2 {
+#intro > .homeSectionHeading {
   border-top: 2px solid var(--color-blue);
   margin: 2em 0 1em 0;
 }

--- a/packages/lit-dev-content/site/home/1-splash.html
+++ b/packages/lit-dev-content/site/home/1-splash.html
@@ -2,15 +2,16 @@
   <div id="splash">
     <section id="intro">
       <div id="splashLogo">
-        <img src="{{site.baseurl}}/images/logo.svg" />
+        <img src="{{site.baseurl}}/images/logo.svg" aria-label="Lit" />
         <!-- Trick for detecting when the logo has scrolled under the header.
             See src/home.ts -->
         <div id="splashLogoHeaderOffset"></div>
       </div>
 
-      <h2 class="homeSectionHeading">
+      <p class="homeSectionHeading">
+        <!-- If in an h2, with the br, VoiceOver weirdly reads this twice.-->
         Simple. Fast. Lightweight.<br />Web components.
-      </h2>
+      </p>
 
       <p>
         Lit is a library for building fast, lightweight web components. Based on
@@ -23,8 +24,8 @@
     </section>
 
     <section id="helloWorld">
-      <div class="homeExample">
-        <h4>Hello World</h4>
+      <figure class="homeExample">
+        <figcaption>Hello World</figcaption>
         <div class="code">
           {% highlight 'js' %}{% include './1-splash-example.js' %}{% endhighlight
           %}
@@ -35,6 +36,6 @@
           endhighlight %}
         </div>
       </div>
-    </section>
+    </figure>
   </div>
 </div>

--- a/packages/lit-dev-content/site/home/2-use-cases.html
+++ b/packages/lit-dev-content/site/home/2-use-cases.html
@@ -11,7 +11,7 @@
 
     <div class="useCasesArt">
       <div class="lhsBackground"></div>
-      <svg class="standalone">
+      <svg class="standalone" aria-hidden="true" focusable="false">
         <use xlink:href="{{site.baseurl}}/images/home/standalone.svg#main"></use>
       </svg>
     </div>
@@ -27,7 +27,7 @@
 
     <div class="useCasesArt">
       <div class="lhsBackground"></div>
-      <svg>
+      <svg role="presentation" aria-hidden="true" focusable="false">
         <use xlink:href="{{site.baseurl}}/images/home/design-systems.svg#main"></use>
       </svg>
     </div>
@@ -43,7 +43,7 @@
 
     <div class="useCasesArt last">
       <div class="lhsBackground"></div>
-      <svg>
+      <svg aria-hidden="true" focusable="false">
         <use xlink:href="{{site.baseurl}}/images/home/applications.svg#main"></use>
       </svg>
     </div>

--- a/packages/lit-dev-content/site/home/3-simplicity.html
+++ b/packages/lit-dev-content/site/home/3-simplicity.html
@@ -16,8 +16,8 @@
       </p>
     </div>
 
-    <div class="homeExample">
-      <h4>Create a component</h4>
+    <figure class="homeExample">
+      <figcaption>Create a component</figcaption>
       <div class="code">
         {% highlight 'js' %}{% include './3-simplicity-example.js' %}{%
         endhighlight %}

--- a/packages/lit-dev-content/site/home/5-who-is-using.html
+++ b/packages/lit-dev-content/site/home/5-who-is-using.html
@@ -4,25 +4,30 @@
   </h2>
 
   <div id="whoIsUsingLogos">
-    <svg>
+    <svg role="img">
+      <title>Netflix</title>
       <use xlink:href="{{ site.baseurl }}/images/logos/netflix.svg#logo"></use>
     </svg>
 
-    <svg>
+    <svg role="img">
+      <title>Microsoft</title>
       <use
         xlink:href="{{ site.baseurl }}/images/logos/microsoft.svg#logo"
       ></use>
     </svg>
 
-    <svg>
+    <svg role="img">
+      <title>Google</title>
       <use xlink:href="{{ site.baseurl }}/images/logos/google.svg#logo"></use>
     </svg>
 
-    <svg>
+    <svg role="img">
+      <title>GitHub</title>
       <use xlink:href="{{ site.baseurl }}/images/logos/github.svg#logo"></use>
     </svg>
 
-    <svg>
+    <svg role="img">
+      <title>YouTube</title>
       <use xlink:href="{{ site.baseurl }}/images/logos/youtube.svg#logo"></use>
     </svg>
   </div>

--- a/packages/lit-dev-tools/src/playground-plugin/renderer.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/renderer.ts
@@ -111,7 +111,7 @@ export class Renderer {
         },
         [lang, code]
       );
-      const html = `<div class="CodeMirror cm-s-default">${codemirrorHtml}</div>`;
+      const html = `<figure class="CodeMirror cm-s-default">${codemirrorHtml}</figure>`;
       return {html};
     } finally {
       this.releasePageLock();


### PR DESCRIPTION
Did a pass through the home page and docs with voiceover on Safari.

- Disabled reading of decorative images.

- Added labels for some images that were missing them.

- Switched code snippets to `<figure>` elements. If there's a `<figcaption>`, as we now have on the homepage, it reads it nicely, otherwise it seems to read the same. Maybe we can add captions to our other code snippets if we have time. I think it should help with navigation though, (i.e. "skip this figure" command, vs a div where there's no semantic encapsulation).

Fixes https://github.com/PolymerLabs/lit.dev/issues/158