### PR TITLE
Implement a Content Security Policy (CSP) for lit.dev (report only for now)

### DIFF
--- a/cloudbuild-main.yaml
+++ b/cloudbuild-main.yaml
@@ -46,7 +46,7 @@ steps:
       - '--min-instances=1'
       - '--max-instances=1000'
       # Serve the main site
-      - '--update-env-vars=MODE=main'
+      - '--update-env-vars=MODE=main,REPORT_CSP_VIOLATIONS=true'
 
   # Create a new Cloud Run revision for the Playground sandbox.
   #

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type Koa from 'koa';
+
+/**
+ * Options for contentSecurityPolicyMiddleware.
+ */
+export interface ContentSecurityPolicyMiddlewareOptions {
+  /**
+   * Enables some additional directives that are only required when running in
+   * local dev mode.
+   */
+  devMode?: boolean;
+
+  /**
+   * If true, CSP violations will be reported to the Google CSP Collector.
+   */
+  reportViolations?: boolean;
+}
+
+/**
+ * Creates a Koa middleware that sets the lit.dev Content Security Policy (CSP)
+ * headers.
+ *
+ * Some good resources about CSP:
+ * https://web.dev/strict-csp/
+ * https://www.w3.org/TR/CSP3/
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+ * https://speakerdeck.com/lweichselbaum/csp-a-successful-mess-between-hardening-and-mitigation
+ */
+export const contentSecurityPolicyMiddleware = (
+  opts: ContentSecurityPolicyMiddlewareOptions = {}
+): Koa.Middleware => {
+  const cspHeaderValue = [
+    // TODO(aomarks) We should also enable trusted types, but that will require
+    // a policy in playground-elements for creating the worker, and a policy
+    // es-module-lexer for doing an eval (see next comment for more on that).
+
+    // TODO(aomarks) unsafe-eval is needed for an eval that is made by
+    // es-module-lexer to perform JavaScript string unescaping
+    // (https://github.com/guybedford/es-module-lexer/blob/91964da6b086dc5029091eeef481180a814ce24a/src/lexer.js#L32).
+    // There are a number of ways we could make this stricter: [1] use the
+    // asm.js build which doesn't use eval (but it's significantly slower), [2]
+    // use a separate CSP for the worker (except Chrome doesn't support that
+    // yet, though we could simulate it with an iframe), [3] get trusted types
+    // into the WASM build, [4] modify or fork the WASM build to implement
+    // string unescaping without eval (needs benchmarking).
+    //
+    // In dev mode, data: scripts are required because @web/dev-server uses them
+    // for automatic reloads.
+    `script-src 'self' 'unsafe-eval' https://www.googletagmanager.com/gtag/js ${
+      opts.devMode ? ` data:` : ''
+    }`,
+
+    // unpkg.com is needed to allow the Playground worker to fetch dependencies.
+    // TODO(aomarks) After https://crbug.com/1253267 is fixed we can serve a
+    // separate CSP policy just for the worker script (Firefox and Safari
+    // already support this).
+    //
+    // In dev mode, ws: connections are required because @web/dev-server uses
+    // them for automatic reloads.
+    `connect-src 'self' https://unpkg.com/${opts.devMode ? ` ws:` : ''}`,
+
+    // TODO(aomarks) These frame-src directives are only needed for embedding
+    // Playground previews. We can know the exact origin that is being used for
+    // Playground previews, so we could restrict this further by passing that in
+    // as a parameter to the middleware.
+    //
+    // In dev mode, http: is needed for http://localhost Playground iframes.
+    `frame-src https:${opts.devMode ? ' http:' : ''}`,
+
+    // We need 'unsafe-inline' because CodeMirror uses inline styles See
+    // https://discuss.codemirror.net/t/inline-styles-and-content-security-policy/1311/2
+    // TODO(aomarks) Is it possible to know all of the possible inline styles
+    // CodeMirror will use, and provide them here using 'unsafe-hashes'? They
+    // look quite dynamic though.
+    `style-src 'self' 'unsafe-inline'`,
+
+    // TODO(aomarks) We need fonts.gstatic.com for fetching Open Sans (Manrope
+    // is already hosted locally). We should probably just host Open Sans
+    // ourselves, because there is no cross-origin caching benefit (see
+    // https://developers.google.com/web/updates/2020/10/http-cache-partitioning),
+    // and it would be one fewer connection to make.
+    `font-src 'self' https://fonts.gstatic.com/`,
+
+    // TODO(aomarks) We use some data: URLs for SVGs in docs.css. There's
+    // probably a simpler way.
+    // The ytimg.com domain is needed for embedded YouTube videos.
+    `img-src 'self' data: https://i.ytimg.com/`,
+
+    // TODO(aomarks) This could be 'none' if we didn't use <svg><use> elements,
+    // because Firefox does not follow the img-src directive for them, so there
+    // is no other directive to use. See
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1303364#c4 and
+    // https://github.com/w3c/webappsec-csp/issues/199.
+    `default-src 'self'`,
+
+    ...(opts.reportViolations
+      ? [`report-uri https://csp.withgoogle.com/csp/lit-dev`]
+      : []),
+  ].join('; ');
+
+  return async (ctx, next) => {
+    await next();
+    if (ctx.response.type === 'text/html') {
+      // TODO(aomarks) Remove -Report-Only suffix when we are confident the
+      // policy is working.
+      ctx.set('Content-Security-Policy-Report-Only', cspHeaderValue);
+    }
+  };
+};

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -40,6 +40,11 @@ export const contentSecurityPolicyMiddleware = (
     // a policy in playground-elements for creating the worker, and a policy
     // es-module-lexer for doing an eval (see next comment for more on that).
 
+    // TODO(aomarks) unsafe-inline is needed because we use some inline scripts
+    // on some pages. We should generate hashes for them during Eleventy build
+    // and allowlist them here using `<hash-algorithm>-<base64-value>`
+    // directives.
+    //
     // TODO(aomarks) unsafe-eval is needed for an eval that is made by
     // es-module-lexer to perform JavaScript string unescaping
     // (https://github.com/guybedford/es-module-lexer/blob/91964da6b086dc5029091eeef481180a814ce24a/src/lexer.js#L32).
@@ -52,7 +57,7 @@ export const contentSecurityPolicyMiddleware = (
     //
     // In dev mode, data: scripts are required because @web/dev-server uses them
     // for automatic reloads.
-    `script-src 'self' 'unsafe-eval' https://www.googletagmanager.com/gtag/js ${
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com/gtag/js ${
       opts.devMode ? ` data:` : ''
     }`,
 

--- a/packages/lit-dev-server/src/server.ts
+++ b/packages/lit-dev-server/src/server.ts
@@ -12,6 +12,7 @@ import {fileURLToPath} from 'url';
 import * as path from 'path';
 import {redirectMiddleware} from './middleware/redirect-middleware.js';
 import {playgroundMiddleware} from './middleware/playground-middleware.js';
+import {contentSecurityPolicyMiddleware} from './middleware/content-security-policy-middleware.js';
 
 const mode = process.env.MODE;
 if (mode !== 'main' && mode !== 'playground') {
@@ -40,6 +41,12 @@ const app = new Koa();
 
 if (mode === 'playground') {
   app.use(playgroundMiddleware());
+} else {
+  app.use(
+    contentSecurityPolicyMiddleware({
+      reportViolations: process.env.REPORT_CSP_VIOLATIONS === 'true',
+    })
+  );
 }
 
 app.use(redirectMiddleware());

--- a/packages/lit-dev-tools-esm/src/dev-server.ts
+++ b/packages/lit-dev-tools-esm/src/dev-server.ts
@@ -9,6 +9,7 @@ import {fileURLToPath} from 'url';
 import * as pathlib from 'path';
 import {redirectMiddleware} from 'lit-dev-server/lib/middleware/redirect-middleware.js';
 import {playgroundMiddleware} from 'lit-dev-server/lib/middleware/playground-middleware.js';
+import {contentSecurityPolicyMiddleware} from 'lit-dev-server/lib/middleware/content-security-policy-middleware.js';
 
 const THIS_DIR = pathlib.dirname(fileURLToPath(import.meta.url));
 const CONTENT_PKG = pathlib.resolve(THIS_DIR, '..', '..', 'lit-dev-content');
@@ -77,7 +78,10 @@ startDevServer({
       dontResolveBareModulesInPlaygroundFiles,
       removeWatchScriptFromPlaygroundFiles,
     ],
-    middleware: [redirectMiddleware()],
+    middleware: [
+      contentSecurityPolicyMiddleware({devMode: true}),
+      redirectMiddleware(),
+    ],
     watch: true,
     nodeResolve: true,
     preserveSymlinks: true,


### PR DESCRIPTION
Adds a new `contentSecurityPolicyMiddleware` which we run in both the prod and dev servers.

For now it is using the `Content-Security-Policy-Report-Only` heading. This means violations will be shown in the console, but they won't actually throw any exceptions. On the production site, violations will additionally get reported to the Google CSP collector, which has a dashboard we can use to see if violations are occuring.

The policy isn't as strict as we would like. In particular, we have to allow `unsafe-eval` because of a library we are using inside the Playground web worker. More details in the TODO. I plan to send some followup PRs that will incrementally lock down this policy.

Part of https://github.com/lit/lit.dev/issues/517