### PR TITLE
Fix litdev-search CLS

### DIFF
--- a/packages/lit-dev-content/site/_includes/site-nav.html
+++ b/packages/lit-dev-content/site/_includes/site-nav.html
@@ -6,7 +6,7 @@
    <a href="{{ site.baseurl }}/playground/">Playground</a></li>
 <li class="navItem{% if page.url.includes('/blog') %} active{% endif %}">
    <a href="{{ site.baseurl }}/blog/">Blog</a></li>
-<li class="navItem"><litdev-search></litdev-search></li>
+<li class="navItem search"><litdev-search></litdev-search></li>
 <li class="navItem">
    <a
       href="https://github.com/lit/lit/"

--- a/packages/lit-dev-content/site/css/header.css
+++ b/packages/lit-dev-content/site/css/header.css
@@ -55,6 +55,12 @@ header > nav {
   width: 222px;
 }
 
+#desktopNav > .navItem.search {
+  /* Reserve space fixing CLS caused by litdev-search */
+  width: 230px;
+  height: 37px;
+}
+
 #desktopNav > .navItem > a:hover,
 #desktopNav > .navItem.active > a {
   color: var(--color-blue);


### PR DESCRIPTION
Tested by measuring web vitals in Chrome Canary.

Results:
<img width="549" alt="Screen Shot 2021-08-17 at 10 14 37 AM" src="https://user-images.githubusercontent.com/15080861/129771205-421b3173-0498-4a8b-98ee-2b87a4221347.png">


I initially expected that adding the concrete dimensions or aspect ratio to the litdev-search component, but the web vitals CLS was only fixed by addressing the container div.


### Tested

Build and run locally (or use the preview link), and run Performance web vitals.
On production a content layout shift occurs when litdev-search loads. With this change there is no CLS on litdev-search loading.
