### PR TITLE
Unify styles of single/multi file inline examples

### DIFF
--- a/packages/lit-dev-content/samples/docs/components/events/comm/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/comm/project.json
@@ -5,5 +5,6 @@
     "my-listener.ts": {},
     "index.html": {}
   },
-  "editorHeight": "920px"
+  "editorHeight": "760px",
+  "previewHeight": "180px"
 }

--- a/packages/lit-dev-content/samples/docs/components/shadowdom/slots/project.json
+++ b/packages/lit-dev-content/samples/docs/components/shadowdom/slots/project.json
@@ -3,7 +3,8 @@
     "index.html": {},
     "my-element.ts": {}
   },
-  "editorHeight": "440px",
+  "editorHeight": "400px",
+  "previewHeight": "165px",
     "importMap": {
     "imports": {
       "lit": "https://cdn.skypack.dev/lit",

--- a/packages/lit-dev-content/samples/docs/controllers/names/project.json
+++ b/packages/lit-dev-content/samples/docs/controllers/names/project.json
@@ -6,5 +6,6 @@
     "names-api.ts": {},
     "index.html": {}
   },
-  "editorHeight": "1160px"
+  "editorHeight": "1060px",
+  "previewHeight": "150px"
 }

--- a/packages/lit-dev-content/samples/docs/controllers/overview/project.json
+++ b/packages/lit-dev-content/samples/docs/controllers/overview/project.json
@@ -5,5 +5,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "830px"
+  "editorHeight": "700px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/compose/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/compose/project.json
@@ -4,6 +4,6 @@
     "my-page.ts": {},
     "index.html": {}
   },
-  "editorHeight": "775px",
+  "editorHeight": "785px",
   "previewHeight": "90px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/compose/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/compose/project.json
@@ -4,6 +4,6 @@
     "my-page.ts": {},
     "index.html": {}
   },
-  "editorHeight": "770px",
+  "editorHeight": "775px",
   "previewHeight": "90px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/composeimports/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/composeimports/project.json
@@ -7,5 +7,5 @@
     "my-footer.ts": {},
     "index.html": {}
   },
-  "editorHeight": "550px"
+  "editorHeight": "500px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/lists-map/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/lists-map/project.json
@@ -8,5 +8,5 @@
     "index.html": {}
   },
   "editorHeight": "340px",
-  "previewHeight": "75px"
+  "previewHeight": "85px"
 }

--- a/packages/lit-dev-content/samples/docs/what-is-lit/project.json
+++ b/packages/lit-dev-content/samples/docs/what-is-lit/project.json
@@ -4,7 +4,8 @@
         "index.html": {},
         "icons.ts": {}
     },
