### PR TITLE
Cache fonts for 1 hour

### DIFF
--- a/packages/lit-dev-server/src/index.ts
+++ b/packages/lit-dev-server/src/index.ts
@@ -59,6 +59,13 @@ app.use(
     // Serve pre-compressed .br and .gz files if available.
     brotli: true,
     gzip: true,
+    setHeaders(res, path) {
+      // TODO(aomarks) Oddly can't access the request URL path from this API.
+      // This `path` is the path on disk. Works for now, though.
+      if (path.includes('/fonts/')) {
+        res.setHeader('Cache-Control', 'max-age=3600');
+      }
+    },
   })
 );
 


### PR DESCRIPTION
Will add more complete caching strategy, probably service worker, soon. But for now, just give fonts a 1 hour max-age instead of 0 because it's the one thing that noticeably suffers from needing an ETag request.