### PR TITLE
Redirects for dev mode short links

### DIFF
--- a/packages/lit-dev-server/src/index.ts
+++ b/packages/lit-dev-server/src/index.ts
@@ -43,6 +43,8 @@ if (mode === 'playground') {
 }
 
 app.use(async (ctx, next) => {
+  // If there would be multiple redirects, resolve them all here so that we
+  // serve just one HTTP redirect instead of a chain.
   let path = ctx.path;
   if (path.match(/\/[^\/\.]+$/)) {
     // Canonicalize paths to have a trailing slash, except for files with

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export const pageRedirects  = new Map(
-  [
-    ['/slack-invite/', 'https://join.slack.com/t/lit-and-friends/shared_invite/zt-llwznvsy-LZwT13R66gOgnrg12PUGqw'],
-  ]
-)
+// prettier-ignore
+export const pageRedirects = new Map([
+  ['/slack-invite', 'https://join.slack.com/t/lit-and-friends/shared_invite/zt-llwznvsy-LZwT13R66gOgnrg12PUGqw'],
+].map(([path, redir]) => [
+  // Trailing slashes are required because this redirect map is consulted after
+  // standard lit.dev path canonicalization.
+  path.match(/\/[^\/\.]+$/) ? path + '/' : path,
+  redir,
+]));

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -7,6 +7,20 @@
 // prettier-ignore
 export const pageRedirects = new Map([
   ['/slack-invite', 'https://join.slack.com/t/lit-and-friends/shared_invite/zt-llwznvsy-LZwT13R66gOgnrg12PUGqw'],
+
+  ['/msg/dev-mode',                  '/docs/tools/development/#development-and-production-builds'],
+  // TODO(sorvell) https://github.com/lit/lit.dev/issues/455
+  ['/msg/multiple-versions',         '/docs/tools/requirements/'],
+  ['/msg/polyfill-support-missing',  '/docs/tools/requirements/#polyfills'],
+  // TODO(sorvell) https://github.com/lit/lit.dev/issues/462
+  ['/msg/class-field-shadowing',     '/docs/components/properties/#declare'],
+  // TODO(aomarks) Should we add something specifically about this issue?
+  ['/msg/change-in-update',          '/docs/components/properties/#when-properties-change'],
+  ['/msg/deprecated-import-path',    '/docs/releases/upgrade/#update-packages-and-import-paths'],
+  ['/msg/removed-api',               '/docs/releases/upgrade/#litelement'],
+  ['/msg/renamed-api',               '/docs/releases/upgrade/#update-to-renamed-apis'],
+  ['/msg/undefined-attribute-value', '/docs/releases/upgrade/#litelement'],
+  ['/msg/request-update-promise',    '/docs/releases/upgrade/#litelement'],
 ].map(([path, redir]) => [
   // Trailing slashes are required because this redirect map is consulted after
   // standard lit.dev path canonicalization.


### PR DESCRIPTION
Adds a `https://lit.dev/msg/<code>` redirect for all warnings logged by Lit's dev mode.

Half of https://github.com/lit/lit/issues/2078. Other half is at https://github.com/lit/lit/pull/2119.