### PR TITLE
Sync disconnection-related docs with changes in lit/#2034

### DIFF
--- a/packages/lit-dev-content/site/docs/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/components/lifecycle.md
@@ -46,7 +46,7 @@ Invoked when a component is added to the document's DOM.
 
 Lit initiates the first element update cycle after the element is connected. In preparation for rendering, Lit also ensures the `renderRoot` (typically, its `shadowRoot`) is created.
 
-Note, component updates proceed only when the component is connected. They are paused when the component is disconnected. When the components is reconnected, any changes made while it was disconnected are applied.
+Once an element has connected to the document at least once, component updates will proceed regardless of the connection state of the element.
 
 #### Use cases
 

--- a/packages/lit-dev-content/site/docs/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/releases/upgrade.md
@@ -211,10 +211,6 @@ that you may need to adapt your code to. We expect these changes to affect
 relatively few users.
 
 ### `LitElement`
-* The `update` and `render` callbacks will only be called when the element is
-connected to the document. If an element is disconnected while an update is
-pending, or if an update is requested while the element is disconnected,
-update callbacks will be called if/when the element is re-connected.
 * For simplicity, `requestUpdate` no longer returns a Promise. Instead await the `updateComplete` Promise.
 * Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledrejection` event handler on window.
 * Creation of `shadowRoot` via `createRenderRoot` and support for applying `static styles` to the `shadowRoot` has moved from `LitElement` to `ReactiveElement`.

--- a/packages/lit-dev-content/site/docs/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/templates/custom-directives.md
@@ -250,7 +250,11 @@ Here, the rendered template shows "Waiting for promise to resolve," followed by 
 
 Async directives often need to subscribe to external resources. To prevent memory leaks async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
 
-* `disconnected()`: Called when a directive is no longer in use.  Directive instances are disconnected when the value of a given expression no longer resolves to the same directive, or if the subtree the directive was contained in was removed from the DOM. After a directive receives a `disconnected` callback, it should release all resources it may have subscribed to during `update` or `render` to prevent memory leaks.
+* `disconnected()`: Called when a directive is no longer in use.  Directive instances are disconnected in three cases:
+  - When the DOM tree the directive is contained in is removed from the DOM
+  - When the directive's host element is disconnected
+  - When the expression that produced the directive no longer resolves to the same directive.
+  After a directive receives a `disconnected` callback, it should release all resources it may have subscribed to during `update` or `render` to prevent memory leaks.
 
 * `reconnected()`: Because DOM subtrees can be temporarily disconnected and then reconnected again later (for example, when DOM is moved or cached for later use) a disconnected directive may need to react to being re-connected. So the `reconnected()` callback should always be implemented alongside `disconnected()`, in order to restore a disconnected directive back to its working state.
 

--- a/packages/lit-dev-content/site/docs/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/templates/custom-directives.md
@@ -256,13 +256,13 @@ Async directives often need to subscribe to external resources. To prevent memor
   - When the expression that produced the directive no longer resolves to the same directive.
   After a directive receives a `disconnected` callback, it should release all resources it may have subscribed to during `update` or `render` to prevent memory leaks.
 
-* `reconnected()`: Because DOM subtrees can be temporarily disconnected and then reconnected again later (for example, when DOM is moved or cached for later use) a disconnected directive may need to react to being re-connected. So the `reconnected()` callback should always be implemented alongside `disconnected()`, in order to restore a disconnected directive back to its working state.
+* `reconnected()`: Called when a previously disconnected directive is being returned to use. Because DOM subtrees can be temporarily disconnected and then reconnected again later, a disconnected directive may need to react to being reconnected. Examples of this include when DOM is removed and cached for later use, or when a host element is moved causing a disconnection and reconnection. The `reconnected()` callback should always be implemented alongside `disconnected()`, in order to restore a disconnected directive back to its working state.
 
 * `isConnected`: Reflects the current connection state of the directive.
 
 <div class="alert alert-info">
 
-Note that it is possible for an `AsyncDirective` to continue receiving updates while it is disconnected if its containing tree is re-rendered. As such, `update` and/or `render` should always check the `this.isConnected` flag before subscribing to any long-held resources to prevent memory leaks.
+Note that it is possible for an `AsyncDirective` to continue receiving updates while it is disconnected if its containing tree is re-rendered. Bacause of this, `update` and/or `render` should always check the `this.isConnected` flag before subscribing to any long-held resources to prevent memory leaks.
 
 </div>
 

--- a/packages/lit-dev-content/site/docs/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/templates/custom-directives.md
@@ -254,6 +254,7 @@ Async directives often need to subscribe to external resources. To prevent memor
   - When the DOM tree the directive is contained in is removed from the DOM
   - When the directive's host element is disconnected
   - When the expression that produced the directive no longer resolves to the same directive.
+
   After a directive receives a `disconnected` callback, it should release all resources it may have subscribed to during `update` or `render` to prevent memory leaks.
 
 * `reconnected()`: Called when a previously disconnected directive is being returned to use. Because DOM subtrees can be temporarily disconnected and then reconnected again later, a disconnected directive may need to react to being reconnected. Examples of this include when DOM is removed and cached for later use, or when a host element is moved causing a disconnection and reconnection. The `reconnected()` callback should always be implemented alongside `disconnected()`, in order to restore a disconnected directive back to its working state.
@@ -262,7 +263,7 @@ Async directives often need to subscribe to external resources. To prevent memor
 
 <div class="alert alert-info">
 
-Note that it is possible for an `AsyncDirective` to continue receiving updates while it is disconnected if its containing tree is re-rendered. Bacause of this, `update` and/or `render` should always check the `this.isConnected` flag before subscribing to any long-held resources to prevent memory leaks.
+Note that it is possible for an `AsyncDirective` to continue receiving updates while it is disconnected if its containing tree is re-rendered. Because of this, `update` and/or `render` should always check the `this.isConnected` flag before subscribing to any long-held resources to prevent memory leaks.
 
 </div>
 


### PR DESCRIPTION
See https://github.com/lit/lit/pull/2034, which reverts the change in Lit 2.0 that caused LitElement lifecycle to be paused while the element was disconnected. This was deemed too risky of a change for existing code, and was reverted, hence it is no longer an upgrade-guide topic, and the docs on the lifecycle and custom directives pages are updated.

Note that the implementation change shifts the API contract such that the onus is now on `AsyncDirective` authors to check the `isConnected` flag during `update`, and this responsibility is given special treatment with an info box.

Should maybe wait to deploy this change until the next RC release?