### PR TITLE
Remove 404 MDN ParentNode link

### DIFF
--- a/packages/lit-dev-content/site/docs/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/components/shadow-dom.md
@@ -33,7 +33,7 @@ For more information on shadow DOM:
 
 Lit renders components to its `renderRoot`, which is a shadow root by default. To find internal elements, you can use DOM query APIs, such as `this.renderRoot.querySelector()`.
 
-The `renderRoot` should always be either a shadow root or an element. Both implement the [`ParentNode`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode) interface and share API like `.querySelectorAll()` and `.children`.
+The `renderRoot` should always be either a shadow root or an element, which share APIs like `.querySelectorAll()` and `.children`.
 
 You can query internal DOM after component initial render (for example, in `firstUpdated`), or use a getter pattern:
 


### PR DESCRIPTION
MDN doesn't have a page for ParentNode. In the HTML spec it's an interface mixin (https://dom.spec.whatwg.org/#parentnode), and in TypeScript it's an interface type. Neither of these seem like very friendly or important things to link to, so I've just removed the link.