### PR TITLE
Fix layout shift on "What is Lit" page

### DIFF
--- a/packages/lit-dev-content/site/_includes/header.html
+++ b/packages/lit-dev-content/site/_includes/header.html
@@ -1,7 +1,7 @@
 <header>
   <nav>
     <a id="homeLink" href="{{ site.baseurl }}/" aria-label="Home">
-      <img id="headerLogo" class="black" src="{{ site.baseurl }}/images/logo.svg" alt="Lit Home" />
+      <img id="headerLogo" class="black" src="{{ site.baseurl }}/images/logo.svg" alt="Lit Home" width="425" height="200" />
     </a>
 
     <ol id="desktopNav">

--- a/packages/lit-dev-content/site/css/header.css
+++ b/packages/lit-dev-content/site/css/header.css
@@ -15,6 +15,7 @@ header {
 
 #headerLogo {
   height: 2em;
+  width: auto;
   padding: 0.1em 0.5em;
 }
 

--- a/packages/lit-dev-content/site/docs/index.md
+++ b/packages/lit-dev-content/site/docs/index.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   order: 1
 ---
 
-![Lit Logo]({{ site.baseurl }}/images/logo.svg){.logo}
+![Lit Logo]({{ site.baseurl }}/images/logo.svg){.logo width="425" height="200"}
 
 Lit is a simple library for building fast, lightweight web components.
 

--- a/packages/lit-dev-content/site/home/1-splash.html
+++ b/packages/lit-dev-content/site/home/1-splash.html
@@ -1,6 +1,6 @@
 <section id="intro">
   <div id="splashLogo" role="heading" aria-level="1">
-    <img src="{{site.baseurl}}/images/logo.svg" aria-label="Lit" />
+    <img src="{{site.baseurl}}/images/logo.svg" aria-label="Lit" width="425" height="200" />
     <!-- Trick for detecting when the logo has scrolled under the header.
         See src/home.ts -->
     <div id="splashLogoHeaderOffset"></div>


### PR DESCRIPTION
## Context

Resolves issue: #372 

By adding width and height attributes, resolves layout shift.

Added width and height attributes to the logo in:
 - navigation
 - what is lit page
 - home page

### Screenshots

Lighthouse performance for [currently deployed docs page](https://lit.dev/docs):
![Screen Shot 2021-05-13 at 4 59 58 PM](https://user-images.githubusercontent.com/15080861/118201590-af626300-b40c-11eb-8a07-41f2981ad4f3.png)

This change brings Cumulative Layout Shift down to 0. Ran a lighthouse test locally, against node production environment.