### PR TITLE
Use Manrope from source GitHub repo instead of Google fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ packages/lit-dev-content/_site
 packages/lit-dev-content/_dev
 packages/lit-dev-content/playground-plugin
 packages/lit-dev-content/rollupout
+packages/lit-dev-content/site/fonts
+packages/lit-dev-content/temp
 
 packages/lit-dev-api/lit/
 packages/lit-dev-api/api-data/**/*

--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -45,6 +45,7 @@ module.exports = function (eleventyConfig) {
     // In dev mode, we symlink these directly to source.
     eleventyConfig.addPassthroughCopy({'rollupout/': './js/'});
     eleventyConfig.addPassthroughCopy('site/css');
+    eleventyConfig.addPassthroughCopy('site/fonts');
     eleventyConfig.addPassthroughCopy('site/images');
     eleventyConfig.addPassthroughCopy('samples');
     eleventyConfig.addPassthroughCopy({
@@ -353,6 +354,10 @@ ${content}
       await symlinkForce(
         path.join(__dirname, 'site', 'images'),
         path.join(__dirname, '_dev', 'images')
+      );
+      await symlinkForce(
+        path.join(__dirname, 'site', 'fonts'),
+        path.join(__dirname, '_dev', 'fonts')
       );
       await symlinkForce(
         path.join(__dirname, 'samples'),

--- a/packages/lit-dev-content/package-lock.json
+++ b/packages/lit-dev-content/package-lock.json
@@ -8,6 +8,7 @@
 			"version": "0.0.0",
 			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@lit-labs/task": "1.0.0-pre.2",
 				"@material/mwc-button": "^0.20.0",
 				"@material/mwc-drawer": "^0.20.0",
 				"@material/mwc-formfield": "^0.20.0",
@@ -274,6 +275,14 @@
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"node_modules/@lit-labs/task": {
+			"version": "1.0.0-pre.2",
+			"resolved": "https://registry.npmjs.org/@lit-labs/task/-/task-1.0.0-pre.2.tgz",
+			"integrity": "sha512-BXQ26VorNwkvyAYe1NzCYAUYF4q/ReRtg9F9n5wU+uAf4+PFZS1pI5mc3Ehl/RpXeRvw5mdj0cIreokDttXcRw==",
+			"dependencies": {
+				"@lit/reactive-element": "^1.0.0-pre.3"
 			}
 		},
 		"node_modules/@lit/reactive-element": {
@@ -9381,6 +9390,14 @@
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@lit-labs/task": {
+			"version": "1.0.0-pre.2",
+			"resolved": "https://registry.npmjs.org/@lit-labs/task/-/task-1.0.0-pre.2.tgz",
+			"integrity": "sha512-BXQ26VorNwkvyAYe1NzCYAUYF4q/ReRtg9F9n5wU+uAf4+PFZS1pI5mc3Ehl/RpXeRvw5mdj0cIreokDttXcRw==",
+			"requires": {
+				"@lit/reactive-element": "^1.0.0-pre.3"
 			}
 		},
 		"@lit/reactive-element": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -7,6 +7,7 @@
   "license": "BSD-3-Clause",
   "main": "_site/index.html",
   "scripts": {
+    "postinstall": "npm run fonts:manrope",
     "build": "rm -rf _site && npm run build:ts && npm run build:rollup && npm run build:site && npm run build:samples",
     "build:ts": "../../node_modules/.bin/tsc",
     "build:ts:watch": "../../node_modules/.bin/tsc --watch",
@@ -16,6 +17,7 @@
     "build:rollup:watch": "rm -rf rollupout && rollup -c --watch",
     "build:samples": "tsc --project samples  --noEmit",
     "build:samples:watch": "tsc --project samples --watch --noEmit",
+    "fonts:manrope": "rm -rf site/fonts temp && mkdir -p site/fonts && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/ && cd ../.. && rm -rf temp",
     "dev:build:site": "rm -rf _dev && ELEVENTY_ENV=dev eleventy",
     "dev:build:site:watch": "rm -rf _dev && ELEVENTY_ENV=dev eleventy --watch",
     "dev:serve": "web-dev-server --root-dir=_dev --node-resolve --watch --open --preserve-symlinks",

--- a/packages/lit-dev-content/site/css/fonts/manrope.css
+++ b/packages/lit-dev-content/site/css/fonts/manrope.css
@@ -3,22 +3,9 @@
 @font-face {
   font-family: 'Manrope';
   font-style: normal;
-  font-weight: 300;
-  font-display: swap;
-  src: url(https://fonts.gstatic.com/s/manrope/v4/xn7gYHE41ni1AdIRggexSg.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: 'Manrope';
-  font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/manrope/v4/xn7gYHE41ni1AdIRggexSg.woff2)
-    format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  src: url(/fonts/manrope-regular.woff2) format('woff2');
 }
 
 @font-face {
@@ -26,11 +13,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/manrope/v4/xn7gYHE41ni1AdIRggexSg.woff2)
-    format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  src: url(/fonts/manrope-medium.woff2) format('woff2');
 }
 
 @font-face {
@@ -38,11 +21,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/manrope/v4/xn7gYHE41ni1AdIRggexSg.woff2)
-    format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  src: url(/fonts/manrope-semibold.woff2) format('woff2');
 }
 
 @font-face {
@@ -50,11 +29,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/manrope/v4/xn7gYHE41ni1AdIRggexSg.woff2)
-    format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  src: url(/fonts/manrope-bold.woff2) format('woff2');
 }
 
 @font-face {
@@ -62,9 +37,5 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/manrope/v4/xn7_YHE41ni1AdIRqAuZuw1Bx9mbZk59E9_C-bk.woff2)
-    format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  src: url(/fonts/manrope-extrabold.woff2) format('woff2');
 }

--- a/packages/lit-dev-content/site/css/global.css
+++ b/packages/lit-dev-content/site/css/global.css
@@ -14,6 +14,7 @@ html {
   --footer-top-height: 12rem;
   --footer-bottom-height: 6rem;
   --content-max-width: 76rem;
+  -webkit-font-smoothing: antialiased;
 }
 
 code {

--- a/packages/lit-dev-content/site/css/home.css
+++ b/packages/lit-dev-content/site/css/home.css
@@ -37,7 +37,7 @@ p {
 /* Large section headings with blue underline */
 
 .homeSectionHeading {
-  font-size: 1.5em;
+  font-size: 32px;
   font-weight: 500;
   border-bottom: 2px solid var(--color-blue);
   padding: 0.7em 0;

--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -26,7 +26,7 @@
 #tagline {
   color: rgb(48, 48, 48);
   font-size: 20px;
-  font-weight: 700;
+  font-weight: 800;
   margin: 0 60px -9px 0;
 }
 
@@ -69,7 +69,7 @@
   background: #325cff;
   color: white;
   text-align: center;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 16px;
 }
 

--- a/packages/lit-dev-content/site/css/home/3-tour.css
+++ b/packages/lit-dev-content/site/css/home/3-tour.css
@@ -109,6 +109,7 @@
   padding: 10px 30px;
   text-align: center;
   margin-top: 2em;
+  font-weight: 600;
 }
 
 #playgroundLink:hover,


### PR DESCRIPTION
- This fixes rendering bugs that affect the Google fonts version, according to https://github.com/sharanda/manrope/issues/62

- Set `-webkit-font-smoothing: antialiased` which improves macOS rendering of Manrope, and unifies font-weights between OSs.

- Adjust some font weights to more closely match mocks, now that heavier weights render correctly on macOS.