-    "editorHeight": "840px",
+    "editorHeight": "650px",
+    "previewHeight": "125px",
       "importMap": {
       "imports": {
         "lit": "https://cdn.skypack.dev/lit",

--- a/packages/lit-dev-content/samples/docs/what-is-lit/project.json
+++ b/packages/lit-dev-content/samples/docs/what-is-lit/project.json
@@ -4,7 +4,7 @@
         "index.html": {},
         "icons.ts": {}
     },
-    "editorHeight": "650px",
+    "editorHeight": "670px",
     "previewHeight": "125px",
       "importMap": {
       "imports": {

--- a/packages/lit-dev-content/src/components/litdev-example.ts
+++ b/packages/lit-dev-content/src/components/litdev-example.ts
@@ -102,9 +102,8 @@ export class LitDevExample extends LitElement {
     }
     const showTabBar = !this.filename
     // Only the top element should have a border radius.
-    const fileEditorOverrideStyles = showTabBar
-      ? styleMap({ 'border-radius': '0' })
-      : nothing;
+    const fileEditorOverrideStyles =
+      { borderRadius: showTabBar ? 'unset': 'inherit' }
 
     return html`
       <playground-project
@@ -127,7 +126,7 @@ export class LitDevExample extends LitElement {
         id="project-file-editor"
         project="project"
         filename="${ifDefined(this.filename)}"
-        style=${fileEditorOverrideStyles}
+        style=${styleMap(fileEditorOverrideStyles)}
       >
       </playground-file-editor>
 

--- a/packages/lit-dev-content/src/components/litdev-example.ts
+++ b/packages/lit-dev-content/src/components/litdev-example.ts
@@ -5,6 +5,7 @@
  */
 
 import {LitElement, html, css, property} from 'lit-element';
+import {styleMap} from 'lit-html/directives/style-map';
 import {nothing} from 'lit-html';
 import {ifDefined} from 'lit-html/directives/if-defined.js';
 import 'playground-elements/playground-ide.js';
@@ -22,9 +23,18 @@ export class LitDevExample extends LitElement {
     }
 
     playground-file-editor,
-    playground-preview {
+    playground-preview,
+    playground-tab-bar {
       border-radius: 5px;
       box-sizing: border-box;
+    }
+
+    playground-tab-bar {
+      background: #fff;
+      --mdc-typography-button-font-family: 'Open Sans',sans-serif;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      border-bottom: var(--code-border);
     }
 
     playground-file-editor {
@@ -75,6 +85,7 @@ export class LitDevExample extends LitElement {
 
   /**
    * Name of file in project to display.
+   * If no file is provided, we show the tab-bar with all project files.
    */
   @property()
   filename?: string;
@@ -86,9 +97,15 @@ export class LitDevExample extends LitElement {
   sandboxBaseUrl?: string;
 
   render() {
-    if (!this.project || !this.filename) {
+    if (!this.project) {
       return nothing;
     }
+    const showTabBar = !this.filename
+    // Only the top element should have a border radius.
+    const fileEditorOverrideStyles = showTabBar
+      ? styleMap({ 'border-radius': '0' })
+      : nothing;
+
     return html`
       <playground-project
         sandbox-base-url=${ifDefined(this.sandboxBaseUrl)}
@@ -97,10 +114,24 @@ export class LitDevExample extends LitElement {
       >
       </playground-project>
 
-      <playground-file-editor project="project" filename="${this.filename}">
+      ${
+        showTabBar
+          ? html`<playground-tab-bar
+                    project="project"
+                    editor="project-file-editor"
+                  ></playground-tab-bar>`
+          : nothing
+      }
+
+      <playground-file-editor
+        id="project-file-editor"
+        project="project"
+        filename="${ifDefined(this.filename)}"
+        style=${fileEditorOverrideStyles}
+      >
       </playground-file-editor>
 
-      <playground-preview project="project"> </playground-preview>
+      <playground-preview project="project"></playground-preview>
 
       <a
         class="openInPlayground"

--- a/packages/lit-dev-tools/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/plugin.ts
@@ -124,22 +124,26 @@ export const playgroundPlugin = (
       );
     }
     const config = await readProjectConfig(project);
-    const styleHeight = config.editorHeight
-      ? `style="height: ${config.editorHeight};"`
-      : '';
-    const lineNumbers = config.lineNumbers ? 'line-numbers' : '';
+
+    // Note we explicitly set "height" here so that the pre-upgrade height is
+    // correct, to prevent layout shift.
+    const editorHeight = config.editorHeight ?? '300px';
+    const previewHeight = config.previewHeight ?? '120px';
+    const fileTabBarHeight = '45px';
     return `
-      <playground-ide ${styleHeight}
-      ${lineNumbers} resizable
-        project-src="/samples/${project}/project.json">
-      </playground-ide>
-    `.trim();
+    <litdev-example ${sandboxUrl ? `sandbox-base-url='${sandboxUrl}'` : ''}
+      style="height:calc(${editorHeight} + ${previewHeight} + ${fileTabBarHeight});
+              --litdev-example-editor-height:${editorHeight};
+              --litdev-example-preview-height:${previewHeight}"
+      project=${project}
+    >
+    </litdev-example>
+  `.trim();
   });
 
   type LitProjectConfig = ProjectManifest & {
     editorHeight?: string;
     previewHeight?: string;
-    lineNumbers?: boolean;
   };
 
   // TODO(aomarks)


### PR DESCRIPTION
Address issue #371, using our `litdev-example` component for both `playground-ide` and `playground-example` shortcodes.

### Context

The multi-file and single file examples have very different layouts. This PR updates the multi-file example to have the same style and layout as the single file example.

An additional benefit is there is now a playground link button in the multi file examples.

### How

Unify the style by using the same underlying component for both example shortcodes. The primary difference between the two shortcodes is whether or not there is a file tab bar displayed. Thus we handle both cases through the presence of the parameter `filename`.

This PR also removed a line-number parameter which isn't used, and updated some example config heights to remove a tiny amount of scrolling.

### Testing

Tested manually with `npm run dev`. Went page by page tweaking some of the heights to better reflect the new layout. Firefox has a larger font line-height, so most of the height changes were minor. Most of the changes were to allow a larger preview. 

I also ran `npm run test` but I don't believe we test the playground examples.
Please let me know if there are any automated tests I can add or include in this PR.

Manually tested in browsers:
 - [x] Chrome
 - [x] Firefox
 - [x] Safari

Manually tested narrow screen width with horizontal scrolling of file tabs.

### Screenshots of change

<img width="1665" alt="Screen Shot 2021-07-08 at 4 42 36 PM" src="https://user-images.githubusercontent.com/15080861/125003188-85dc4700-e00b-11eb-9c76-989d1b476723.png">

<img width="1665" alt="Screen Shot 2021-07-08 at 4 43 13 PM" src="https://user-images.githubusercontent.com/15080861/125003239-a0162500-e00b-11eb-9a9f-8dfdca993547.png">

<img width="347" alt="Screen Shot 2021-07-08 at 5 13 47 PM" src="https://user-images.githubusercontent.com/15080861/125005419-8cb98880-e010-11eb-9f16-4df910285a6a.png">
