### PR TITLE
Use timeout in clock-controller

### DIFF
--- a/packages/lit-dev-content/samples/docs/controllers/overview/clock-controller.ts
+++ b/packages/lit-dev-content/samples/docs/controllers/overview/clock-controller.ts
@@ -17,7 +17,7 @@ export class ClockController implements ReactiveController {
       this.value = new Date();
       // Update the host with new value
       this.host.requestUpdate();
-    });
+    }, this.timeout);
   }
   hostDisconnected() {
     // Clear the timer when the host is disconnected


### PR DESCRIPTION
In the clock-controller example the setTimeout function is used to regularly update the current time.
It seems that setTimeout is unintentionally being used without the timout parameter despite a separate `timeout` filed being present.
