### PR TITLE
Start proving out GitHub authentication integration

### DIFF
--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -18,7 +18,7 @@
     "build:samples": "rm -rf samples/js && node ../lit-dev-tools-esm/lib/generate-js-samples.js",
     "build:samples:watch": "npm run build:samples -- --watch",
     "fonts:manrope": "rm -rf site/fonts temp && mkdir -p site/fonts && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/ && cd ../.. && rm -rf temp",
-    "dev:build:site": "rm -rf _dev && ELEVENTY_ENV=dev PLAYGROUND_SANDBOX=http://localhost:5416/ eleventy",
+    "dev:build:site": "rm -rf _dev && ELEVENTY_ENV=dev PLAYGROUND_SANDBOX=http://localhost:5416/ GITHUB_CLIENT_ID=FAKE_CLIENT_ID GITHUB_AUTHORIZE_URL=http://localhost:5417/login/oauth/authorize eleventy",
     "dev:build:site:watch": "npm run dev:build:site -- --watch",
     "dev:serve": "node ../lit-dev-tools-esm/lib/dev-server.js --open",
     "format": "../../node_modules/.bin/prettier \"**/*.{ts,js,json,html,css,md}\" --write"

--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -38,6 +38,7 @@ export default [
       'lib/components/litdev-search.js',
       'lib/components/playground-elements.js',
       'lib/components/resize-bar.js',
+      'lib/github/github-signin-receiver-page.js',
       'lib/global/mobile-nav.js',
       'lib/pages/docs.js',
       'lib/pages/home.js',

--- a/packages/lit-dev-content/site/_data/env.js
+++ b/packages/lit-dev-content/site/_data/env.js
@@ -12,4 +12,6 @@
    DEV: process.env.ELEVENTY_ENV === 'dev',
    PLAYGROUND_SANDBOX: process.env.PLAYGROUND_SANDBOX || 'http://localhost:6416/',
    GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
+   GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
+   GITHUB_AUTHORIZE_URL: process.env.GITHUB_AUTHORIZE_URL,
  }

--- a/packages/lit-dev-content/site/css/mods.css
+++ b/packages/lit-dev-content/site/css/mods.css
@@ -22,3 +22,10 @@
   --playground-code-attribute-color: #9cdcfe;
   --playground-code-callee-color: #dcdcaa;
 }
+
+litdev-github-share-button {
+  display: none;
+}
+.gists litdev-github-share-button {
+  display: inline-block;
+}

--- a/packages/lit-dev-content/site/css/playground.css
+++ b/packages/lit-dev-content/site/css/playground.css
@@ -137,6 +137,10 @@ litdev-drawer:not([closed])::part(header) {
   align-items: center;
 }
 
+#actionBar > * {
+  margin-left: 1em;
+}
+
 #actionBar > button {
   font-family: "Open Sans", sans-serif;
   background: transparent;
@@ -147,7 +151,6 @@ litdev-drawer:not([closed])::part(header) {
   align-items: center;
   font-size: 16px;
   cursor: pointer;
-  margin-left: 1em;
 }
 
 #actionBar > button:hover {

--- a/packages/lit-dev-content/site/playground/index.html
+++ b/packages/lit-dev-content/site/playground/index.html
@@ -65,6 +65,11 @@ title: Playground
       </svg>
       Share
     </button>
+
+    <litdev-github-share-button
+      clientId="{{ env.GITHUB_CLIENT_ID }}"
+      authorizeUrl="{{ env.GITHUB_AUTHORIZE_URL }}">
+    </litdev-github-share-button>
   </div>
 
   <playground-project

--- a/packages/lit-dev-content/site/playground/signin.html
+++ b/packages/lit-dev-content/site/playground/signin.html
@@ -3,11 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="robots" content="noindex">
+    {% inlinejs "github/github-signin-receiver-page.js" %}
   </head>
-  <body>
-      <!-- In the future, this page will communicate with its parent Playground
-           page (having been opened as a popup window) to pass back an
-           authentication code from GitHub. -->
-    <p>placeholder playground signin</p>
-  </body>
 </html>

