### PR TITLE
Adds JS/TS toggle to interactive docs samples

### DIFF
--- a/packages/lit-dev-content/site/css/code.css
+++ b/packages/lit-dev-content/site/css/code.css
@@ -33,12 +33,10 @@ html {
   overflow-y: auto;
 }
 
-playground-preview,
-playground-ide::part(preview) {
+playground-preview {
   background: var(--color-light-gray);
 }
 
-playground-ide::part(preview-toolbar),
 playground-preview::part(preview-toolbar) {
   background: var(--color-light-gray);
   border-bottom: 1px solid #ccc;
@@ -47,7 +45,6 @@ playground-preview::part(preview-toolbar) {
   box-sizing: border-box;
 }
 
-playground-ide::part(tab-bar),
 playground-tab-bar {
   background: white;
   font-size: 16px;
@@ -56,7 +53,6 @@ playground-tab-bar {
   box-sizing: border-box;
 }
 
-playground-file-editor,
-playground-ide::part(editor) {
+playground-file-editor {
   background: white;
 }

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -116,6 +116,12 @@ article pre > code:not([class]) {
   border: var(--code-border);
 }
 
+litdev-example {
+  /* Prevent layout shift before upgrade, since custom elements default to
+     inline. */
+  display: block;
+}
+
 .CodeMirror,
 litdev-example {
   font-size: 0.85em;

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -116,24 +116,11 @@ article pre > code:not([class]) {
   border: var(--code-border);
 }
 
-/* Playground examples */
-litdev-example {
-}
-
-/* Full IDEs */
-playground-ide {
-}
-
 .CodeMirror,
-litdev-example,
-playground-ide {
+litdev-example {
   font-size: 0.85em;
   border-radius: 5px;
   border: var(--code-border);
-}
-
-playground-ide {
-  background: var(--playground-code-background);
 }
 
 figure {

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -116,10 +116,24 @@ article pre > code:not([class]) {
   border: var(--code-border);
 }
 
+/* With tabs */
+litdev-example:not([filename]) {
+  --litdev-example-bar-height: 45px;
+}
+
+/* Without tabs */
+litdev-example[filename] {
+  --litdev-example-bar-height: 31px;
+}
+
 litdev-example {
   /* Prevent layout shift before upgrade, since custom elements default to
-     inline. */
+  inline. */
   display: block;
+  height: calc(
+    var(--litdev-example-bar-height) +
+    var(--litdev-example-editor-height) +
+    var(--litdev-example-preview-height));
 }
 
 .CodeMirror,

--- a/packages/lit-dev-content/site/css/mods.css
+++ b/packages/lit-dev-content/site/css/mods.css
@@ -22,3 +22,9 @@
   --playground-code-attribute-color: #9cdcfe;
   --playground-code-callee-color: #dcdcaa;
 }
+
+.jsSamples {
+  /* TODO(aomarks) Remove when JS samples launch, and update the
+  litdev-typescript-switch display property to match this. */
+  --litdev-typescript-switch-display: inline-flex;
+}

--- a/packages/lit-dev-content/src/components/litdev-example-controls.ts
+++ b/packages/lit-dev-content/src/components/litdev-example-controls.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html, css, customElement, property} from 'lit-element';
+import './litdev-typescript-switch.js';
+
+/**
+ * Controls for lit.dev code examples.
+ */
+@customElement('litdev-example-controls')
+export class LitDevExampleControls extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+      margin-left: auto;
+    }
+
+    #openInPlayground {
+      display: flex;
+      color: inherit;
+      opacity: 70%;
+      margin-left: 10px;
+    }
+
+    #openInPlayground:hover {
+      opacity: 100%;
+    }
+  `;
+
+  /**
+   * Path to the project dir from `samples/PROJECT/project.json`.
+   */
+  @property()
+  project?: string;
+
+  override render() {
+    return html`
+      <litdev-typescript-switch></litdev-typescript-switch>
+      <a
+        id="openInPlayground"
+        title="Open this example in the playground"
+        target="_blank"
+        href="/playground/#sample=${this.project}"
+      >
+        <!-- Source: https://material.io/resources/icons/?icon=launch&style=baseline -->
+        <svg width="22px" height="22px" viewBox="0 0 24 24" fill="#5f5f5f">
+          <path
+            d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+          />
+        </svg>
+      </a>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'litdev-typescript-controls': LitDevExampleControls;
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-typescript-switch.ts
+++ b/packages/lit-dev-content/src/components/litdev-typescript-switch.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html, css, customElement} from 'lit-element';
+import {
+  getTypeScriptPreference,
+  setTypeScriptPreference,
+  TYPESCRIPT_PREFERENCE_EVENT_NAME,
+} from '../typescript-preference.js';
+
+/**
+ * A switch that toggles between TypeScript and JavaScript preferences.
+ *
+ * When changed, the preference is saved to localStorage. If the preference is
+ * updated anywhere on the page, every instance of this switch will
+ * automatically update to reflect it.
+ */
+@customElement('litdev-typescript-switch')
+export class LitDevTypeScriptSwitch extends LitElement {
+  static override styles = css`
+    :host {
+      display: inline-flex;
+      font-family: 'Open Sans', sans-serif;
+    }
+
+    button {
+      display: flex;
+      font-family: inherit;
+      font-weight: inherit;
+      color: black;
+      background: #fbfcff;
+      padding: 2px 14px;
+      border: 1.5px solid #8e9498;
+      transition: background-color 100ms;
+    }
+
+    /* Note [disabled] implies selected, because the active choice is always
+    disabled.*/
+    button[disabled],
+    button:hover {
+      background: #ebeeff;
+      border-color: #7589ff;
+    }
+
+    button:not([disabled]) {
+      cursor: pointer;
+    }
+
+    button:first-of-type {
+      border-radius: 15px 0 0 15px;
+    }
+
+    button:last-of-type {
+      border-radius: 0 15px 15px 0;
+      border-left-color: #8e9498;
+    }
+
+    button:not(:last-of-type) {
+      border-right: none;
+    }
+  `;
+
+  override connectedCallback() {
+    // TODO(aomarks) After we upgrade to Lit 2, this and similar code in other
+    // components could be refactored into a controller.
+    super.connectedCallback();
+    window.addEventListener(
+      TYPESCRIPT_PREFERENCE_EVENT_NAME,
+      this._onTypeScriptPreferenceChanged
+    );
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener(
+      TYPESCRIPT_PREFERENCE_EVENT_NAME,
+      this._onTypeScriptPreferenceChanged
+    );
+  }
+
+  private _onTypeScriptPreferenceChanged = () => {
+    this.requestUpdate();
+  };
+
+  override render() {
+    const mode = getTypeScriptPreference();
+    return html`
+      <button
+        title="Display code as JavaScript"
+        aria-label="Display code as JavaScript"
+        ?disabled=${mode === 'js'}
+        @click=${this._onClickJs}
+      >
+        JS
+      </button>
+
+      <button
+        title="Display code as TypeScript"
+        aria-label="Display code as TypeScript"
+        ?disabled=${mode === 'ts'}
+        @click=${this._onClickTs}
+      >
+        TS
+      </button>
+    `;
+  }
+
+  private _onClickJs() {
+    setTypeScriptPreference('js');
+  }
+
+  private _onClickTs() {
+    setTypeScriptPreference('ts');
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'litdev-typescript-switch': LitDevTypeScriptSwitch;
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-typescript-switch.ts
+++ b/packages/lit-dev-content/src/components/litdev-typescript-switch.ts
@@ -22,7 +22,8 @@ import {
 export class LitDevTypeScriptSwitch extends LitElement {
   static override styles = css`
     :host {
-      display: inline-flex;
+      /* TODO(aomarks) Fix as inline-flex after jsSamples mod is retired. */
+      display: var(--litdev-typescript-switch-display, none);
       font-family: 'Open Sans', sans-serif;
     }
 

--- a/packages/lit-dev-content/src/typescript-preference.ts
+++ b/packages/lit-dev-content/src/typescript-preference.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+type TypeScriptPreference = 'ts' | 'js';
+
+const LOCAL_STORAGE_KEY = 'typescript-preference';
+
+/**
+ * Name of the event that is fired on window whenever the global user TypeScript
+ * preference changes.
+ */
+export const TYPESCRIPT_PREFERENCE_EVENT_NAME = 'typescript-preference-changed';
+
+/**
+ * Get the user's TypeScript vs JavaScript preference from localStorage.
+ * Defaults to TypeScript if there is no preference.
+ */
+export const getTypeScriptPreference = (): TypeScriptPreference =>
+  (localStorage.getItem(LOCAL_STORAGE_KEY) as TypeScriptPreference | null) ??
+  'ts';
+
+/**
+ * Save the user's TypeScript vs JavaScript preference to localStorage, and fire
+ * a change event on window.
+ */
+export const setTypeScriptPreference = (
+  preference: TypeScriptPreference
+): void => {
+  localStorage.setItem(LOCAL_STORAGE_KEY, preference);
+  window.dispatchEvent(new Event(TYPESCRIPT_PREFERENCE_EVENT_NAME));
+};

--- a/packages/lit-dev-tools/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/plugin.ts
@@ -129,12 +129,10 @@ export const playgroundPlugin = (
     // correct, to prevent layout shift.
     const editorHeight = config.editorHeight ?? '300px';
     const previewHeight = config.previewHeight ?? '120px';
-    const fileTabBarHeight = '45px';
     return `
     <litdev-example ${sandboxUrl ? `sandbox-base-url='${sandboxUrl}'` : ''}
-      style="height:calc(${editorHeight} + ${previewHeight} + ${fileTabBarHeight});
-              --litdev-example-editor-height:${editorHeight};
-              --litdev-example-preview-height:${previewHeight}"
+      style="--litdev-example-editor-height:${editorHeight};
+             --litdev-example-preview-height:${previewHeight}"
       project=${project}
     >
     </litdev-example>
@@ -174,8 +172,7 @@ export const playgroundPlugin = (
       const previewHeight = config.previewHeight ?? '120px';
       return `
       <litdev-example ${sandboxUrl ? `sandbox-base-url='${sandboxUrl}'` : ''}
-        style="height:calc(${editorHeight} + ${previewHeight});
-               --litdev-example-editor-height:${editorHeight};
+        style="--litdev-example-editor-height:${editorHeight};
                --litdev-example-preview-height:${previewHeight}"
         project=${project}
         filename=${filename}


### PR DESCRIPTION
Adds a JS/TS toggle to all interactive samples in the docs, behind the `?mods=jsSamples` feature flag.

**Note:** The playground page, tutorial page, and static samples will come in a followup PR.

**Also note:** There are a some issues with the JS samples that I've seen already, mostly around `/*playground-fold*/` and `/*playground-hide*/` comments not getting preserved quite right. I'll address those in a followup too.

Also fixes layout shift issues with inline playgrounds.

#### With tabs
<img src="https://user-images.githubusercontent.com/48894/132420551-6f700813-71b6-4b58-9cc0-80c6c891e0f3.png" width="500px">

#### Without tabs
<img src="https://user-images.githubusercontent.com/48894/132420560-89c60b17-bf9b-482e-ae0d-c3b468e7dec1.png" width="500px">

