### PR TITLE
Add JS/TS toggle to playground

### DIFF
--- a/packages/lit-dev-content/site/css/code.css
+++ b/packages/lit-dev-content/site/css/code.css
@@ -3,7 +3,7 @@ html {
   --playground-code-font-size: 14px;
   --playground-code-line-height: 1.6em;
   --litdev-code-padding: 0.5em 0 0.5em 1em;
-  --playground-bar-height: 2.5rem;
+  --playground-bar-height: 44px;
   --playground-code-gutter-background: white;
   --playground-code-gutter-border-right: none;
 

--- a/packages/lit-dev-content/site/css/playground.css
+++ b/packages/lit-dev-content/site/css/playground.css
@@ -169,6 +169,22 @@ litdev-drawer:not([closed])::part(header) {
   display: flex;
   flex-direction: column;
 }
+/* TODO(aomarks) There is some duplication between this layout and the
+   tutorial. It's very similar, but slightly different in a few places. */
+#tabsAndControls {
+  display: flex;
+  padding-right: 8px;
+  /* Move border from the tab-bar to this wrapping div. */
+  border-bottom: 1px solid #ccc;
+  height: var(--playground-bar-height);
+  box-sizing: border-box;
+}
+
+playground-tab-bar {
+  min-width: 0;
+  border-bottom: none;
+  height: auto;
+}
 
 /* Playground */
 

--- a/packages/lit-dev-content/site/playground.html
+++ b/packages/lit-dev-content/site/playground.html
@@ -76,11 +76,16 @@ title: Playground
 
   <did id="tabsEditorAndPreview">
     <div id="tabsAndEditor">
-      <playground-tab-bar
-        editable-file-system
-        project="project"
-        editor="editor">
-      </playground-tab-bar>
+
+      <div id="tabsAndControls">
+        <playground-tab-bar
+          editable-file-system
+          project="project"
+          editor="editor">
+        </playground-tab-bar>
+
+        <litdev-example-controls></litdev-example-controls>
+      </div>
 
       <playground-file-editor
         id="editor"

--- a/packages/lit-dev-content/src/components/litdev-example-controls.ts
+++ b/packages/lit-dev-content/src/components/litdev-example-controls.ts
@@ -38,9 +38,14 @@ export class LitDevExampleControls extends LitElement {
   @property()
   project?: string;
 
+  @property({type: Boolean})
+  hideTypeScriptSwitch = false;
+
   override render() {
     return html`
-      <litdev-typescript-switch></litdev-typescript-switch>
+      ${this.hideTypeScriptSwitch
+        ? nothing
+        : html`<litdev-typescript-switch></litdev-typescript-switch>`}
       ${this.project
         ? html`<a
             id="openInPlayground"
@@ -62,6 +67,6 @@ export class LitDevExampleControls extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'litdev-typescript-controls': LitDevExampleControls;
+    'litdev-example-controls': LitDevExampleControls;
   }
 }

--- a/packages/lit-dev-content/src/pages/playground.ts
+++ b/packages/lit-dev-content/src/pages/playground.ts
@@ -7,6 +7,11 @@
 import '@material/mwc-button';
 import '@material/mwc-snackbar';
 import 'playground-elements/playground-ide.js';
+import '../components/litdev-example-controls.js';
+import {
+  getTypeScriptPreference,
+  TYPESCRIPT_PREFERENCE_EVENT_NAME,
+} from '../typescript-preference.js';
 
 import Tar from 'tarts';
 import {Snackbar} from '@material/mwc-snackbar';
@@ -135,6 +140,7 @@ window.addEventListener('DOMContentLoaded', () => {
     $('.exampleItem.active')?.classList.remove('active');
 
     if (urlFiles) {
+      hideTypeScriptSwitch();
       project.config = {
         extends: '/samples/base.json',
         files: Object.fromEntries(
@@ -142,12 +148,15 @@ window.addEventListener('DOMContentLoaded', () => {
         ),
       };
     } else {
+      showTypeScriptSwitch();
       let sample = 'examples/hello-world-typescript';
       const urlSample = params.get('sample');
       if (urlSample?.match(/^[a-zA-Z0-9_\-\/]+$/)) {
         sample = urlSample;
       }
-      project.projectSrc = `/samples/${sample}/project.json`;
+      const samplesRoot =
+        getTypeScriptPreference() === 'ts' ? '/samples' : '/samples/js';
+      project.projectSrc = `${samplesRoot}/${sample}/project.json`;
 
       const link = $(`.exampleItem[data-sample="${sample}"]`);
       if (link) {
@@ -163,6 +172,10 @@ window.addEventListener('DOMContentLoaded', () => {
 
   syncStateFromUrlHash();
   window.addEventListener('hashchange', syncStateFromUrlHash);
+  window.addEventListener(
+    TYPESCRIPT_PREFERENCE_EVENT_NAME,
+    syncStateFromUrlHash
+  );
 
   // Trigger URL sharing when Control-s or Command-s is pressed.
   let controlDown = false;
@@ -189,6 +202,28 @@ window.addEventListener('DOMContentLoaded', () => {
     commandDown = false;
   });
 });
+
+const exampleControls = document.body.querySelector('litdev-example-controls');
+
+/**
+ * Set the opacity of the TypeScript/JavaScript language switch.
+ *
+ * When a Playground is comes from a base64-encoded project in the URL (i.e.
+ * through the "Share" button), it's not possible to automatically translate
+ * between JS and TS forms. Only pre-built TS samples have a generated JS
+ * version available.
+ */
+const hideTypeScriptSwitch = () => {
+  if (exampleControls) {
+    exampleControls.hideTypeScriptSwitch = true;
+  }
+};
+
+const showTypeScriptSwitch = () => {
+  if (exampleControls) {
+    exampleControls.hideTypeScriptSwitch = false;
+  }
+};
 
 /**
  * Note we don't use scrollIntoView() because it also steals focus.


### PR DESCRIPTION
Adds the JS/TS toggle to the playground page page (still behind the `?mods=jsSamples` feature flag).

One special thing about this integration is that we remove the toggle when the project is shared, or loaded from the base64 URL, since we only have JS versions available for our pre-defined samples.

Part of #332

![image](https://user-images.githubusercontent.com/48894/132549488-a8494fc9-927b-4145-beca-0466ce60f620.png)
