### PR TITLE
Auto compute sample heights for JS and TS independently

### DIFF
--- a/packages/lit-dev-content/samples/docs/components/events/child/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/child/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "430px",
   "previewHeight": "100px"
 }

--- a/packages/lit-dev-content/samples/docs/components/events/comm/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/comm/project.json
@@ -5,6 +5,5 @@
     "my-listener.ts": {},
     "index.html": {}
   },
-  "editorHeight": "760px",
   "previewHeight": "180px"
 }

--- a/packages/lit-dev-content/samples/docs/components/events/delegation/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/delegation/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "560px",
   "previewHeight": "80px"
 }

--- a/packages/lit-dev-content/samples/docs/components/events/dispatch/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/dispatch/project.json
@@ -1,14 +1,8 @@
 {
+  "extends": "/samples/base.json",
   "files": {
     "my-dispatcher.ts": {},
     "my-listener.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "750px",
-  "importMap": {
-    "imports": {
-      "lit": "https://cdn.skypack.dev/lit",
-      "lit/": "https://cdn.skypack.dev/lit/"
-    }
-}
+  }
 }

--- a/packages/lit-dev-content/samples/docs/components/events/host/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/host/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "640px",
   "previewHeight": "120px"
 }

--- a/packages/lit-dev-content/samples/docs/components/events/list/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/list/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "650px",
   "previewHeight": "120px"
 }

--- a/packages/lit-dev-content/samples/docs/components/events/update/project.json
+++ b/packages/lit-dev-content/samples/docs/components/events/update/project.json
@@ -4,6 +4,5 @@
     "my-dispatcher.ts": {},
     "my-listener.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "610px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/components/overview/simple-greeting/project.json
+++ b/packages/lit-dev-content/samples/docs/components/overview/simple-greeting/project.json
@@ -4,6 +4,5 @@
     "simple-greeting.ts": {},
     "index.html": {}
   },
-  "editorHeight": "555px",
   "previewHeight": "80px"
 }

--- a/packages/lit-dev-content/samples/docs/components/shadowdom/namedslots/project.json
+++ b/packages/lit-dev-content/samples/docs/components/shadowdom/namedslots/project.json
@@ -1,13 +1,7 @@
 {
+  "extends": "/samples/base.json",
   "files": {
     "index.html": {},
     "my-element.ts": {}
-  },
-  "editorHeight": "440px",
-    "importMap": {
-    "imports": {
-      "lit": "https://cdn.skypack.dev/lit",
-      "lit/": "https://cdn.skypack.dev/lit/"
-    }
   }
 }

--- a/packages/lit-dev-content/samples/docs/components/shadowdom/slots/project.json
+++ b/packages/lit-dev-content/samples/docs/components/shadowdom/slots/project.json
@@ -1,14 +1,8 @@
 {
+  "extends": "/samples/base.json",
   "files": {
     "index.html": {},
     "my-element.ts": {}
   },
-  "editorHeight": "400px",
-  "previewHeight": "165px",
-    "importMap": {
-    "imports": {
-      "lit": "https://cdn.skypack.dev/lit",
-      "lit/": "https://cdn.skypack.dev/lit/"
-    }
-  }
+  "previewHeight": "165px"
 }

--- a/packages/lit-dev-content/samples/docs/components/style/basic/project.json
+++ b/packages/lit-dev-content/samples/docs/components/style/basic/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "390px",
   "previewHeight": "80px"
 }

--- a/packages/lit-dev-content/samples/docs/components/style/host/project.json
+++ b/packages/lit-dev-content/samples/docs/components/style/host/project.json
@@ -3,6 +3,5 @@
   "files": {
     "my-element.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "530px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/components/style/maps/project.json
+++ b/packages/lit-dev-content/samples/docs/components/style/maps/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "600px",
   "previewHeight": "80px"
 }

--- a/packages/lit-dev-content/samples/docs/components/style/slottedselector/project.json
+++ b/packages/lit-dev-content/samples/docs/components/style/slottedselector/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "460px",
   "previewHeight": "100px"
 }

--- a/packages/lit-dev-content/samples/docs/components/style/superstyles/project.json
+++ b/packages/lit-dev-content/samples/docs/components/style/superstyles/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "super-element.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "490px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/components/style/theming/project.json
+++ b/packages/lit-dev-content/samples/docs/components/style/theming/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "510px",
   "previewHeight": "100px"
 }

--- a/packages/lit-dev-content/samples/docs/controllers/mouse/project.json
+++ b/packages/lit-dev-content/samples/docs/controllers/mouse/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "mouse-controller.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "580px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/controllers/names/project.json
+++ b/packages/lit-dev-content/samples/docs/controllers/names/project.json
@@ -6,6 +6,5 @@
     "names-api.ts": {},
     "index.html": {}
   },
-  "editorHeight": "1060px",
   "previewHeight": "150px"
 }

--- a/packages/lit-dev-content/samples/docs/controllers/overview/project.json
+++ b/packages/lit-dev-content/samples/docs/controllers/overview/project.json
@@ -4,6 +4,5 @@
     "clock-controller.ts": {},
     "my-element.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "700px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/mixins/highlightable/project.json
