### PR TITLE
Fix check external link test timing out

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:links:internal": "run-p -r start check-links:internal",
     "test:links:external": "run-p -r start check-links:external",
     "check-links:internal": "wait-on tcp:8080 && blc http://localhost:8080 --recursive --exclude-external --ordered",
-    "check-links:external": "wait-on tcp:8080 && blc http://localhost:8080 --exclude 'http://localhost:8000/dev/' --exclude 'https://github.com/Polymer/internal*' --exclude 'https://github.com/PolymerLabs/lit.dev*' --exclude 'https://www.npmjs.com/*' --get --recursive --host-requests 1"
+    "check-links:external": "wait-on tcp:8080 && blc http://localhost:8080 --exclude 'http://localhost:8000/dev/' --exclude 'https://www.npmjs.com/*' --exclude 'http://localhost:8000/slack-invite/' --get --recursive --exlude-internal --host-requests 1"
   },
   "author": "Google LLC",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:links:internal": "run-p -r start check-links:internal",
     "test:links:external": "run-p -r start check-links:external",
     "check-links:internal": "wait-on tcp:8080 && blc http://localhost:8080 --recursive --exclude-external --ordered",
-    "check-links:external": "wait-on tcp:8080 && blc http://localhost:8080 --exclude 'http://localhost:8000/dev/' --exclude 'https://www.npmjs.com/*' --exclude 'http://localhost:8000/slack-invite/' --get --recursive --exlude-internal --host-requests 1"
+    "check-links:external": "wait-on tcp:8080 && blc http://localhost:8080 --exclude 'http://localhost:8000/dev/' --exclude 'https://www.npmjs.com/*' --get --recursive --host-requests 1"
   },
   "author": "Google LLC",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:links:internal": "run-p -r start check-links:internal",
     "test:links:external": "run-p -r start check-links:external",
     "check-links:internal": "wait-on tcp:8080 && blc http://localhost:8080 --recursive --exclude-external --ordered",
-    "check-links:external": "wait-on tcp:8080 && blc http://localhost:8080 --exclude 'http://localhost:8000/dev/' --exclude 'https://github.com/Polymer/internal*' --exclude 'https://github.com/PolymerLabs/lit.dev*' --exclude 'https://www.npmjs.com/*' --get --recursive --exclude-internal --host-requests 1"
+    "check-links:external": "wait-on tcp:8080 && blc http://localhost:8080 --exclude 'http://localhost:8000/dev/' --exclude 'https://github.com/Polymer/internal*' --exclude 'https://github.com/PolymerLabs/lit.dev*' --exclude 'https://www.npmjs.com/*' --get --recursive --host-requests 1"
   },
   "author": "Google LLC",
   "license": "BSD-3-Clause",

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/**
- * Any redirects here to an external domain need to be added as exclusions in
- * the `check-links:external` test in the root `package.json`. Otherwise the
- * test queues these external domains for broken link checking crawling those
- * domains and timing out the test.
- */
 export const pageRedirects  = new Map(
   [
     ['/slack-invite/', 'https://join.slack.com/t/lit-and-friends/shared_invite/zt-llwznvsy-LZwT13R66gOgnrg12PUGqw'],

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/**
+ * Any redirects here to an external domain need to be added as exclusions in
+ * the `check-links:external` test in the root `package.json`. Otherwise the
+ * test queues these external domains for broken link checking crawling those
+ * domains and timing out the test.
+ */
 export const pageRedirects  = new Map(
   [
     ['/slack-invite/', 'https://join.slack.com/t/lit-and-friends/shared_invite/zt-llwznvsy-LZwT13R66gOgnrg12PUGqw'],


### PR DESCRIPTION
Note to reviewer. There are three commits that track my attempts to solve this elegantly as I figured out the root cause. The root cause is redirect.ts that makes an internal link redirect to slack domains. This seems to be a bug specific with the "--exclude-internal" CLI argument (which I typo in the second commit). Thus the second commit identifies the cause, but provides the wrong fix.

tl;dr: The `--exclude-internal` flag changes some behavior such that the /slack-invite redirect causes the whole internet to be crawled. Without the flag we don't filter internal links out of the check, but crawl the website correctly without redirecting to slack domains.

### Context

Currently the broken link checker starts to crawl the entire internet until it eventually times out. This happens because the broken link checker queues up pages it thinks are on the `localhost` domain for external link checking. This means that it also queues up redirect urls such as `/slack-invite/` and treats them as valid urls to crawl. This results in slack being crawled by the test which eventually leads to the test timing out after a couple hours of crawling.

### Fix

I was not able to filter out the `/slack-invite/` redirect that causes this issue. The `--exclude-internal` CLI filter changes the behavior resulting in slack domain urls queueing up. In order to timebox this issue and get us to a better place I've removed the flag. This means there is some duplication of link checking as the external command now checks both internal & external links. The crawler no longer crawls onto the Slack domain fixing the timeout.

Also cleaned up two other exclusions that no longer seem to be required.
Filed issue https://github.com/lit/lit.dev/issues/439 for following up on filtering out internal links.

### Testing

This can be tested locally by running `npm run test` in the lit.dev root directory. Running on `main` will lead to the script endlessly crawling, whilst on this branch it eventually ends after traversing the entire lit.dev website.

The github action associated with this PR should also complete rather than timing out. Note I'm not addressing any broken links in this change, just fixing the test.