### PR TITLE
Increase contrast of npm i button for a11y

### DIFF
--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -51,7 +51,7 @@
 
 #npmInstall {
   font-family: var(--playground-code-font-family);
-  background: #9E9E9E;
+  background: #757575;
   color: white;
   margin-bottom: 8px;
   font-size: 16px;
@@ -59,7 +59,7 @@
 
 #npmInstall:hover,
 #npmInstall:focus {
-  background: #818181;
+  background: #575757;
 }
 
 #npmInstall > .prompt {


### PR DESCRIPTION
This gets us from 99% to 100% Lighthouse a11y score on the homepage.