### PR TITLE
Update upgrade.md

### DIFF
--- a/packages/lit-dev-content/site/docs/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/releases/upgrade.md
@@ -235,3 +235,5 @@ update callbacks will be called if/when the element is re-connected.
 * The `templateFactory` option of `RenderOptions` has been removed.
 * `TemplateProcessor` has been removed.
 * Symbols are not converted to a string before mutating DOM, so passing a Symbol to an attribute or text binding will result in an exception.
+* The `ifDefined` directive in an attribute expression now removes the attribute for both `null` and `undefined`, not just `undefined`.
+* Rendering the value `nothing` to an attribute expression causes the attribute to be removed.


### PR DESCRIPTION
Mention that `ifDefined` now removes attributes for both `null` and `undefined`, and that `nothing` can be rendered in an attribute expression.

Closes https://github.com/lit/lit/issues/1927