### PR TITLE
docs: fix casing in link fragment

### DIFF
--- a/packages/lit-dev-content/site/docs/composition/mixins.md
+++ b/packages/lit-dev-content/site/docs/composition/mixins.md
@@ -24,7 +24,7 @@ fields/methods, overriding existing superclass methods, and using `super`.
 <div class="alert alert-info">
 
 For ease of reading, the samples on this page elide some of the TypeScript types
-for mixin functions. See [Mixins in TypeScript](#mixins-in-TypeScript) for details on proper
+for mixin functions. See [Mixins in TypeScript](#mixins-in-typescript) for details on proper
 typing of mixins in TypeScript.
 
 </div>


### PR DESCRIPTION
Fragment should be `#mixins-in-typescript`, otherwise the link doesn't navigate you anywhere.
Currently clicking it is a no-op. Tested in Chrome and Firefox.

## Repo issue

1. Navigate to https://lit.dev/docs/composition/mixins/#mixin-basics
2. In the first info box click the "Mixins in TypeScript" link.

Gif showing current behavior when clicking link:

![clicking-noop](https://user-images.githubusercontent.com/15080861/116845398-9a7b0980-ab9a-11eb-89b7-2340c8d1b090.gif)
