### PR TITLE
Close mobile nav drawer and clear input on search result navigation.

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-search.ts
+++ b/packages/lit-dev-content/src/components/litdev-search.ts
@@ -17,6 +17,7 @@ import Minisearch from 'minisearch';
 
 import '@lion/combobox/define';
 import {LionOption} from '@lion/listbox';
+import type {Drawer} from '@material/mwc-drawer';
 
 /**
  * Representation of each document indexed by Minisearch.
@@ -289,6 +290,18 @@ class LitDevSearch extends LitElement {
     document.location = searchUrl.href as unknown as Location;
     this.input.value = '';
     this.searchText = '';
+
+    // On mobile we manually close the nav drawer, otherwise the drawer remains
+    // open when navigating between fragment identifiers.
+    const navDrawer = document.querySelector(
+      'mwc-drawer#mobileDrawer'
+    ) as Drawer;
+    if (navDrawer) {
+      navDrawer.open = false;
+    }
+
+    // Rerender to visually clear the value on the input.
+    this.requestUpdate();
   }
 
   /**

--- a/packages/lit-dev-content/src/components/litdev-search.ts
+++ b/packages/lit-dev-content/src/components/litdev-search.ts
@@ -140,6 +140,7 @@ class LitDevSearch extends LitElement {
   /**
    * Text value in search input.
    */
+  @state()
   private searchText: string = '';
 
   /**
@@ -299,9 +300,6 @@ class LitDevSearch extends LitElement {
     if (navDrawer) {
       navDrawer.open = false;
     }
-
-    // Rerender to visually clear the value on the input.
-    this.requestUpdate();
   }
 
   /**


### PR DESCRIPTION
## Context

Closes issue #428 as well as fixing the input not properly clearing after navigation.

### Why?

When navigating between page fragment identifiers the page doesn't do a full reload. Thus the search input or mobile drawer don't reset to their initial states.

This change manually cleans up the mobile drawer and search input when a navigation has occurred.

### How?

Although we were setting `this.input.value = ''`, this is not a reactive property and thus the input wasn't being cleared. Requesting an update commits the input clearing.

Similarly we also query for the mobile drawer and close it.

### Testing

To reproduce the issue, navigate to https://lit.dev?mods=search and search between two fragments on the same page.
See video reproducing issue (also sorry for the wild aspect ratio stretching):

https://user-images.githubusercontent.com/15080861/128763409-e492b1ae-34dd-4d56-9830-c9f67b5e227f.mp4

This was manually tested.
