### PR TITLE
Fix ref directive title

### DIFF
--- a/packages/lit-dev-content/samples/examples/directive-ref/project.json
+++ b/packages/lit-dev-content/samples/examples/directive-ref/project.json
@@ -1,7 +1,7 @@
 {
   "extends": "/samples/base.json",
-  "title": "cache directive",
-  "description": "Demo exploring use of the cache directive.",
+  "title": "ref directive",
+  "description": "Demo exploring use of the ref directive.",
   "section": "Directives",
   "files": {
     "my-element.ts": {},


### PR DESCRIPTION
Hey there 👋! I've noticed someone was too fast and forgot to rename the example title of "ref directive" 😀

![image](https://user-images.githubusercontent.com/38350963/115616736-d5ef1b80-a2f0-11eb-8ff9-92c0dcc1c599.png)

Great launch event today by the way!