### PR TITLE
Guard against losing changes when switching languages

### DIFF
--- a/packages/lit-dev-content/package-lock.json
+++ b/packages/lit-dev-content/package-lock.json
@@ -13,6 +13,7 @@
 				"@lit-labs/task": "^1.0.0-pre.4",
 				"@lit/localize": "^0.10.0",
 				"@material/mwc-button": "^0.22.1",
+				"@material/mwc-dialog": "^0.23.0",
 				"@material/mwc-drawer": "^0.22.1",
 				"@material/mwc-formfield": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",
@@ -424,6 +425,181 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"node_modules/@material/dialog": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-uwQZhqZqdm6asp0B1ntSO2nUYeJrCqKMJQHGfZW/WUjAXheRxBhDkXjGouyW50fwsn2Bes0sCtcsmPMfjwozpg==",
+			"dependencies": {
+				"@material/animation": "13.0.0-canary.864798678.0",
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/button": "13.0.0-canary.864798678.0",
+				"@material/dom": "13.0.0-canary.864798678.0",
+				"@material/elevation": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/icon-button": "13.0.0-canary.864798678.0",
+				"@material/ripple": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/shape": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"@material/tokens": "13.0.0-canary.864798678.0",
+				"@material/touch-target": "13.0.0-canary.864798678.0",
+				"@material/typography": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/animation": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-EHM9PQZViuhFWmIXQwQlPdThxdGkJGduMMMLc3k4EMP7cV4EHQAN+K7q2i5KsglfCnEKJcnICN6B+nl0kxEmNw==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/base": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-UB8x0e7Bv/1y82jrYJCLI0QywGEo6O9+6v1gFz5BDBe2ToD3x3Fhvq/CmisJjcLR5xnoopZb7/+pvF4P1LhXNA==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/button": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/button/-/button-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-vN7t6t/CIVop7GM0MvTNlh/a8SbS3eWaPRjmZRTR+m2FLeHU+YLslqOsC0Mz3R3O/cA0iMNW3uE4i7PBrSKM9g==",
+			"dependencies": {
+				"@material/density": "13.0.0-canary.864798678.0",
+				"@material/dom": "13.0.0-canary.864798678.0",
+				"@material/elevation": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/ripple": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/shape": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"@material/tokens": "13.0.0-canary.864798678.0",
+				"@material/touch-target": "13.0.0-canary.864798678.0",
+				"@material/typography": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/density": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/density/-/density-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-aoZA5649C7D2qE0hihAoF2x69Lug8OEJ4PLzcsvteSzlivtl/y/FtkoV3DXacYA6BFej6aN2Cz61H1JXp6Jv3A==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/dom": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/dom/-/dom-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-d2IX/WOtIiNPcW6zX4Wx6jHjxbjxt5k/d4Vv1vxTA0sShbPn/cYio8ZSClxAbbyd0PLBFbytjJ2JzdXJWcy2pg==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/elevation": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-tiimkeFxJjunBzCZvXZzzD9RwBU4KiA84u0s5Fuxj/SzC34vpZp7kcnZHI9RV4t6npGZYSX1tDzbdc1pDhFL6w==",
+			"dependencies": {
+				"@material/animation": "13.0.0-canary.864798678.0",
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/feature-targeting": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-MPgSK9DHhD6r+6Wfl31+estASVrmg7nNXtN7HkLUFJSn8Rk6kL+QPP3JFWm7/jsDLjf6kDKejdIEksDI/OCzgQ==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/icon-button": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-Nsls54mwGW8lHkFHqKoHBZVvjU2K/DY0GZAZFx9bPTGtZdUQqUeW/DfCyi0Capc2liKHC+jZutV5MDCffk4Unw==",
+			"dependencies": {
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/density": "13.0.0-canary.864798678.0",
+				"@material/elevation": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/ripple": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"@material/touch-target": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/ripple": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-gi8GrtvEoLsUxsVxVtxjA4nILz7stdYLIPa1aXuS/7z/oJXupJaVzladK/oZ+CQnlw649YZVfv3mtOPFRRCAQg==",
+			"dependencies": {
+				"@material/animation": "13.0.0-canary.864798678.0",
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/dom": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/rtl": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-AQKPcSYRkO/mVgv9Zl/O5eZB6hoFzx644KWaZ72F/noC1edUWkwG1PcgUD9I7tqhE5ThP2YPrvUMwU1a1M2s7g==",
+			"dependencies": {
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/shape": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/shape/-/shape-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-FEGLlRg4X77nsEIzPkMF0/dVwIev9dOzbHc2IkZCbKc9Ni34XFdzUkFN/gH6fQovLxKl7rth+EQ9pPJgQAf43A==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/theme": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-nlXj3IbvzE1nLqeUwC81qIgcLF5gi8WhHCXv6KfTMIdSjkvq2iPqdxBR0jGgz1STnOGQrfUIHIwMal9OzlhfKA==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/touch-target": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-jrbMG8poSDMrKhncF3Pf7Osd/gh49VErGrnyQk7dlp2xphFH4aoHGGu4I9b0RqiCdT6Ddcf53+HQ8RUDYimGrg==",
+			"dependencies": {
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/dialog/node_modules/@material/typography": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/typography/-/typography-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-GpRvG/HXcWIRjrv5alAKV2Amq68ta05mDovMuNqbm6bovhHjwIH+CwK8CKFtDDsmIgaAODp2Jxt1XsSi4hj6jg==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
 		"node_modules/@material/dom": {
 			"version": "12.0.0-canary.22d29cbb4.0",
 			"resolved": "https://registry.npmjs.org/@material/dom/-/dom-12.0.0-canary.22d29cbb4.0.tgz",
@@ -624,6 +800,132 @@
 				"lit-element": "^2.5.1",
 				"lit-html": "^1.4.1",
 				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-dialog": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.23.0.tgz",
+			"integrity": "sha512-r6fJH18UmtiJ0Ui0ktsxuG0vZv7qT+Fos9AiYraNFMzJlaOqB8LUknQN3AfGa/8ER0X0LuyC3XEtgJPTX87k4w==",
+			"dependencies": {
+				"@material/dialog": "=13.0.0-canary.864798678.0",
+				"@material/dom": "=13.0.0-canary.864798678.0",
+				"@material/mwc-base": "^0.23.0",
+				"@material/mwc-button": "^0.23.0",
+				"blocking-elements": "^0.1.0",
+				"lit-element": "^2.5.1",
+				"lit-html": "^1.4.1",
+				"tslib": "^2.0.1",
+				"wicg-inert": "^3.0.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/animation": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-EHM9PQZViuhFWmIXQwQlPdThxdGkJGduMMMLc3k4EMP7cV4EHQAN+K7q2i5KsglfCnEKJcnICN6B+nl0kxEmNw==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/base": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-UB8x0e7Bv/1y82jrYJCLI0QywGEo6O9+6v1gFz5BDBe2ToD3x3Fhvq/CmisJjcLR5xnoopZb7/+pvF4P1LhXNA==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/dom": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/dom/-/dom-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-d2IX/WOtIiNPcW6zX4Wx6jHjxbjxt5k/d4Vv1vxTA0sShbPn/cYio8ZSClxAbbyd0PLBFbytjJ2JzdXJWcy2pg==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/feature-targeting": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-MPgSK9DHhD6r+6Wfl31+estASVrmg7nNXtN7HkLUFJSn8Rk6kL+QPP3JFWm7/jsDLjf6kDKejdIEksDI/OCzgQ==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/mwc-base": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.23.0.tgz",
+			"integrity": "sha512-hBMUu8ljw3vxa87mkoImLaRmp5DyNT0o7fTxLqmE/ajwrj9l7rCrzU1+mt+yZMPcEekFLBg2X1FdkK4vioAWaQ==",
+			"dependencies": {
+				"@material/base": "=13.0.0-canary.864798678.0",
+				"@material/dom": "=13.0.0-canary.864798678.0",
+				"lit-element": "^2.5.1",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/mwc-button": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.23.0.tgz",
+			"integrity": "sha512-wNuSzHO1rT/NkVLqPj78ydgIK5OHDaCNVgzTtq85ozqebjwVHfSJ/1IVaqQsj6jpbJwGe3+Ap3QIF97X5wC0xQ==",
+			"dependencies": {
+				"@material/mwc-icon": "^0.23.0",
+				"@material/mwc-ripple": "^0.23.0",
+				"lit-element": "^2.5.1",
+				"lit-html": "^1.4.1",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/mwc-icon": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.23.0.tgz",
+			"integrity": "sha512-rb0m5M4KHi8+itaepPFOnS3RDxX+6NtrW5KHsbY/b5+LALzjC1gcXSpf5o79D28dYW/2ddyfQDdR2ssjKDoAgQ==",
+			"dependencies": {
+				"lit-element": "^2.5.1",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/mwc-ripple": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.23.0.tgz",
+			"integrity": "sha512-6S+9/Zstb/N5zh4DbTj4gs1+xZ9vPed1HE/59GA9sZ19pJPMgh4jPapRI+q3Uwl6o0qAKL6cZ9nqoKdMo+BTNw==",
+			"dependencies": {
+				"@material/dom": "=13.0.0-canary.864798678.0",
+				"@material/mwc-base": "^0.23.0",
+				"@material/ripple": "=13.0.0-canary.864798678.0",
+				"lit-element": "^2.5.1",
+				"lit-html": "^1.4.1",
+				"tslib": "^2.0.1"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/ripple": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-gi8GrtvEoLsUxsVxVtxjA4nILz7stdYLIPa1aXuS/7z/oJXupJaVzladK/oZ+CQnlw649YZVfv3mtOPFRRCAQg==",
+			"dependencies": {
+				"@material/animation": "13.0.0-canary.864798678.0",
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/dom": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/rtl": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-AQKPcSYRkO/mVgv9Zl/O5eZB6hoFzx644KWaZ72F/noC1edUWkwG1PcgUD9I7tqhE5ThP2YPrvUMwU1a1M2s7g==",
+			"dependencies": {
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/mwc-dialog/node_modules/@material/theme": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-nlXj3IbvzE1nLqeUwC81qIgcLF5gi8WhHCXv6KfTMIdSjkvq2iPqdxBR0jGgz1STnOGQrfUIHIwMal9OzlhfKA==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/@material/mwc-drawer": {
@@ -965,6 +1267,69 @@
 			"integrity": "sha512-r4xYCgc+CrbvDxCINVqXwAFWQ1WgV3s2+bUse/2iw53YqyemhhtzFjfp+DXLdC4zJSOuObWC45eaDKeseLMGMw==",
 			"dependencies": {
 				"@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-Z7GedA80jsQGATucTXg1MZ4D8qLlj5v4BlDhm7q36R2stCqaoELueudlxoi6n2jBpgsIzhxc/sCaak9USF8B9w==",
+			"dependencies": {
+				"@material/elevation": "13.0.0-canary.864798678.0"
+			}
+		},
+		"node_modules/@material/tokens/node_modules/@material/animation": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-EHM9PQZViuhFWmIXQwQlPdThxdGkJGduMMMLc3k4EMP7cV4EHQAN+K7q2i5KsglfCnEKJcnICN6B+nl0kxEmNw==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens/node_modules/@material/base": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-UB8x0e7Bv/1y82jrYJCLI0QywGEo6O9+6v1gFz5BDBe2ToD3x3Fhvq/CmisJjcLR5xnoopZb7/+pvF4P1LhXNA==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens/node_modules/@material/elevation": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-tiimkeFxJjunBzCZvXZzzD9RwBU4KiA84u0s5Fuxj/SzC34vpZp7kcnZHI9RV4t6npGZYSX1tDzbdc1pDhFL6w==",
+			"dependencies": {
+				"@material/animation": "13.0.0-canary.864798678.0",
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens/node_modules/@material/feature-targeting": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-MPgSK9DHhD6r+6Wfl31+estASVrmg7nNXtN7HkLUFJSn8Rk6kL+QPP3JFWm7/jsDLjf6kDKejdIEksDI/OCzgQ==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens/node_modules/@material/rtl": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-AQKPcSYRkO/mVgv9Zl/O5eZB6hoFzx644KWaZ72F/noC1edUWkwG1PcgUD9I7tqhE5ThP2YPrvUMwU1a1M2s7g==",
+			"dependencies": {
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@material/tokens/node_modules/@material/theme": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-nlXj3IbvzE1nLqeUwC81qIgcLF5gi8WhHCXv6KfTMIdSjkvq2iPqdxBR0jGgz1STnOGQrfUIHIwMal9OzlhfKA==",
+			"dependencies": {
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
 				"tslib": "^2.1.0"
 			}
 		},
@@ -8698,6 +9063,183 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"@material/dialog": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-uwQZhqZqdm6asp0B1ntSO2nUYeJrCqKMJQHGfZW/WUjAXheRxBhDkXjGouyW50fwsn2Bes0sCtcsmPMfjwozpg==",
+			"requires": {
+				"@material/animation": "13.0.0-canary.864798678.0",
+				"@material/base": "13.0.0-canary.864798678.0",
+				"@material/button": "13.0.0-canary.864798678.0",
+				"@material/dom": "13.0.0-canary.864798678.0",
+				"@material/elevation": "13.0.0-canary.864798678.0",
+				"@material/feature-targeting": "13.0.0-canary.864798678.0",
+				"@material/icon-button": "13.0.0-canary.864798678.0",
+				"@material/ripple": "13.0.0-canary.864798678.0",
+				"@material/rtl": "13.0.0-canary.864798678.0",
+				"@material/shape": "13.0.0-canary.864798678.0",
+				"@material/theme": "13.0.0-canary.864798678.0",
+				"@material/tokens": "13.0.0-canary.864798678.0",
+				"@material/touch-target": "13.0.0-canary.864798678.0",
+				"@material/typography": "13.0.0-canary.864798678.0",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"@material/animation": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-EHM9PQZViuhFWmIXQwQlPdThxdGkJGduMMMLc3k4EMP7cV4EHQAN+K7q2i5KsglfCnEKJcnICN6B+nl0kxEmNw==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/base": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-UB8x0e7Bv/1y82jrYJCLI0QywGEo6O9+6v1gFz5BDBe2ToD3x3Fhvq/CmisJjcLR5xnoopZb7/+pvF4P1LhXNA==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/button": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/button/-/button-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-vN7t6t/CIVop7GM0MvTNlh/a8SbS3eWaPRjmZRTR+m2FLeHU+YLslqOsC0Mz3R3O/cA0iMNW3uE4i7PBrSKM9g==",
+					"requires": {
+						"@material/density": "13.0.0-canary.864798678.0",
+						"@material/dom": "13.0.0-canary.864798678.0",
+						"@material/elevation": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/ripple": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/shape": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"@material/tokens": "13.0.0-canary.864798678.0",
+						"@material/touch-target": "13.0.0-canary.864798678.0",
+						"@material/typography": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/density": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/density/-/density-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-aoZA5649C7D2qE0hihAoF2x69Lug8OEJ4PLzcsvteSzlivtl/y/FtkoV3DXacYA6BFej6aN2Cz61H1JXp6Jv3A==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/dom": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/dom/-/dom-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-d2IX/WOtIiNPcW6zX4Wx6jHjxbjxt5k/d4Vv1vxTA0sShbPn/cYio8ZSClxAbbyd0PLBFbytjJ2JzdXJWcy2pg==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/elevation": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-tiimkeFxJjunBzCZvXZzzD9RwBU4KiA84u0s5Fuxj/SzC34vpZp7kcnZHI9RV4t6npGZYSX1tDzbdc1pDhFL6w==",
+					"requires": {
+						"@material/animation": "13.0.0-canary.864798678.0",
+						"@material/base": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/feature-targeting": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-MPgSK9DHhD6r+6Wfl31+estASVrmg7nNXtN7HkLUFJSn8Rk6kL+QPP3JFWm7/jsDLjf6kDKejdIEksDI/OCzgQ==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/icon-button": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-Nsls54mwGW8lHkFHqKoHBZVvjU2K/DY0GZAZFx9bPTGtZdUQqUeW/DfCyi0Capc2liKHC+jZutV5MDCffk4Unw==",
+					"requires": {
+						"@material/base": "13.0.0-canary.864798678.0",
+						"@material/density": "13.0.0-canary.864798678.0",
+						"@material/elevation": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/ripple": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"@material/touch-target": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/ripple": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-gi8GrtvEoLsUxsVxVtxjA4nILz7stdYLIPa1aXuS/7z/oJXupJaVzladK/oZ+CQnlw649YZVfv3mtOPFRRCAQg==",
+					"requires": {
+						"@material/animation": "13.0.0-canary.864798678.0",
+						"@material/base": "13.0.0-canary.864798678.0",
+						"@material/dom": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/rtl": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-AQKPcSYRkO/mVgv9Zl/O5eZB6hoFzx644KWaZ72F/noC1edUWkwG1PcgUD9I7tqhE5ThP2YPrvUMwU1a1M2s7g==",
+					"requires": {
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/shape": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/shape/-/shape-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-FEGLlRg4X77nsEIzPkMF0/dVwIev9dOzbHc2IkZCbKc9Ni34XFdzUkFN/gH6fQovLxKl7rth+EQ9pPJgQAf43A==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/theme": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-nlXj3IbvzE1nLqeUwC81qIgcLF5gi8WhHCXv6KfTMIdSjkvq2iPqdxBR0jGgz1STnOGQrfUIHIwMal9OzlhfKA==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/touch-target": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-jrbMG8poSDMrKhncF3Pf7Osd/gh49VErGrnyQk7dlp2xphFH4aoHGGu4I9b0RqiCdT6Ddcf53+HQ8RUDYimGrg==",
+					"requires": {
+						"@material/base": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/typography": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/typography/-/typography-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-GpRvG/HXcWIRjrv5alAKV2Amq68ta05mDovMuNqbm6bovhHjwIH+CwK8CKFtDDsmIgaAODp2Jxt1XsSi4hj6jg==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				}
+			}
+		},
 		"@material/dom": {
 			"version": "12.0.0-canary.22d29cbb4.0",
 			"resolved": "https://registry.npmjs.org/@material/dom/-/dom-12.0.0-canary.22d29cbb4.0.tgz",
@@ -8898,6 +9440,134 @@
 				"lit-element": "^2.5.1",
 				"lit-html": "^1.4.1",
 				"tslib": "^2.0.1"
+			}
+		},
+		"@material/mwc-dialog": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.23.0.tgz",
+			"integrity": "sha512-r6fJH18UmtiJ0Ui0ktsxuG0vZv7qT+Fos9AiYraNFMzJlaOqB8LUknQN3AfGa/8ER0X0LuyC3XEtgJPTX87k4w==",
+			"requires": {
+				"@material/dialog": "=13.0.0-canary.864798678.0",
+				"@material/dom": "=13.0.0-canary.864798678.0",
+				"@material/mwc-base": "^0.23.0",
+				"@material/mwc-button": "^0.23.0",
+				"blocking-elements": "^0.1.0",
+				"lit-element": "^2.5.1",
+				"lit-html": "^1.4.1",
+				"tslib": "^2.0.1",
+				"wicg-inert": "^3.0.0"
+			},
+			"dependencies": {
+				"@material/animation": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-EHM9PQZViuhFWmIXQwQlPdThxdGkJGduMMMLc3k4EMP7cV4EHQAN+K7q2i5KsglfCnEKJcnICN6B+nl0kxEmNw==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/base": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-UB8x0e7Bv/1y82jrYJCLI0QywGEo6O9+6v1gFz5BDBe2ToD3x3Fhvq/CmisJjcLR5xnoopZb7/+pvF4P1LhXNA==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/dom": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/dom/-/dom-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-d2IX/WOtIiNPcW6zX4Wx6jHjxbjxt5k/d4Vv1vxTA0sShbPn/cYio8ZSClxAbbyd0PLBFbytjJ2JzdXJWcy2pg==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/feature-targeting": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-MPgSK9DHhD6r+6Wfl31+estASVrmg7nNXtN7HkLUFJSn8Rk6kL+QPP3JFWm7/jsDLjf6kDKejdIEksDI/OCzgQ==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/mwc-base": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.23.0.tgz",
+					"integrity": "sha512-hBMUu8ljw3vxa87mkoImLaRmp5DyNT0o7fTxLqmE/ajwrj9l7rCrzU1+mt+yZMPcEekFLBg2X1FdkK4vioAWaQ==",
+					"requires": {
+						"@material/base": "=13.0.0-canary.864798678.0",
+						"@material/dom": "=13.0.0-canary.864798678.0",
+						"lit-element": "^2.5.1",
+						"tslib": "^2.0.1"
+					}
+				},
+				"@material/mwc-button": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.23.0.tgz",
+					"integrity": "sha512-wNuSzHO1rT/NkVLqPj78ydgIK5OHDaCNVgzTtq85ozqebjwVHfSJ/1IVaqQsj6jpbJwGe3+Ap3QIF97X5wC0xQ==",
+					"requires": {
+						"@material/mwc-icon": "^0.23.0",
+						"@material/mwc-ripple": "^0.23.0",
+						"lit-element": "^2.5.1",
+						"lit-html": "^1.4.1",
+						"tslib": "^2.0.1"
+					}
+				},
+				"@material/mwc-icon": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.23.0.tgz",
+					"integrity": "sha512-rb0m5M4KHi8+itaepPFOnS3RDxX+6NtrW5KHsbY/b5+LALzjC1gcXSpf5o79D28dYW/2ddyfQDdR2ssjKDoAgQ==",
+					"requires": {
+						"lit-element": "^2.5.1",
+						"tslib": "^2.0.1"
+					}
+				},
+				"@material/mwc-ripple": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.23.0.tgz",
+					"integrity": "sha512-6S+9/Zstb/N5zh4DbTj4gs1+xZ9vPed1HE/59GA9sZ19pJPMgh4jPapRI+q3Uwl6o0qAKL6cZ9nqoKdMo+BTNw==",
+					"requires": {
+						"@material/dom": "=13.0.0-canary.864798678.0",
+						"@material/mwc-base": "^0.23.0",
+						"@material/ripple": "=13.0.0-canary.864798678.0",
+						"lit-element": "^2.5.1",
+						"lit-html": "^1.4.1",
+						"tslib": "^2.0.1"
+					}
+				},
+				"@material/ripple": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-gi8GrtvEoLsUxsVxVtxjA4nILz7stdYLIPa1aXuS/7z/oJXupJaVzladK/oZ+CQnlw649YZVfv3mtOPFRRCAQg==",
+					"requires": {
+						"@material/animation": "13.0.0-canary.864798678.0",
+						"@material/base": "13.0.0-canary.864798678.0",
+						"@material/dom": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/rtl": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-AQKPcSYRkO/mVgv9Zl/O5eZB6hoFzx644KWaZ72F/noC1edUWkwG1PcgUD9I7tqhE5ThP2YPrvUMwU1a1M2s7g==",
+					"requires": {
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/theme": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-nlXj3IbvzE1nLqeUwC81qIgcLF5gi8WhHCXv6KfTMIdSjkvq2iPqdxBR0jGgz1STnOGQrfUIHIwMal9OzlhfKA==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				}
 			}
 		},
 		"@material/mwc-drawer": {
@@ -9240,6 +9910,71 @@
 			"requires": {
 				"@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
 				"tslib": "^2.1.0"
+			}
+		},
+		"@material/tokens": {
+			"version": "13.0.0-canary.864798678.0",
+			"resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-13.0.0-canary.864798678.0.tgz",
+			"integrity": "sha512-Z7GedA80jsQGATucTXg1MZ4D8qLlj5v4BlDhm7q36R2stCqaoELueudlxoi6n2jBpgsIzhxc/sCaak9USF8B9w==",
+			"requires": {
+				"@material/elevation": "13.0.0-canary.864798678.0"
+			},
+			"dependencies": {
+				"@material/animation": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-EHM9PQZViuhFWmIXQwQlPdThxdGkJGduMMMLc3k4EMP7cV4EHQAN+K7q2i5KsglfCnEKJcnICN6B+nl0kxEmNw==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/base": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-UB8x0e7Bv/1y82jrYJCLI0QywGEo6O9+6v1gFz5BDBe2ToD3x3Fhvq/CmisJjcLR5xnoopZb7/+pvF4P1LhXNA==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/elevation": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-tiimkeFxJjunBzCZvXZzzD9RwBU4KiA84u0s5Fuxj/SzC34vpZp7kcnZHI9RV4t6npGZYSX1tDzbdc1pDhFL6w==",
+					"requires": {
+						"@material/animation": "13.0.0-canary.864798678.0",
+						"@material/base": "13.0.0-canary.864798678.0",
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"@material/rtl": "13.0.0-canary.864798678.0",
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/feature-targeting": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-MPgSK9DHhD6r+6Wfl31+estASVrmg7nNXtN7HkLUFJSn8Rk6kL+QPP3JFWm7/jsDLjf6kDKejdIEksDI/OCzgQ==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/rtl": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-AQKPcSYRkO/mVgv9Zl/O5eZB6hoFzx644KWaZ72F/noC1edUWkwG1PcgUD9I7tqhE5ThP2YPrvUMwU1a1M2s7g==",
+					"requires": {
+						"@material/theme": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@material/theme": {
+					"version": "13.0.0-canary.864798678.0",
+					"resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0-canary.864798678.0.tgz",
+					"integrity": "sha512-nlXj3IbvzE1nLqeUwC81qIgcLF5gi8WhHCXv6KfTMIdSjkvq2iPqdxBR0jGgz1STnOGQrfUIHIwMal9OzlhfKA==",
+					"requires": {
+						"@material/feature-targeting": "13.0.0-canary.864798678.0",
+						"tslib": "^2.1.0"
+					}
+				}
 			}
 		},
 		"@material/touch-target": {

--- a/packages/lit-dev-content/package-lock.json
+++ b/packages/lit-dev-content/package-lock.json
@@ -24,7 +24,7 @@
 				"lit-element": "^2.3.1",
 				"lit-html": "^1.2.1",
 				"minisearch": "^3.0.4",
-				"playground-elements": "^0.12.1",
+				"playground-elements": "^0.13.0",
 				"tarts": "^1.0.0",
 				"tslib": "^2.2.0"
 			},
@@ -6508,9 +6508,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.12.1.tgz",
-			"integrity": "sha512-YatLXTcJOqQQZOIBAdg12aD0MWJL3O//aAuAkMvCrh4d7HhwZgxfESxamyOpJWYjX13WD0KzwiibQIyZiztaGA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.13.0.tgz",
+			"integrity": "sha512-JkzUOUy/7BcJfz0cwxTDx2Ou71bVexvouOp3bzVtIdtXGSY0tdJXOeg2iANgFJo+txmrClzU7wygwn3nm7dp+w==",
 			"dependencies": {
 				"@material/mwc-button": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",
@@ -14124,9 +14124,9 @@
 			}
 		},
 		"playground-elements": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.12.1.tgz",
-			"integrity": "sha512-YatLXTcJOqQQZOIBAdg12aD0MWJL3O//aAuAkMvCrh4d7HhwZgxfESxamyOpJWYjX13WD0KzwiibQIyZiztaGA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.13.0.tgz",
+			"integrity": "sha512-JkzUOUy/7BcJfz0cwxTDx2Ou71bVexvouOp3bzVtIdtXGSY0tdJXOeg2iANgFJo+txmrClzU7wygwn3nm7dp+w==",
 			"requires": {
 				"@material/mwc-button": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -61,7 +61,7 @@
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "minisearch": "^3.0.4",
-    "playground-elements": "^0.12.1",
+    "playground-elements": "^0.13.0",
     "tarts": "^1.0.0",
     "tslib": "^2.2.0"
   }

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -50,6 +50,7 @@
     "@lit-labs/task": "^1.0.0-pre.4",
     "@lit/localize": "^0.10.0",
     "@material/mwc-button": "^0.22.1",
+    "@material/mwc-dialog": "^0.23.0",
     "@material/mwc-drawer": "^0.22.1",
     "@material/mwc-formfield": "^0.22.1",
     "@material/mwc-icon-button": "^0.22.1",

--- a/packages/lit-dev-content/site/playground.html
+++ b/packages/lit-dev-content/site/playground.html
@@ -85,6 +85,10 @@ title: Playground
         </playground-tab-bar>
 
         <litdev-example-controls></litdev-example-controls>
+
+        <litdev-playground-change-guard
+          project="project">
+        </litdev-playground-change-guard>
       </div>
 
       <playground-file-editor

--- a/packages/lit-dev-content/site/tutorial/index.html
+++ b/packages/lit-dev-content/site/tutorial/index.html
@@ -40,6 +40,10 @@ title: Tutorial
     </playground-tab-bar>
 
     <litdev-example-controls></litdev-example-controls>
+
+    <litdev-playground-change-guard
+      project="tutorialProject">
+    </litdev-playground-change-guard>
   </div>
 
   <playground-file-editor

--- a/packages/lit-dev-content/src/code-language-preference.ts
+++ b/packages/lit-dev-content/src/code-language-preference.ts
@@ -52,8 +52,15 @@ export const getCodeLanguagePreference = (): CodeLanguagePreference =>
   'ts';
 
 /**
- * Save the user's TypeScript vs JavaScript preference to localStorage, and fire
- * a change event on window.
+ * Save the user's TypeScript vs JavaScript preference.
+ *
+ * Unless `force` is true, a "before-code-language-change" event is first fired
+ * on window, which gives playgrounds an opportunity to cancel the preference
+ * change in case they have unsaved changes.
+ *
+ * If no handlers cancel the change, or if `force` is true, then the preference
+ * is written to local storage, a "code-language-change" event is fired on
+ * window, and an HTML attribute is written to the body.
  */
 export const setCodeLanguagePreference = (
   preference: CodeLanguagePreference,

--- a/packages/lit-dev-content/src/components/litdev-code-language-switch.ts
+++ b/packages/lit-dev-content/src/components/litdev-code-language-switch.ts
@@ -8,7 +8,7 @@ import {LitElement, html, css, customElement} from 'lit-element';
 import {
   getCodeLanguagePreference,
   setCodeLanguagePreference,
-  CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+  CODE_LANGUAGE_CHANGE,
 } from '../code-language-preference.js';
 
 /**
@@ -107,7 +107,7 @@ export class LitDevCodeLanguageSwitch extends LitElement {
     // components could be refactored into a controller.
     super.connectedCallback();
     window.addEventListener(
-      CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+      CODE_LANGUAGE_CHANGE,
       this._onCodeLanguagePreferenceChanged
     );
   }
@@ -115,7 +115,7 @@ export class LitDevCodeLanguageSwitch extends LitElement {
   override disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener(
-      CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+      CODE_LANGUAGE_CHANGE,
       this._onCodeLanguagePreferenceChanged
     );
   }

--- a/packages/lit-dev-content/src/components/litdev-example.ts
+++ b/packages/lit-dev-content/src/components/litdev-example.ts
@@ -10,7 +10,7 @@ import {nothing} from 'lit-html';
 import {ifDefined} from 'lit-html/directives/if-defined.js';
 import {
   getCodeLanguagePreference,
-  CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+  CODE_LANGUAGE_CHANGE,
 } from '../code-language-preference.js';
 import 'playground-elements/playground-ide.js';
 import './litdev-example-controls.js';
@@ -126,7 +126,7 @@ export class LitDevExample extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     window.addEventListener(
-      CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+      CODE_LANGUAGE_CHANGE,
       this._onCodeLanguagePreferenceChanged
     );
   }
@@ -134,7 +134,7 @@ export class LitDevExample extends LitElement {
   override disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener(
-      CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+      CODE_LANGUAGE_CHANGE,
       this._onCodeLanguagePreferenceChanged
     );
   }

--- a/packages/lit-dev-content/src/components/litdev-playground-change-guard.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-change-guard.ts
@@ -19,7 +19,7 @@ import type {CodeLanguagePreference} from '../code-language-preference.js';
 
 /**
  * Prompts the user to continue or cancel if the global code language preference
- * is about to change if the associated Playground has been modified.
+ * is about to change and the associated Playground has been modified.
  */
 @customElement('litdev-playground-change-guard')
 export class LitDevPlaygroundChangeGuard extends PlaygroundConnectedElement {

--- a/packages/lit-dev-content/src/components/litdev-playground-change-guard.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-change-guard.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@material/mwc-dialog';
+import '@material/mwc-button';
+
+import {html, css, customElement, internalProperty} from 'lit-element';
+import {nothing} from 'lit-html';
+import {PlaygroundConnectedElement} from 'playground-elements/playground-connected-element.js';
+import {
+  BEFORE_CODE_LANGUAGE_CHANGE,
+  setCodeLanguagePreference,
+} from '../code-language-preference.js';
+
+import type {CodeLanguagePreference} from '../code-language-preference.js';
+
+/**
+ * Prompts the user to continue or cancel if the global code language preference
+ * is about to change if the associated Playground has been modified.
+ */
+@customElement('litdev-playground-change-guard')
+export class LitDevPlaygroundChangeGuard extends PlaygroundConnectedElement {
+  static styles = css`
+    :host {
+      --mdc-theme-primary: var(--color-blue);
+    }
+    p {
+      /* The built-in mwc-dialog styles have a lot of padding above the action
+         buttons which looks a bit odd here. This is a hacky way to reduce it,
+         since mwc-dialog doesn't allow any padding adjustments. */
+      margin-bottom: -10px;
+    }
+  `;
+
+  override render() {
+    if (!this._pendingLanguage) {
+      return nothing;
+    }
+    return html`
+      <mwc-dialog
+        heading="Changes will be lost"
+        open
+        @closed=${this._onDialogClosed}
+      >
+        <p>
+          The changes you made will be lost if you switch languages. Are you
+          sure you want to continue?
+        </p>
+        <mwc-button slot="primaryAction" dialogAction="cancel">
+          Cancel
+        </mwc-button>
+        <mwc-button slot="secondaryAction" dialogAction="continue">
+          Switch
+        </mwc-button>
+      </mwc-dialog>
+    `;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener(
+      BEFORE_CODE_LANGUAGE_CHANGE,
+      this._onBeforeCodeLanguageChange
+    );
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener(
+      BEFORE_CODE_LANGUAGE_CHANGE,
+      this._onBeforeCodeLanguageChange
+    );
+  }
+
+  @internalProperty()
+  private _pendingLanguage: CodeLanguagePreference | undefined = undefined;
+
+  private _onBeforeCodeLanguageChange = (
+    event: WindowEventMap[typeof BEFORE_CODE_LANGUAGE_CHANGE]
+  ) => {
+    if (this._project?.modified) {
+      event.detail.cancel();
+      this._pendingLanguage = event.detail.pendingLanguage;
+    }
+  };
+
+  private _onDialogClosed(
+    event: CustomEvent<{action: 'cancel' | 'continue' | 'close'}>
+  ) {
+    if (
+      event.detail.action === 'continue' &&
+      this._pendingLanguage !== undefined
+    ) {
+      setCodeLanguagePreference(this._pendingLanguage, /* force */ true);
+    }
+    this._pendingLanguage = undefined;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'litdev-playground-change-guard': LitDevPlaygroundChangeGuard;
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -11,10 +11,11 @@ import {manifest, TutorialStep} from './litdev-tutorial-manifest.js';
 import {addModsParameterToUrlIfNeeded} from '../mods.js';
 import {
   getCodeLanguagePreference,
-  CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+  CODE_LANGUAGE_CHANGE,
 } from '../code-language-preference.js';
 import '@material/mwc-icon-button';
 import './litdev-example-controls.js';
+import './litdev-playground-change-guard.js';
 
 interface ExpandedTutorialStep extends TutorialStep {
   idx: number;
@@ -175,7 +176,7 @@ export class LitDevTutorial extends LitElement {
     this._readUrl();
     window.addEventListener('hashchange', this._readUrl);
     window.addEventListener(
-      CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+      CODE_LANGUAGE_CHANGE,
       this._onCodeLanguagePreferenceChanged
     );
   }
@@ -184,7 +185,7 @@ export class LitDevTutorial extends LitElement {
     super.disconnectedCallback();
     window.removeEventListener('hashchange', this._readUrl);
     window.removeEventListener(
-      CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+      CODE_LANGUAGE_CHANGE,
       this._onCodeLanguagePreferenceChanged
     );
   }

--- a/packages/lit-dev-content/src/pages/playground.ts
+++ b/packages/lit-dev-content/src/pages/playground.ts
@@ -8,9 +8,10 @@ import '@material/mwc-button';
 import '@material/mwc-snackbar';
 import 'playground-elements/playground-ide.js';
 import '../components/litdev-example-controls.js';
+import '../components/litdev-playground-change-guard.js';
 import {
   getCodeLanguagePreference,
-  CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
+  CODE_LANGUAGE_CHANGE,
 } from '../code-language-preference.js';
 
 import Tar from 'tarts';
@@ -172,10 +173,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   syncStateFromUrlHash();
   window.addEventListener('hashchange', syncStateFromUrlHash);
-  window.addEventListener(
-    CODE_LANGUAGE_PREFERENCE_EVENT_NAME,
-    syncStateFromUrlHash
-  );
+  window.addEventListener(CODE_LANGUAGE_CHANGE, syncStateFromUrlHash);
 
   // Trigger URL sharing when Control-s or Command-s is pressed.
   let controlDown = false;

--- a/packages/lit-dev-tools-esm/package-lock.json
+++ b/packages/lit-dev-tools-esm/package-lock.json
@@ -9,13 +9,23 @@
 			"version": "0.0.0",
 			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@lit/ts-transformers": "^1.0.0",
 				"@types/ansi-escape-sequences": "^4.0.0",
 				"@types/prettier": "^2.3.2",
 				"ansi-escape-sequences": "^6.2.0",
 				"chokidar": "^3.5.2",
 				"node-fetch": "^3.0.0",
-				"playground-elements": "^0.12.1",
+				"playground-elements": "^0.13.0",
 				"prettier": "^2.3.2"
+			}
+		},
+		"node_modules/@lit/ts-transformers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@lit/ts-transformers/-/ts-transformers-1.0.1.tgz",
+			"integrity": "sha512-y1sPz1UVedvPKScLSeIiomoWKB3EmiC7zuBLCVMzM+4FL9U7GGT8TNvbsLhI5/TTPG68okXxV0O6SVqE0HDtsg==",
+			"dependencies": {
+				"ts-clone-node": "^0.3.23",
+				"typescript": "^4.3.5"
 			}
 		},
 		"node_modules/@material/animation": {
@@ -564,6 +574,20 @@
 			"resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
 			"integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA=="
 		},
+		"node_modules/compatfactory": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/compatfactory/-/compatfactory-0.0.9.tgz",
+			"integrity": "sha512-WzoRZSBtsC5TT2J+MZNlo4Qpssf7ofSaRJUT3hN8nNeGilKOnTjR707k+hUU7QhVbyg3cmfWJlabTfMZgZtvEA==",
+			"dependencies": {
+				"helpertypes": "^0.0.4"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=3.x || >= 4.x"
+			}
+		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
@@ -626,6 +650,14 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/helpertypes": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/helpertypes/-/helpertypes-0.0.4.tgz",
+			"integrity": "sha512-q8f29R4Rdw9n5L4vGmUR8Ld6CXbxPxA7Xrcs4vto3K6w0LSF13TnWSm67uDrZRulf3t/ZHKCfeZ0qIletxSEow==",
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/is-binary-path": {
@@ -715,9 +747,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.12.1.tgz",
-			"integrity": "sha512-YatLXTcJOqQQZOIBAdg12aD0MWJL3O//aAuAkMvCrh4d7HhwZgxfESxamyOpJWYjX13WD0KzwiibQIyZiztaGA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.13.0.tgz",
+			"integrity": "sha512-JkzUOUy/7BcJfz0cwxTDx2Ou71bVexvouOp3bzVtIdtXGSY0tdJXOeg2iANgFJo+txmrClzU7wygwn3nm7dp+w==",
 			"dependencies": {
 				"@material/mwc-button": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",
@@ -766,10 +798,40 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/ts-clone-node": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/ts-clone-node/-/ts-clone-node-0.3.25.tgz",
+			"integrity": "sha512-rqwcmTt3ZP8fGm2OCG9d++gKHVM/TlStKfBpw9Acbn7AWi/Rd6GMGyetEJP+Upq7y4DjRpQ9Iy7hSjSJYdi76g==",
+			"dependencies": {
+				"compatfactory": "^0.0.9"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/wessberg/ts-clone-node?sponsor=1"
+			},
+			"peerDependencies": {
+				"typescript": "^3.x || ^4.x"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
+		"node_modules/typescript": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
 		"node_modules/vscode-jsonrpc": {
 			"version": "6.0.0",
@@ -814,6 +876,15 @@
 		}
 	},
 	"dependencies": {
+		"@lit/ts-transformers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@lit/ts-transformers/-/ts-transformers-1.0.1.tgz",
+			"integrity": "sha512-y1sPz1UVedvPKScLSeIiomoWKB3EmiC7zuBLCVMzM+4FL9U7GGT8TNvbsLhI5/TTPG68okXxV0O6SVqE0HDtsg==",
+			"requires": {
+				"ts-clone-node": "^0.3.23",
+				"typescript": "^4.3.5"
+			}
+		},
 		"@material/animation": {
 			"version": "12.0.0-canary.22d29cbb4.0",
 			"resolved": "https://registry.npmjs.org/@material/animation/-/animation-12.0.0-canary.22d29cbb4.0.tgz",
@@ -1340,6 +1411,14 @@
 			"resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
 			"integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA=="
 		},
+		"compatfactory": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/compatfactory/-/compatfactory-0.0.9.tgz",
+			"integrity": "sha512-WzoRZSBtsC5TT2J+MZNlo4Qpssf7ofSaRJUT3hN8nNeGilKOnTjR707k+hUU7QhVbyg3cmfWJlabTfMZgZtvEA==",
+			"requires": {
+				"helpertypes": "^0.0.4"
+			}
+		},
 		"data-uri-to-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
@@ -1374,6 +1453,11 @@
 			"requires": {
 				"is-glob": "^4.0.1"
 			}
+		},
+		"helpertypes": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/helpertypes/-/helpertypes-0.0.4.tgz",
+			"integrity": "sha512-q8f29R4Rdw9n5L4vGmUR8Ld6CXbxPxA7Xrcs4vto3K6w0LSF13TnWSm67uDrZRulf3t/ZHKCfeZ0qIletxSEow=="
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -1434,9 +1518,9 @@
 			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
 		},
 		"playground-elements": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.12.1.tgz",
-			"integrity": "sha512-YatLXTcJOqQQZOIBAdg12aD0MWJL3O//aAuAkMvCrh4d7HhwZgxfESxamyOpJWYjX13WD0KzwiibQIyZiztaGA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.13.0.tgz",
+			"integrity": "sha512-JkzUOUy/7BcJfz0cwxTDx2Ou71bVexvouOp3bzVtIdtXGSY0tdJXOeg2iANgFJo+txmrClzU7wygwn3nm7dp+w==",
 			"requires": {
 				"@material/mwc-button": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",
@@ -1473,10 +1557,23 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"ts-clone-node": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/ts-clone-node/-/ts-clone-node-0.3.25.tgz",
+			"integrity": "sha512-rqwcmTt3ZP8fGm2OCG9d++gKHVM/TlStKfBpw9Acbn7AWi/Rd6GMGyetEJP+Upq7y4DjRpQ9Iy7hSjSJYdi76g==",
+			"requires": {
+				"compatfactory": "^0.0.9"
+			}
+		},
 		"tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
+		"typescript": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
 		},
 		"vscode-jsonrpc": {
 			"version": "6.0.0",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -19,7 +19,7 @@
     "chokidar": "^3.5.2",
     "lit-dev-server": "^0.0.0",
     "node-fetch": "^3.0.0",
-    "playground-elements": "^0.12.1",
+    "playground-elements": "^0.13.0",
     "prettier": "^2.3.2"
   }
 }

--- a/packages/lit-dev-tools/package-lock.json
+++ b/packages/lit-dev-tools/package-lock.json
@@ -18,7 +18,7 @@
 				"jsdom": "^17.0.0",
 				"minisearch": "^3.0.4",
 				"outdent": "^0.8.0",
-				"playground-elements": "^0.12.1",
+				"playground-elements": "^0.13.0",
 				"playwright": "^1.8.0",
 				"source-map": "^0.7.3",
 				"strip-comments": "^2.0.1",
@@ -2657,9 +2657,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.12.1.tgz",
-			"integrity": "sha512-YatLXTcJOqQQZOIBAdg12aD0MWJL3O//aAuAkMvCrh4d7HhwZgxfESxamyOpJWYjX13WD0KzwiibQIyZiztaGA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.13.0.tgz",
+			"integrity": "sha512-JkzUOUy/7BcJfz0cwxTDx2Ou71bVexvouOp3bzVtIdtXGSY0tdJXOeg2iANgFJo+txmrClzU7wygwn3nm7dp+w==",
 			"dependencies": {
 				"@material/mwc-button": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",
@@ -5602,9 +5602,9 @@
 			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
 		},
 		"playground-elements": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.12.1.tgz",
-			"integrity": "sha512-YatLXTcJOqQQZOIBAdg12aD0MWJL3O//aAuAkMvCrh4d7HhwZgxfESxamyOpJWYjX13WD0KzwiibQIyZiztaGA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.13.0.tgz",
+			"integrity": "sha512-JkzUOUy/7BcJfz0cwxTDx2Ou71bVexvouOp3bzVtIdtXGSY0tdJXOeg2iANgFJo+txmrClzU7wygwn3nm7dp+w==",
 			"requires": {
 				"@material/mwc-button": "^0.22.1",
 				"@material/mwc-icon-button": "^0.22.1",

--- a/packages/lit-dev-tools/package.json
+++ b/packages/lit-dev-tools/package.json
@@ -21,7 +21,7 @@
     "jsdom": "^17.0.0",
     "minisearch": "^3.0.4",
     "outdent": "^0.8.0",
-    "playground-elements": "^0.12.1",
+    "playground-elements": "^0.13.0",
     "playwright": "^1.8.0",
     "source-map": "^0.7.3",
     "strip-comments": "^2.0.1",


### PR DESCRIPTION
If the user has modified code on the Tutorial or Playground pages, and then clicks the change-language toggle, a dialog will now pop up telling them that they'll lose changes, and gives them a chance to cancel.

![image](https://user-images.githubusercontent.com/48894/133316492-87373a28-c3a2-48b9-9b4f-6a88583ee3d4.png)

Also brings in the new package exports support (https://github.com/PolymerLabs/playground-elements/pull/200), so Lit will now run in development mode, and more packages will be importable (like Lion elements).

Fixes https://github.com/lit/lit.dev/issues/485