### PR TITLE
Replace current state in history instead of pushing new when saving tutorial

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -260,7 +260,7 @@ export class LitDevTutorial extends LitElement {
   };
 
   private _writeUrl() {
-    window.history.pushState(
+    window.history.replaceState(
       null,
       '',
       addModsParameterToUrlIfNeeded(this._info.url)


### PR DESCRIPTION
The history get's flooded quite fast when typing in the tutorial, and it would be beneficial to instead replacethe current history state instead of pushing a new one every time.