### PR TITLE
Reduce padding on mobile search options

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-search.ts
+++ b/packages/lit-dev-content/src/components/litdev-search.ts
@@ -406,6 +406,12 @@ class LitdevSearchOption extends LionOption {
           margin-left: 1em;
           font-weight: 600;
         }
+
+        @media (max-width: 864px) {
+          .suggestion {
+            padding: 0.2em 0.4em;
+          }
+        }
       `,
     ];
   }


### PR DESCRIPTION
## Context

This is a minor polish change, reducing the padding on mobile. Otherwise long single words would overflow the result.

It's also minor as it is possible to scroll horizontally on the phone. However I think reducing the padding when constrained to a smaller width is a better experience and conveys more information.

## Screenshots

After change (writing `test` in the search query):
<img width="483" alt="Screen Shot 2021-08-09 at 4 48 36 PM" src="https://user-images.githubusercontent.com/15080861/128788186-8948170a-4c3b-487d-bfa8-8a866b28a9db.png">

vs how it currently looks on lit.dev:
<img width="484" alt="Screen Shot 2021-08-09 at 4 49 17 PM" src="https://user-images.githubusercontent.com/15080861/128788224-1fef5093-c12c-40b0-a975-846168e362e7.png">