--- a/packages/lit-dev-content/src/components/litdev-github-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-github-share-button.ts
@@ -40,6 +40,7 @@ export class LitDevGitHubShareButton extends LitElement {
     if (!this.clientId || !this.authorizeUrl) {
       throw new Error('Missing required properties');
     }
+    // TODO(aomarks) Prevent multiple signups from being queued.
     const result = await signInToGithub({
       clientId: this.clientId,
       authorizeUrl: this.authorizeUrl,

--- a/packages/lit-dev-content/src/components/litdev-github-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-github-share-button.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {signInToGithub} from '../github/github-signin.js';
+
+/**
+ * A button that shares a Playground project as a GitHub gist. If the user isn't
+ * signed into GitHub yet, they are prompted to do so.
+ *
+ * // TODO(aomarks) Implement actually sharing. This is just an early WIP.
+ * // TODO(aomarks) Show a scrim and some indication about what is happening
+ * //               while the popup is open.
+ * // TODO(aomarks) Style this button
+ */
+@customElement('litdev-github-share-button')
+export class LitDevGitHubShareButton extends LitElement {
+  /**
+   * GitHub OAuth App client ID. Generated when a GitHub OAuth App is first
+   * created.
+   */
+  @property()
+  clientId?: string;
+
+  /**
+   * URL where users will be redirected to authorize with GitHub.
+   */
+  @property()
+  authorizeUrl?: string;
+
+  override render() {
+    return html`<button @click=${this._onClick}>Share with GitHub</button>`;
+  }
+
+  private async _onClick() {
+    if (!this.clientId || !this.authorizeUrl) {
+      return;
+    }
+    const result = await signInToGithub({
+      clientId: this.clientId,
+      authorizeUrl: this.authorizeUrl,
+    });
+    if (result.error) {
+      alert(`error: ${result.error}`);
+    } else {
+      alert(`code: ${result.code}`);
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'litdev-github-share-button': LitDevGitHubShareButton;
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-github-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-github-share-button.ts
@@ -38,7 +38,7 @@ export class LitDevGitHubShareButton extends LitElement {
 
   private async _onClick() {
     if (!this.clientId || !this.authorizeUrl) {
-      return;
+      throw new Error('Missing required properties');
     }
     const result = await signInToGithub({
       clientId: this.clientId,

--- a/packages/lit-dev-content/src/github/github-signin-receiver-page.ts
+++ b/packages/lit-dev-content/src/github/github-signin-receiver-page.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type {GitHubSigninReceiverMessage} from './github-types.js';
+
+// This is the inlined script for the /playground/signin/ page.
+//
+// This page is assumed to be running in a popup window created by the main
+// Playground page. After the user clicks "Accept" or "Cancel" on the GitHub
+// authorization page, GitHub will redirect to this page with a "code" or
+// "error" URL parameter. This page will then message the original parent
+// Playground window with that code or error, and the popup window will close.
+
+const opener = window.opener as Window | null;
+if (opener) {
+  const url = new URL(document.location.href);
+  const params = url.searchParams;
+  const code = params.get('code');
+  const error = params.get('error');
+  let message: GitHubSigninReceiverMessage;
+  if (error) {
+    message = {error};
+  } else if (!code) {
+    message = {error: 'No code'};
+  } else {
+    message = {code};
+  }
+  opener.postMessage(message);
+} else {
+  const p = document.createElement('p');
+  p.textContent = `Oops! Something went wrong while signing into GitHub.
+The Playground tab that opened this window could not be found.`;
+  document.body.appendChild(p);
+}

--- a/packages/lit-dev-content/src/github/github-signin.ts
+++ b/packages/lit-dev-content/src/github/github-signin.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type {GitHubSigninReceiverMessage} from './github-types.js';
+
+/**
+ * Options for signInToGithub.
+ */
+export interface GitHubSigninOptions {
+  /**
+   * GitHub OAuth App client ID. Generated when a GitHub OAuth App is first
+   * created.
+   */
+  clientId: string;
+
+  /**
+   * URL where users will be redirected to authorize with GitHub.
+   */
+  authorizeUrl: string;
+}
+
+/**
+ * Pop open a window to authenticate the current user with GitHub following the
+ * procedure documented at
+ * https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow.
+ */
+export const signInToGithub = async (
+  options: GitHubSigninOptions
+): Promise<GitHubSigninReceiverMessage> => {
+  const url = new URL(options.authorizeUrl);
+  url.searchParams.set('client_id', options.clientId);
+  url.searchParams.set('scope', 'gist');
+  url.searchParams.set(
+    'redirect_uri',
+    new URL('/playground/signin/', document.location.href).href
+  );
+  // Width and height found by empirically.
+  const width = 600;
+  const height = 650;
+  // Position the popup in the middle of this tab.
+  const top = window.screenY + window.outerHeight / 2 - height / 2;
+  const left = window.screenX + window.outerWidth / 2 - width / 2;
+  const popup = window.open(
+    url,
+    '_blank',
+    `width=${width},height=${height},top=${top},left=${left}`
+  );
+  if (popup === null) {
+    throw new Error('Could not open window. Are popups disabled?');
+  }
+  const result = await new Promise<GitHubSigninReceiverMessage>((resolve) => {
+    const listener = (event: MessageEvent<GitHubSigninReceiverMessage>) => {
+      if (event.source === popup) {
+        resolve(event.data);
+        window.removeEventListener('message', listener);
+      }
+    };
+    window.addEventListener('message', listener);
+  });
+  popup.close();
+  return result;
+};

--- a/packages/lit-dev-content/src/github/github-types.d.ts
+++ b/packages/lit-dev-content/src/github/github-types.d.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export type GitHubSigninReceiverMessage =
+  | {code: string; error?: undefined}
+  | {code?: undefined; error: string};

--- a/packages/lit-dev-content/src/pages/playground.ts
+++ b/packages/lit-dev-content/src/pages/playground.ts
@@ -9,6 +9,7 @@ import '@material/mwc-snackbar';
 import 'playground-elements/playground-ide.js';
 import '../components/litdev-example-controls.js';
 import '../components/litdev-playground-change-guard.js';
+import '../components/litdev-github-share-button.js';
 import {
   getCodeLanguagePreference,
   CODE_LANGUAGE_CHANGE,


### PR DESCRIPTION
- Adds a temporary unstyled "Share with GitHub" button to the Playground page behind the `?mods=gists` URL parameter. In dev, this is hooked up to the local fake GitHub server. On prod and in staging URLs, it won't do anything at all for now.

    <img src="https://user-images.githubusercontent.com/48894/135545167-268db014-c54d-4812-bf34-254241a1f04b.png" width="400px">

- Clicking the button performs the first half of the GitHub authentication process described at https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity. Just shows the code or error that was received to demonstrate that it's working, since the second half (token exchange) isn't implemented yet.

    <img src="https://user-images.githubusercontent.com/48894/135545316-ae5c71f6-914d-4873-9c68-2a58d583c63b.png" width="400px">

Part of https://github.com/lit/lit.dev/issues/533