### PR TITLE
Fix outdated eventOptions import

### DIFF
--- a/packages/lit-dev-content/site/docs/components/events.md
+++ b/packages/lit-dev-content/site/docs/components/events.md
@@ -27,7 +27,8 @@ You can use `@` expressions in your template to add event listeners to element's
 If you need to customize the event options used for a declarative event listener (like `passive` or `capture`), you can specify these on the listener using the `@eventOptions` decorator. The object passed to `@eventOptions` is passed as the `options` parameter to `addEventListener`.
 
 ```js
-import {LitElement, html, eventOptions} from 'lit-element';
+import {LitElement, html} from 'lit';
+import {eventOptions} from 'lit/decorators.js';
 //...
 @eventOptions({passive: true})
 private _handleTouchStart(e) { console.log(e.type) }


### PR DESCRIPTION
Noticed this while browsing the docs, it seems like this section was using an outdated import path

(new to lit, please let me know if the current is indeed correct)