### PR TITLE
Prevent janky FOUT layout change above fold on index

### DIFF
--- a/packages/lit-dev-content/site/home/1-splash.html
+++ b/packages/lit-dev-content/site/home/1-splash.html
@@ -9,7 +9,7 @@
   <p id="tagline">
     <span>Simple.</span>
     <span>Fast.</span>
-    <span>Web Components.</span>
+    <span style="white-space: nowrap;">Web Components.</span>
   </p>
 
   <div id="splashButtons">


### PR DESCRIPTION
before font's flip this happens:

![image](https://user-images.githubusercontent.com/5981958/115519493-1b9edc00-a23e-11eb-9427-0cad1095b2ea.png)

This will make it look like this:

![image](https://user-images.githubusercontent.com/5981958/115519575-2e191580-a23e-11eb-8e42-e4d5d7fe4f89.png)
