### PR TITLE
Fix copy pasting rendered code blocks with line breaks

### DIFF
--- a/packages/lit-dev-tools/src/playground-plugin/renderer.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/renderer.ts
@@ -104,8 +104,8 @@ export class Renderer {
             lastLine.remove();
           }
 
-          // Replace zero width newlines that doesn't copy paste into editors with
-          // a line feed unicode character that pastes correctly.
+          // Replace zero width newlines that don't copy paste well with a line
+          // feed unicode character that pastes correctly.
           const codeLines = cm.querySelectorAll('.CodeMirror-line > span > span[cm-text]');
           for (const line of codeLines) {
             if (line?.textContent?.match(/^[\u200B]*$/)) {

--- a/packages/lit-dev-tools/src/playground-plugin/renderer.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/renderer.ts
@@ -103,6 +103,16 @@ export class Renderer {
           if (lastLine?.textContent?.match(/^[\s\u200B]*$/)) {
             lastLine.remove();
           }
+
+          // Replace zero width newlines that doesn't copy paste into editors with
+          // a line feed unicode character that pastes correctly.
+          const codeLines = cm.querySelectorAll('.CodeMirror-line > span > span[cm-text]');
+          for (const line of codeLines) {
+            if (line?.textContent?.match(/^[\u200B]*$/)) {
+              line.textContent = `\u000A`;
+            }
+          }
+
           return cm.innerHTML;
         },
         [lang, code]


### PR DESCRIPTION
This PR contains a possible solution for issue #380 

### Context

This is an ergonomic fix that may remove some initial friction when interacting with the site, and home page specifically.
Currently if you copy paste the home page example into an editor or the lit.dev playground, the zero width spaces remain and can break dev tooling or add visual confusion ([as seen in our playground](https://lit.dev/playground/#project=W3sibmFtZSI6InNpbXBsZS1ncmVldGluZy50cyIsImNvbnRlbnQiOiIvLyBDb3B5IHBhc3RlZCBmcm9tIHRoZSBob21lIHBhZ2UgKG5vdGUgdGhlIG5ld2xpbmVzKTpcbmltcG9ydCB7aHRtbCwgY3NzLCBMaXRFbGVtZW50fSBmcm9tICdsaXQnO1xuaW1wb3J0IHtjdXN0b21FbGVtZW50LCBwcm9wZXJ0eX0gZnJvbSAnbGl0L2RlY29yYXRvcnMuanMnO1xu4oCLXG5AY3VzdG9tRWxlbWVudCgnc2ltcGxlLWdyZWV0aW5nJylcbmV4cG9ydCBjbGFzcyBTaW1wbGVHcmVldGluZyBleHRlbmRzIExpdEVsZW1lbnQge1xuICBzdGF0aWMgc3R5bGVzID0gY3NzYHAgeyBjb2xvcjogYmx1ZSB9YDtcbuKAi1xuICBAcHJvcGVydHkoKVxuICBuYW1lID0gJ1NvbWVib2R5JztcbuKAi1xuICByZW5kZXIoKSB7XG4gICAgcmV0dXJuIGh0bWxgPHA-SGVsbG8sICR7dGhpcy5uYW1lfSE8L3A-YDtcbiAgfVxufSJ9LHsibmFtZSI6ImluZGV4Lmh0bWwiLCJjb250ZW50IjoiPCFET0NUWVBFIGh0bWw-XG48aGVhZD5cbiAgPHNjcmlwdCB0eXBlPVwibW9kdWxlXCIgc3JjPVwiLi9zaW1wbGUtZ3JlZXRpbmcuanNcIj48L3NjcmlwdD5cbjwvaGVhZD5cbjxib2R5PlxuICA8c2ltcGxlLWdyZWV0aW5nIG5hbWU9XCJXb3JsZFwiPjwvc2ltcGxlLWdyZWV0aW5nPlxuPC9ib2R5PlxuIn1d)).

This change also fixes copy pasting any rendered code blocks in our documentation that contain newlines.
For example at the bottom of the [decorators page](https://lit.dev/docs/components/decorators/#using-typescript-with-babel) or the second [event listener example](https://lit.dev/docs/components/events/#understanding-this-in-event-listeners).

### Fix

Update our renderer to replace a zero width unicode symbol with a line carriage.

This preserves the visual space in the home page example, and spaces when pasted elsewhere.

### Testing

Manual testing, by triggering `npm run build` to rebuild the code samples.

 - Ensure the home page keeps spaces.
 - Copy pasting the home page example:
     - to the lit.dev playground
     - into VS code

I also tested some code fences, such as at the bottom of the [decorators section](https://lit.dev/docs/components/decorators/).

### Risk

Some debt added since this adds an assumption about the CodeMirror editor html format.

There is also some risk that this change breaks any of the highlighted syntax examples, or `{% highlight "js" %}` shortcodes.

### Other notes

I also tried to replace the zero width space with an empty string.
This works visually on the home page, but will lose the newlines on copy paste into another file.


### Screenshot of change

Before this change copy pasting the home page creates the following whitespace:

<img width="620" alt="Screen Shot 2021-05-19 at 4 53 49 PM" src="https://user-images.githubusercontent.com/15080861/118899095-eaf4a580-b8c2-11eb-8b1d-592f84f5929e.png">

With this change:

<img width="617" alt="Screen Shot 2021-05-19 at 4 55 31 PM" src="https://user-images.githubusercontent.com/15080861/118899165-0d86be80-b8c3-11eb-9c2b-7745e595cb73.png">
