### PR TITLE
Bump playground version to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lit.dev",
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "devDependencies": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -60,7 +60,7 @@
     "lit": "^2.0.0-pre.1",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
-    "playground-elements": "^0.11.1",
+    "playground-elements": "^0.12.0",
     "tarts": "^1.0.0",
     "tslib": "^2.2.0"
   }

--- a/packages/lit-dev-content/samples/base.json
+++ b/packages/lit-dev-content/samples/base.json
@@ -1,17 +1,8 @@
 {
-  "importMap": {
-    "imports": {
-      "lit": "https://cdn.skypack.dev/lit@2.0.0-rc.2",
-      "lit/": "https://cdn.skypack.dev/lit@2.0.0-rc.2/",
-      "@lit/reactive-element": "https://cdn.skypack.dev/@lit/reactive-element@1.0.0-rc.2",
-      "@lit/reactive-element/": "https://cdn.skypack.dev/@lit/reactive-element@1.0.0-rc.2/",
-      "@lit-labs/task": "https://cdn.skypack.dev/@lit-labs/task@1.0.0-rc.2",
-      "@lit-labs/task/": "https://cdn.skypack.dev/@lit-labs/task@1.0.0-rc.2/",
-      "lit-element": "https://cdn.skypack.dev/lit-element@3.0.0-rc.2",
-      "lit-element/": "https://cdn.skypack.dev/lit-element@3.0.0-rc.2/",
-      "lit-html": "https://cdn.skypack.dev/lit-html@2.0.0-rc.3",
-      "lit-html/": "https://cdn.skypack.dev/lit-html@2.0.0-rc.3/",
-      "typescript/": "https://unpkg.com/typescript@4.3.5/"
+  "files": {
+    "package.json": {
+      "content": "{\"dependencies\":{\"lit\":\"^2.0.0-rc.2\",\"@lit/reactive-element\":\"^1.0.0-rc.2\",\"lit-element\":\"^3.0.0-rc.2\",\"lit-html\":\"^2.0.0-rc.3\"}}",
+      "hidden": true
     }
   }
 }

--- a/packages/lit-dev-tools/package.json
+++ b/packages/lit-dev-tools/package.json
@@ -21,7 +21,7 @@
     "markdown-it-anchor": "^7.1.0",
     "minisearch": "^3.0.4",
     "outdent": "^0.8.0",
-    "playground-elements": "^0.11.1",
+    "playground-elements": "^0.12.0",
     "playwright": "^1.8.0",
     "source-map": "^0.7.3",
     "strip-comments": "^2.0.1",


### PR DESCRIPTION
Brings in these changes: https://github.com/PolymerLabs/playground-elements/blob/main/CHANGELOG.md#0120---2021-08-17