### PR TITLE
Misc. updates based on TODO scrub

### DIFF
--- a/packages/lit-dev-content/site/docs/components/styles.md
+++ b/packages/lit-dev-content/site/docs/components/styles.md
@@ -233,7 +233,7 @@ render() {
 
 <div class="alert alert-info">
 
-**Limitations in the ShadyCSS polyfill around expressions.** Expressions in `<style>` elements won't update per instance in ShadyCSS, due to limitations of the ShadyCSS polyfill. See the [ShadyCSS limitations](https://github.com/webcomponents/shadycss/blob/master/README.md#limitations) for more information.
+**Limitations in the ShadyCSS polyfill around expressions.** Expressions in `<style>` elements won't update per instance in ShadyCSS, due to limitations of the ShadyCSS polyfill. In addition, `<style>` nodes may not be passed as expression values when using the ShadyCSS polyfill. See the [ShadyCSS limitations](https://github.com/webcomponents/polyfills/tree/master/packages/shadycss#limitations) for more information.
 
 </div>
 
@@ -257,7 +257,7 @@ While you can include an external style sheet in your template with a `<link>`, 
 
 **External stylesheet caveats.**
 
-*  The [ShadyCSS polyfill](https://github.com/webcomponents/shadycss/blob/master/README.md#limitations) doesn't support external style sheets.
+*  The [ShadyCSS polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/shadycss#limitations) doesn't support external style sheets.
 *   External styles can cause a flash-of-unstyled-content (FOUC) while they load.
 *   The URL in the `href` attribute is relative to the **main document**. This is okay if you're building an app and your asset URLs are well-known, but avoid using external style sheets when building a reusable element.
 

--- a/packages/lit-dev-content/site/docs/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/releases/upgrade.md
@@ -233,3 +233,4 @@ relatively few users.
 * Symbols are not converted to a string before mutating DOM, so passing a Symbol to an attribute or text binding will result in an exception.
 * The `ifDefined` directive in an attribute expression now removes the attribute for both `null` and `undefined`, not just `undefined`.
 * Rendering the value `nothing` to an attribute expression causes the attribute to be removed—even if there are multiple expressions in the attribute value position and only one is `nothing`. For example given `src="${baseurl}/${filename}"`, the `src` attribute is removed if _either_ `baseurl` or `filename` evaluate to `nothing`.
+* Rendering the value `nothing`, `null`, or `undefined` in the `unsafeHTML` or `unsafeSVG` directive will now result in no content being rendered (previously it would render `'[object Object]'`, `'null'`, or `'undefined'`, respectively).


### PR DESCRIPTION
* Clarify that a `<style>` _node_ is no longer supported in a `css` tagged string literal expression when using ShadyCSS
* Clarify `unsafeSVG` and `unsafeHTML` behavior for nothing/null/undefined