### PR TITLE
Hand-roll the JS output for the 2nd tutorial step

### DIFF
--- a/packages/lit-dev-content/samples/tsconfig.json
+++ b/packages/lit-dev-content/samples/tsconfig.json
@@ -14,5 +14,9 @@
     "outDir": "js"
   },
   "include": ["./**/*.ts"],
-  "exclude": []
+  "exclude": [
+    // Intentionally contains unused imports. This one's .js output is
+    // hand-rolled becuase TypeScript will elide imports.
+    "tutorial/02-define/before/my-element.ts"
+  ]
 }

--- a/packages/lit-dev-content/samples/tutorial/02-define/before/my-element.js
+++ b/packages/lit-dev-content/samples/tutorial/02-define/before/my-element.js
@@ -1,0 +1,1 @@
+import {LitElement, html} from 'lit';

--- a/packages/lit-dev-content/samples/tutorial/02-define/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorial/02-define/before/my-element.ts
@@ -1,3 +1,2 @@
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
-

--- a/packages/lit-dev-tools-esm/src/typescript-util.ts
+++ b/packages/lit-dev-tools-esm/src/typescript-util.ts
@@ -5,7 +5,6 @@
  */
 
 import ts from 'typescript';
-import fs from 'fs';
 import pathlib from 'path';
 
 /**
@@ -33,8 +32,13 @@ export interface InvokeTypeScriptOpts {
  * without errors. Diagnostics are logged to stderr.
  */
 export const compileTypeScriptOnce = (opts: InvokeTypeScriptOpts): boolean => {
+  const rawConfig = ts.readConfigFile(opts.tsConfigPath, ts.sys.readFile);
+  if (rawConfig.error !== undefined) {
+    logDiagnostic(rawConfig.error);
+    return false;
+  }
   const config = ts.parseJsonConfigFileContent(
-    JSON.parse(fs.readFileSync(opts.tsConfigPath, 'utf8')),
+    rawConfig.config,
     ts.sys,
     pathlib.dirname(opts.tsConfigPath)
   );


### PR DESCRIPTION
This file intentionally contains unused imports, and we don't want TypeScript to remove them.

Part of #332