### PR TITLE
doc: correct shadowRootOptions spread syntax

### DIFF
--- a/packages/lit-dev-content/site/docs/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/components/shadow-dom.md
@@ -259,7 +259,7 @@ The simplest way to customize the render root is to set the `shadowRootOptions` 
 
 ```js
 class DelagatesFocus extends LitElement {
-  static shadowRootOptions = {...super.shadowRootOptions, delegatesFocus: true};
+  static shadowRootOptions = {...LitElement.shadowRootOptions, delegatesFocus: true};
 }
 ```
 


### PR DESCRIPTION
`super` can't be used in the format indicated in the doc. this corrects the example to properly reference the parent class.