### PR TITLE
Two small doc fixes

### DIFF
--- a/packages/lit-dev-content/site/docs/components/properties.md
+++ b/packages/lit-dev-content/site/docs/components/properties.md
@@ -290,10 +290,12 @@ The tables below shows how the default converter handles conversion for each typ
 
 | Type    | Conversion |
 |:--------|:-----------|
-| `String`  | If the attribute is defined, set the property to the attribute value. |
-| `Number`  | If the attribute is defined, set the property to `Number(attributeValue)`. |
-| `Boolean` | If the attribute is defined and non-null, set the property to true.<br>If the property is null or undefined, set the property to false. |
-| `Object`, `Array` | If the attribute is defined, set the property value to `JSON.parse(attributeValue)`. |
+| `String`  | If the element has the corresponding attribute, set the property to the attribute value. |
+| `Number`  | If the element has the corresponding attribute, set the property to `Number(attributeValue)`. |
+| `Boolean` | If the element has the corresponding attribute, set the property to true.<br>If not, set the property to false. |
+| `Object`, `Array` | If the element has the corresponding attribute, set the property value to `JSON.parse(attributeValue)`. |
+
+For any case except `Boolean`, if the element doesn't have the corresponding attribute, the property keeps its default value, or `undefined` if no default is set.
 
 **From property to attribute**
 
@@ -302,8 +304,6 @@ The tables below shows how the default converter handles conversion for each typ
 | `String`, `Number` | If property is defined and non-null, set the attribute to the property value.<br>If property is null or undefined, remove the attribute. |
 | `Boolean` | If property is truthy, create the attribute and set its value to an empty string. <br>If property is falsy, remove the attribute |
 | `Object`, `Arrray` | If property is defined and non-null, set the attribute to `JSON.stringify(propertyValue)`.<br>If property is null or undefined, remove the attribute. |
-
-
 
 
 ### Providing a custom converter {#conversion-converter}

--- a/packages/lit-dev-content/site/docs/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/releases/upgrade.md
@@ -236,4 +236,4 @@ update callbacks will be called if/when the element is re-connected.
 * `TemplateProcessor` has been removed.
 * Symbols are not converted to a string before mutating DOM, so passing a Symbol to an attribute or text binding will result in an exception.
 * The `ifDefined` directive in an attribute expression now removes the attribute for both `null` and `undefined`, not just `undefined`.
-* Rendering the value `nothing` to an attribute expression causes the attribute to be removed.
+* Rendering the value `nothing` to an attribute expression causes the attribute to be removed—even if there are multiple expressions in the attribute value position and only one is `nothing`. For example given `src="${baseurl}/${filename}"`, the `src` attribute is removed if _either_ `baseurl` or `filename` evaluate to `nothing`.


### PR DESCRIPTION
Clarifies the note about `nothing` in the upgrade guide.

Also fixes an unrelated typo in the properties guide, and clarifies some text.

For some reason when I started this branch these two issues seemed related. They aren't, so I separated the commits. But they're both teeny, so I'm leaving them in one PR. Hope that's OK.