### PR TITLE
Further restrict CSP and fix misfiring Google Analytics violation

### DIFF
--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -39,6 +39,12 @@ export interface ContentSecurityPolicyMiddlewareOptions {
 const CSP_REPORT_URI = 'https://csp.withgoogle.com/csp/lit-dev';
 
 /**
+ * TODO(aomarks) Generate this automatically. See
+ * https://github.com/lit/lit.dev/issues/531.
+ */
+const GOOGLE_ANALYTICS_INLINE_SCRIPT_HASH = `'sha256-bG+QS/Ob2lFyxJ7r7PCtj/a8YofLHFx4t55RzjR1znI='`;
+
+/**
  * Creates a Koa middleware that sets the lit.dev Content Security Policy (CSP)
  * headers.
  *
@@ -79,6 +85,7 @@ export const contentSecurityPolicyMiddleware = (
       `'self'`,
       `'unsafe-eval'`,
       `https://www.googletagmanager.com/gtag/js`,
+      GOOGLE_ANALYTICS_INLINE_SCRIPT_HASH,
       ...(opts.inlineScriptHashes?.map((hash) => `'${hash}'`) ?? []),
       ...(opts.devMode ? [`data:`] : []),
     ].join(' ')}`,

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -75,18 +75,16 @@ export const contentSecurityPolicyMiddleware = (
     // TODO(aomarks) We should also enable trusted types, but that will require
     // a policy in playground-elements for creating the worker, and a policy
     // es-module-lexer for doing an eval (see next comment for more on that).
-
-    // TODO(aomarks) Remove unsafe-eval when https://crbug.com/1253267 is fixed.
-    // See comment below about playgroundWorkerCsp.
-    //
-    // In dev mode, data: scripts are required because @web/dev-server uses them
-    // for automatic reloads.
     `script-src ${[
       `'self'`,
+      // TODO(aomarks) Remove unsafe-eval when https://crbug.com/1253267 is fixed.
+      // See comment below about playgroundWorkerCsp.
       `'unsafe-eval'`,
       `https://www.googletagmanager.com/gtag/js`,
       GOOGLE_ANALYTICS_INLINE_SCRIPT_HASH,
       ...(opts.inlineScriptHashes?.map((hash) => `'${hash}'`) ?? []),
+      // In dev mode, data: scripts are required because @web/dev-server uses them
+      // for automatic reloads.
       ...(opts.devMode ? [`data:`] : []),
     ].join(' ')}`,
 


### PR DESCRIPTION
- For all requests other than our HTML entrypoints and the playground worker script, serve a super strict policy,  just in case a response that shouldn't normally allow any code execution somehow actually does. Based on [this](https://github.com/w3c/webappsec/issues/520#issuecomment-488516726) and [this](https://github.com/webhintio/hint/issues/3403#issue-528402128) comment.

- Add some directives that I found through https://csp-evaluator.withgoogle.com/ and [this comment](https://github.com/w3c/webappsec/issues/520#issuecomment-562874306).

- Temporary fix for inline Google Analytics script which was being reported as a violation. See https://github.com/lit/lit.dev/issues/531 for details. Will fix properly in followup.