+++ b/packages/lit-dev-content/samples/docs/mixins/highlightable/project.json
@@ -5,6 +5,5 @@
     "element-one.ts": {},
     "element-two.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "640px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/templates/compose/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/compose/project.json
@@ -4,6 +4,5 @@
     "my-page.ts": {},
     "index.html": {}
   },
-  "editorHeight": "785px",
   "previewHeight": "90px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/composeimports/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/composeimports/project.json
@@ -6,6 +6,5 @@
     "my-article.ts": {},
     "my-footer.ts": {},
     "index.html": {}
-  },
-  "editorHeight": "500px"
+  }
 }

--- a/packages/lit-dev-content/samples/docs/templates/design/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/design/project.json
@@ -4,6 +4,5 @@
     "update-properties.ts": {},
     "index.html": {}
   },
-  "editorHeight": "750px",
   "previewHeight": "80px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/expressions/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/expressions/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "300px",
   "previewHeight": "160px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/lists-arrays/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/lists-arrays/project.json
@@ -7,6 +7,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "195px",
   "previewHeight": "50px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/lists-map/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/lists-map/project.json
@@ -7,6 +7,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "340px",
   "previewHeight": "85px"
 }

--- a/packages/lit-dev-content/samples/docs/templates/lists-repeat/project.json
+++ b/packages/lit-dev-content/samples/docs/templates/lists-repeat/project.json
@@ -7,6 +7,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "370px",
   "previewHeight": "130px"
 }

--- a/packages/lit-dev-content/samples/docs/what-is-lit/project.json
+++ b/packages/lit-dev-content/samples/docs/what-is-lit/project.json
@@ -1,15 +1,9 @@
 {
-    "files": {
-        "my-timer.ts": {},
-        "index.html": {},
-        "icons.ts": {}
-    },
-    "editorHeight": "670px",
-    "previewHeight": "125px",
-      "importMap": {
-      "imports": {
-        "lit": "https://cdn.skypack.dev/lit",
-        "lit/": "https://cdn.skypack.dev/lit/"
-      }
-    }
-  }
+  "extends": "/samples/base.json",
+  "files": {
+    "my-timer.ts": {},
+    "index.html": {},
+    "icons.ts": {}
+  },
+  "previewHeight": "125px"
+}

--- a/packages/lit-dev-content/samples/properties/attributereflect/project.json
+++ b/packages/lit-dev-content/samples/properties/attributereflect/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "670px",
   "previewHeight": "70px"
 }

--- a/packages/lit-dev-content/samples/properties/haschanged/project.json
+++ b/packages/lit-dev-content/samples/properties/haschanged/project.json
@@ -4,6 +4,5 @@
     "my-element.ts": {},
     "index.html": {}
   },
-  "editorHeight": "675px",
   "previewHeight": "100px"
 }

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -126,9 +126,16 @@ litdev-example[filename] {
   --litdev-example-bar-height: 31px;
 }
 
+body[code-language-preference="ts"] litdev-example {
+  --litdev-example-editor-height: var(--litdev-example-editor-lines-ts) * 22px + 22px;
+}
+
+body[code-language-preference="js"] litdev-example {
+  --litdev-example-editor-height: var(--litdev-example-editor-lines-js) * 22px + 22px;
+}
+
 litdev-example {
-  /* Prevent layout shift before upgrade, since custom elements default to
-  inline. */
+  /* Prevent upgrade layout shift. */
   display: block;
   height: calc(
     var(--litdev-example-bar-height) +

--- a/packages/lit-dev-content/site/docs/internal/demos.md
+++ b/packages/lit-dev-content/site/docs/internal/demos.md
@@ -29,7 +29,6 @@ Arguments:
 2. Filename from project to show.
 
 Additional `project.json` config options:
-- `editorHeight`: Height of the editor in pixels (default `300px`).
 - `previewHeight`: Height of the preview in pixels (default `120px`).
 
 ```
@@ -59,21 +58,5 @@ configuration that resolve imports to `lit-next`:
 ```json
 {
   "extends": "/samples/base.json",
-}
-```
-
-Use `importMap.imports` in your `project.json` file to further control the
-resolution of bare module specifiers.
-
-```json
-{
-  "importMap": {
-    "imports": {
-      "lit-element": "https://cdn.skypack.dev/lit-element@next-major",
-      "lit-element/": "https://cdn.skypack.dev/lit-element@next-major/",
-      "lit-html": "https://cdn.skypack.dev/lit-html@next-major",
-      "lit-html/": "https://cdn.skypack.dev/lit-html@next-major/"
-    }
-  }
 }
 ```


### PR DESCRIPTION
Previously, interactive sample heights were hard-coded in the `project.json` files.

Now, they are computed automatically based on the number of lines in the first visible file. This is done independently for the TS and JS versions, so they will change height when the switch is toggled, just like the statically rendered samples already do.

Part of #332