### PR TITLE
Add TOC link for page headers

### DIFF
--- a/packages/lit-dev-content/site/_includes/docs.html
+++ b/packages/lit-dev-content/site/_includes/docs.html
@@ -25,7 +25,7 @@
   <div id="rhsTocWrapper">
     {% if toc | tocHasEntries %}
       <nav id="rhsToc">
-        <h2>Contents</h2>
+        <h2><a href="#content">Contents: {{ title }}</a></h2>
         <div id="rhsTocInner">
           {{ toc | safe }}
         </div>

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -547,6 +547,10 @@ td {
   margin-top: 0;
 }
 
+#rhsToc > h2 > a {
+  color: inherit;
+}
+
 /* Scroller */
 #rhsTocInner {
   overflow-y: auto;


### PR DESCRIPTION
Fixes #459 

This lets users navigate to the top of the page with the TOC.

It's not perfect, as the current section indicator still tops out at the first `<h2>`, but it's better than before IMO.