### PR TITLE
Remove invalid closing tag from input element

### DIFF
--- a/packages/lit-dev-content/site/docs/templates/expressions.md
+++ b/packages/lit-dev-content/site/docs/templates/expressions.md
@@ -236,7 +236,7 @@ html`<div ?hidden=${!this.showAdditional}>This text may be hidden.</div>`;
 You can set a JavaScript property on an element using the `.` prefix and the property name:
 
 ```js
-html`<input .value=${this.itemCount}></input>`;
+html`<input .value=${this.itemCount}>`;
 ```
 
 You can use this syntax to pass complex data down the tree to subcomponents. For example, if you have a `my-list` component with a `listItems` property, you could pass it an array of objects:


### PR DESCRIPTION
`<input>` is a void element.

> Void elements only have a start tag; end tags must not be specified for void elements.

https://html.spec.whatwg.org/multipage/syntax.html#elements-2

Fixes invalid HTML in an example shown at https://lit.dev/docs/templates/expressions/#property-expressions

Changes:
```ts
html`<input .value=${this.itemCount}></input>`;
```

to:
```ts
html`<input .value=${this.itemCount}>`;
```

This also makes the example consistent with the few other examples that contain an `<input>` element on the same page.