### PR TITLE
Fixes for code sample fold regions

### DIFF
--- a/packages/lit-dev-content/samples/docs/what-is-lit/my-timer.ts
+++ b/packages/lit-dev-content/samples/docs/what-is-lit/my-timer.ts
@@ -1,6 +1,6 @@
 import {LitElement, html, css} from 'lit';
-/* playground-fold */
 import {customElement, property, state} from 'lit/decorators.js';
+/* playground-fold */
 import {play, pause, replay} from './icons.js';
 /* playground-fold-end */
 

--- a/packages/lit-dev-tools-esm/src/generate-js-samples.ts
+++ b/packages/lit-dev-tools-esm/src/generate-js-samples.ts
@@ -196,6 +196,7 @@ const tsCompileOpts: InvokeTypeScriptOpts = {
       parser: 'typescript',
       singleQuote: true,
       bracketSpacing: false,
+      embeddedLanguageFormatting: 'off',
     });
     return js;
   },

--- a/packages/lit-dev-tools/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools/src/playground-plugin/plugin.ts
@@ -63,6 +63,8 @@ const countVisibleLines = (filename: string, code: string): number => {
     if (kind === 'fold') {
       // In the fold case a clickable "..." is put in its place. For some
       // reason, these lines have slightly more height than a normal code line.
+      // TODO(aomarks) Ideally these would be the same height. Investigate in
+      // CodeMirror/Playground.
       count += 1.03;
     }
   }


### PR DESCRIPTION
- Fix broken folding range. In this example, the `/* playground-fold */` comment was associated with the decorators `import` statement. Since that import gets removed as part of our transform, the comment was getting removed too. The quick fix here is to just shift the comment down. This means the decorator import is now visible in TS mode, but that seems fine.

- Don't auto-format embedded HTML/CSS. By default, Prettier automatically formats HTML and CSS inside html and css backtick functions. This could be good with some tweaks, but right now it seems to just be worse, since we already took care to manually format our HTML and CSS.

- Improve visible line calculation. Previously we did not account for the fact that a folded region gets a clickable `...`, which is slightly taller than a normal code line.