### PR TITLE
A couple of sample-fixes

### DIFF
--- a/packages/lit-dev-content/site/docs/composition/controllers.md
+++ b/packages/lit-dev-content/site/docs/composition/controllers.md
@@ -42,7 +42,7 @@ A controller will typically expose some functionality to be used in the host's `
 ```ts
   render() {
     return html`
-      <div>Current time: ${this.clock.time}</div>
+      <div>Current time: ${this.clock.value}</div>
     `;
   }
 ```
@@ -130,12 +130,12 @@ class DualClockController implements ReactiveController {
   private clock2: ClockController;
 
   constructor(host: ReactiveControllerHost, delay1: number, delay2: number) {
-    clock1 = new ClockController(host, delay1);
-    clock2 = new ClockController(host, delay2);
+    this.clock1 = new ClockController(host, delay1);
+    this.clock2 = new ClockController(host, delay2);
   }
 
-  get time1() { return this.clock1.time; }
-  get time2() { return this.clock2.time; }
+  get time1() { return this.clock1.value; }
+  get time2() { return this.clock2.value; }
 }
 ```
 


### PR DESCRIPTION
Seems the clock-controller uses .value and not .time to store the time. Also the dual-clock controller probably wants to save the controller instances on the element-instance. 

For reference the clock-controller code is here: https://github.com/lit/lit.dev/blob/main/packages/lit-dev-content/samples/docs/controllers/overview/clock-controller.ts 