### PR TITLE
Fix until directive example

### DIFF
--- a/packages/lit-dev-content/samples/examples/directive-until/my-element.ts
+++ b/packages/lit-dev-content/samples/examples/directive-until/my-element.ts
@@ -3,11 +3,11 @@ import {customElement, state} from 'lit/decorators.js';
 import {until} from 'lit/directives/until.js';
 
 const fetchData = async () => {
-  const response = await fetch('https://api.mocki.io/v1/b551e5c3');
+  const response = await fetch('https://jsonplaceholder.typicode.com/todos/2');
   const json = await response.json();
   // Add some delay for demo purposes
   await new Promise<void>((r) => setTimeout(() => r(), 1000));
-  return json.data;
+  return json.title;
 }
 
 @customElement('my-element')


### PR DESCRIPTION
Fix issue #342 .

Checked with Kevin and it's ok to change the example json api.
Now the example loads some lorem ipsum style text after a second.

Testing was done manually, and the risk is low.
Fixed `until` example link: https://pr381-1f513b3---lit-dev-5ftespv5na-uc.a.run.app/playground/#sample=examples/directive-until


Do we have a style guide or formatting rules for the examples?