### PR TITLE
Squeeze RHS TOC into narrower horizontal resolutions

### DIFF
--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -542,7 +542,7 @@ td {
 }
 
 #rhsToc {
-  padding: calc(var(--docs-margin-top) + 0.3em) 1.5em 0 1em;
+  padding: calc(var(--docs-margin-top) + 0.3em) 1em 0 0;
   position: sticky;
   top: var(--header-height);
 }

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -684,7 +684,7 @@ td {
 }
 
 /**
- * Hide the RHS nav when very narrow.
+ * Hide the LHS nav when very narrow.
  *
  * (14 + 30 + 3) * 18 = 846
  *  |    |    |    +------------- font-size

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -19,7 +19,7 @@ main {
      @media query thresholds below need to be updated. */
   --docs-nav-min-width: 14em;
   --docs-nav-max-width: 1fr;
-  --docs-toc-min-width: 10em;
+  --docs-toc-min-width: 5em;
   --docs-article-min-width: 30em;
   --docs-article-max-width: 49em;
   --docs-article-margin-horizontal: 3em;
@@ -630,14 +630,14 @@ td {
 /**
  * Move the TOC inline when slightly narrow.
  *
- * (14 + 49 + 10 + (3 * 2)) * 18 = 1422
- *  |    |    |     |         +-- font-size
- *  |    |    |     +------------ docs-article-margin-horizontal
+ * (14 + 49 + 5 + (3 * 2)) * 18 = 1332
+ *  |    |    |    |         +--- font-size
+ *  |    |    |    +------------- docs-article-margin-horizontal
  *  |    |    +------------------ docs-toc-min-width
  *  |    +----------------------- docs-article-max-width
  *  +---------------------------- docs-nav-min-width
  */
-@media (max-width: 1440px) {
+@media (max-width: 1332px) {
   main {
     --docs-article-margin-horizontal: 2.5em;
   }

--- a/packages/lit-dev-content/site/docs/components/overview.md
+++ b/packages/lit-dev-content/site/docs/components/overview.md
@@ -23,5 +23,3 @@ Creating a Lit component involves a number of concepts:
 Here's a sample component:
 
 {% playground-example "docs/components/overview/simple-greeting" "simple-greeting.ts" %}
-
-</div>


### PR DESCRIPTION
The RHS TOC will now display when the horizontal resolution is >1332px, where previously it required >1440px. This way we'll cover 1344x840 (the next highest scaling setting on a recent 16" MBP), and also 1366x768 (a generally common resolution).

(The exact 1332px number is a little arbitrary looking because we use a formula that makes the transitions look smooth, so this came from halving the width that we allow the TOC to squeeze to).

Fixes https://github.com/lit/lit.dev/issues/522

cc @castastrophe