### PR TITLE
Release lit.dev site search

### DIFF
--- a/packages/lit-dev-content/site/css/mods.css
+++ b/packages/lit-dev-content/site/css/mods.css
@@ -22,8 +22,3 @@
   --playground-code-attribute-color: #9cdcfe;
   --playground-code-callee-color: #dcdcaa;
 }
-
-/* TODO(https://github.com/lit/lit.dev/issues/423) - Land Lit.dev search */
-body:not(.search) litdev-search {
-  display: none;
-}


### PR DESCRIPTION
### Context

Removes the search mod parameter releasing the lit.dev search to https://lit.dev.
Issue: #423 

### Testing

This has been manually tested behind a feature flag. Release plan is to merge Tuesday morning so that if anything comes up it can be addressed.