### PR TITLE
Add JS versions of tutorial code samples

### DIFF
--- a/packages/lit-dev-content/samples/tutorial/06-template-logic/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorial/06-template-logic/after/todo-list.ts
@@ -26,8 +26,8 @@ class ToDoList extends LitElement {
 
   addToDo() {
     this.listItems.push({text: this.input.value, completed: false});
-    this.requestUpdate();
     this.input.value = '';
+    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorial/07-styles/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorial/07-styles/after/todo-list.ts
@@ -53,7 +53,7 @@ export class ToDoList extends LitElement {
 
   addToDo() {
     this.listItems.push({text: this.input.value, completed: false});
-    this.requestUpdate();
     this.input.value = '';
+    this.requestUpdate();
   }
 }

--- a/packages/lit-dev-content/samples/tutorial/07-styles/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorial/07-styles/before/todo-list.ts
@@ -45,8 +45,8 @@ export class ToDoList extends LitElement {
 
   addToDo() {
     this.listItems.push({text: this.input.value, completed: false});
-    this.requestUpdate();
     this.input.value = '';
+    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorial/08-finishing-touches/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorial/08-finishing-touches/after/todo-list.ts
@@ -79,8 +79,8 @@ export class ToDoList extends LitElement {
 
   addToDo() {
     this.listItems.push({text: this.input.value, completed: false});
-    this.requestUpdate();
     this.input.value = '';
+    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorial/08-finishing-touches/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorial/08-finishing-touches/before/todo-list.ts
@@ -73,8 +73,8 @@ export class ToDoList extends LitElement {
 
   addToDo() {
     this.listItems.push({text: this.input.value, completed: false});
-    this.requestUpdate();
     this.input.value = '';
+    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/site/tutorial/content/02-define.md
+++ b/packages/lit-dev-content/site/tutorial/content/02-define.md
@@ -3,11 +3,21 @@ In Lit, most things start with defining a _component_. Here we've given you a st
 
 *   **Define a component.**
 
+    {% switchable-sample %}
+
     ```ts
     @customElement('my-element')
     class MyElement extends LitElement {
     }
     ```
+
+    ```js
+    class MyElement extends LitElement {
+    }
+    customElements.define('my-element', MyElement);
+    ```
+
+    {% endswitchable-sample %}
 
     The `MyElement` class provides the implementation for your new component, and the `@customElement` decorator registers it with the browser as a new element type named `my-element`.
 

--- a/packages/lit-dev-content/site/tutorial/content/03-properties.md
+++ b/packages/lit-dev-content/site/tutorial/content/03-properties.md
@@ -6,10 +6,25 @@ Here we've given you a basic component definition. In this step you'll declare a
 
     Add the following field to the `MyElement` class:
 
-    ```js
+    {% switchable-sample %}
+
+    ```ts
     @property()
     message: string = 'Hello again.';
     ```
+
+    ```js
+    static properties = {
+      message: {},
+    };
+
+    constructor() {
+      super();
+      this.message = 'Hello again.';
+    }
+    ```
+
+    {% endswitchable-sample %}
 
     The code snippet above adds a string property called `message` to your element class. The `@property` decorator identifies it as a reactive property.
 

--- a/packages/lit-dev-content/site/tutorial/content/04-events.md
+++ b/packages/lit-dev-content/site/tutorial/content/04-events.md
@@ -20,12 +20,24 @@ Here we've provided a name tag component with a message and an input element. In
 
     Next, add the event handler that's called when the input value changes.
 
+
+    {% switchable-sample %}
+
     ```ts
     changeName(event: Event) {
       const input = event.target as HTMLInputElement;
       this.name = input.value;
     }
     ```
+
+    ```js
+    changeName(event) {
+      const input = event.target;
+      this.name = input.value;
+    }
+    ```
+
+    {% endswitchable-sample %}
 
     Since `name` is a reactive property, setting it in the event handler triggers the component to update.
 

--- a/packages/lit-dev-content/site/tutorial/content/06-template-logic.md
+++ b/packages/lit-dev-content/site/tutorial/content/06-template-logic.md
@@ -27,8 +27,8 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
 
     addToDo() {
       this.listItems.push({text: this.input.value, completed: false});
-      this.requestUpdate();
       this.input.value = '';
+      this.requestUpdate();
     }
     ```
 
@@ -39,8 +39,8 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
 
     addToDo() {
       this.listItems.push({text: this.input.value, completed: false});
-      this.requestUpdate();
       this.input.value = '';
+      this.requestUpdate();
     }
     ```
 

--- a/packages/lit-dev-content/site/tutorial/content/06-template-logic.md
+++ b/packages/lit-dev-content/site/tutorial/content/06-template-logic.md
@@ -18,6 +18,9 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
 
     We've provided an input and an **Add** button, but they aren't hooked up yet. Add the `input` property and an event handler method for the button:
 
+
+    {% switchable-sample %}
+
     ```ts
     @query('#newitem')
     input!: HTMLInputElement;
@@ -28,6 +31,20 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
       this.input.value = '';
     }
     ```
+
+    ```js
+    get input() {
+      return this.renderRoot?.querySelector('#newitem') ?? null;
+    }
+
+    addToDo() {
+      this.listItems.push({text: this.input.value, completed: false});
+      this.requestUpdate();
+      this.input.value = '';
+    }
+    ```
+
+    {% endswitchable-sample %}
 
     As the name suggests, `requestUpdate()` triggers the component to update. Setting a reactive property calls this automatically. Since you're not setting `listItems` here, but only mutating the array, you need to call `requestUpdate()` yourself.
 

--- a/packages/lit-dev-content/site/tutorial/index.html
+++ b/packages/lit-dev-content/site/tutorial/index.html
@@ -9,6 +9,7 @@ title: Tutorial
   <script type="module" src="{{ site.baseurl }}/js/components/litdev-tutorial.js"></script>
   <script type="module" src="{{ site.baseurl }}/js/components/playground-elements.js"></script>
   <script type="module" src="{{ site.baseurl }}/js/components/resize-bar.js"></script>
+  <script type="module" src="{{ site.baseurl }}/js/components/litdev-switchable-sample.js"></script>
 {% endblock %}
 
 {% block content %}

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -213,7 +213,7 @@ export class LitDevTutorial extends LitElement {
 
   private _onClickReset() {
     this._solved = false;
-    this._setProjectSrc(this._info.projectSrcBefore);
+    this._setProjectSrc(this._info.projectSrcBefore, true);
   }
 
   private _onClickNextButton(event: Event) {

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -190,9 +190,6 @@ export class LitDevTutorial extends LitElement {
   }
 
   private _onCodeLanguagePreferenceChanged = () => {
-    // TODO(aomarks) If the user has modified the code, we should show a dialog
-    // on the Playground along the lines of "Switching languages will lose your
-    // changes [Accept] [Cancel]".
     this._setProjectSrc(
       this._solved ? this._info.projectSrcAfter : this._info.projectSrcBefore,
       true

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -63,6 +63,11 @@ export class LitDevTutorial extends LitElement {
   @state()
   private _preloadedHtml?: {idx: number; promise: Promise<string>};
 
+  /**
+   * Whether the tutorial is currently in its "solved" state.
+   */
+  private _solved = false;
+
   createRenderRoot() {
     // This is a site-specific component, and we want to inherit site-wide
     // styles.
@@ -185,7 +190,13 @@ export class LitDevTutorial extends LitElement {
   }
 
   private _onCodeLanguagePreferenceChanged = () => {
-    this._loadStep();
+    // TODO(aomarks) If the user has modified the code, we should show a dialog
+    // on the Playground along the lines of "Switching languages will lose your
+    // changes [Accept] [Cancel]".
+    this._setProjectSrc(
+      this._solved ? this._info.projectSrcAfter : this._info.projectSrcBefore,
+      true
+    );
   };
 
   update(changedProperties: PropertyValues) {
@@ -196,11 +207,13 @@ export class LitDevTutorial extends LitElement {
   }
 
   private _onClickSolve() {
+    this._solved = true;
     this._setProjectSrc(this._info.projectSrcAfter, true);
   }
 
   private _onClickReset() {
-    this._setProjectSrc(this._info.projectSrcBefore, true);
+    this._solved = false;
+    this._setProjectSrc(this._info.projectSrcBefore);
   }
 
   private _onClickNextButton(event: Event) {
@@ -212,6 +225,7 @@ export class LitDevTutorial extends LitElement {
   }
 
   private _onClickPrevButton(event: Event) {
+    this._solved = false;
     event.preventDefault();
     if (this._idx > 0) {
       this._idx--;
@@ -268,6 +282,7 @@ export class LitDevTutorial extends LitElement {
 
   private async _loadStep() {
     this._loading = true;
+    this._solved = false;
     const active = this._info;
     this._html =
       this._preloadedHtml?.idx === this._idx

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -225,7 +225,6 @@ export class LitDevTutorial extends LitElement {
   }
 
   private _onClickPrevButton(event: Event) {
-    this._solved = false;
     event.preventDefault();
     if (this._idx > 0) {
       this._idx--;

--- a/packages/lit-dev-tools/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/plugin.ts
@@ -202,7 +202,7 @@ export const playgroundPlugin = (
    */
   eleventyConfig.addPairedShortcode('switchable-sample', (content: string) => {
     const match = content.match(
-      /^\s*\n\n```ts\n(.+)\n```\s+```js\n(.+)\n```\s*$/s
+      /^\s*\n\n\s*```ts\n(.+)\n\s*```\s+```js\n(.+)\n\s*```\s*$/s
     );
     if (match === null) {
       throw new Error(


### PR DESCRIPTION
Adds JS versions of code samples in the left-hand-side HTML content of the tutorial.

<img src="https://user-images.githubusercontent.com/48894/132719365-ee49788e-0ba0-47a7-ad97-8447f2e0e658.png" width="500px">

Note there is some associated *text* in some places (e.g. in the screenshot above) that are decorator-specific. I think we should update the text to be more neutral (either to let the switchable code speak for itself, or to explain the two possibilities). We could also have switches over *text* content, but I think neutral language is simpler and probably better.

Part of #332