### PR TITLE
Bump to new Playground version with more aggressive SW update logic

### DIFF
--- a/packages/lit-dev-content/package-lock.json
+++ b/packages/lit-dev-content/package-lock.json
@@ -20,7 +20,7 @@
 				"@material/mwc-snackbar": "^0.25.1",
 				"lit": "^2.0.0",
 				"minisearch": "^3.0.4",
-				"playground-elements": "^0.14.2",
+				"playground-elements": "^0.14.3-pre.0",
 				"tarts": "^1.0.0",
 				"tslib": "^2.2.0"
 			},
@@ -5309,9 +5309,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.2.tgz",
-			"integrity": "sha512-TfHLMeru23IOtPWbZprVQJDmntAvDhZ99AflkWq7T1N2adUVpmg87O1tzlV/8T3EvEDLnVsam5quOvY0Y7mumw==",
+			"version": "0.14.3-pre.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.3-pre.0.tgz",
+			"integrity": "sha512-D/D3OAmJDPWjNKpGMaYowfDeWTcpgdMjYcpXdWDr+1Tw/mzavWWHIlCrnMkcaL5IDgmIHStQ9NaJeIBMh1mrOw==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -11635,9 +11635,9 @@
 			}
 		},
 		"playground-elements": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.2.tgz",
-			"integrity": "sha512-TfHLMeru23IOtPWbZprVQJDmntAvDhZ99AflkWq7T1N2adUVpmg87O1tzlV/8T3EvEDLnVsam5quOvY0Y7mumw==",
+			"version": "0.14.3-pre.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.3-pre.0.tgz",
+			"integrity": "sha512-D/D3OAmJDPWjNKpGMaYowfDeWTcpgdMjYcpXdWDr+1Tw/mzavWWHIlCrnMkcaL5IDgmIHStQ9NaJeIBMh1mrOw==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -57,7 +57,7 @@
     "@material/mwc-snackbar": "^0.25.1",
     "lit": "^2.0.0",
     "minisearch": "^3.0.4",
-    "playground-elements": "^0.14.2",
+    "playground-elements": "^0.14.3-pre.0",
     "tarts": "^1.0.0",
     "tslib": "^2.2.0"
   }

--- a/packages/lit-dev-tools-esm/package-lock.json
+++ b/packages/lit-dev-tools-esm/package-lock.json
@@ -16,7 +16,7 @@
 				"ansi-escape-sequences": "^6.2.0",
 				"chokidar": "^3.5.2",
 				"node-fetch": "^3.0.0",
-				"playground-elements": "^0.14.2",
+				"playground-elements": "^0.14.3-pre.0",
 				"prettier": "^2.3.2"
 			}
 		},
@@ -1862,9 +1862,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.2.tgz",
-			"integrity": "sha512-TfHLMeru23IOtPWbZprVQJDmntAvDhZ99AflkWq7T1N2adUVpmg87O1tzlV/8T3EvEDLnVsam5quOvY0Y7mumw==",
+			"version": "0.14.3-pre.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.3-pre.0.tgz",
+			"integrity": "sha512-D/D3OAmJDPWjNKpGMaYowfDeWTcpgdMjYcpXdWDr+1Tw/mzavWWHIlCrnMkcaL5IDgmIHStQ9NaJeIBMh1mrOw==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -3821,9 +3821,9 @@
 			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
 		},
 		"playground-elements": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.2.tgz",
-			"integrity": "sha512-TfHLMeru23IOtPWbZprVQJDmntAvDhZ99AflkWq7T1N2adUVpmg87O1tzlV/8T3EvEDLnVsam5quOvY0Y7mumw==",
+			"version": "0.14.3-pre.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.3-pre.0.tgz",
+			"integrity": "sha512-D/D3OAmJDPWjNKpGMaYowfDeWTcpgdMjYcpXdWDr+1Tw/mzavWWHIlCrnMkcaL5IDgmIHStQ9NaJeIBMh1mrOw==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -20,7 +20,7 @@
     "chokidar": "^3.5.2",
     "lit-dev-server": "^0.0.0",
     "node-fetch": "^3.0.0",
-    "playground-elements": "^0.14.2",
+    "playground-elements": "^0.14.3-pre.0",
     "prettier": "^2.3.2"
   }
 }

--- a/packages/lit-dev-tools/package-lock.json
+++ b/packages/lit-dev-tools/package-lock.json
@@ -18,7 +18,7 @@
 				"jsdom": "^17.0.0",
 				"minisearch": "^3.0.4",
 				"outdent": "^0.8.0",
-				"playground-elements": "^0.14.2",
+				"playground-elements": "^0.14.3-pre.0",
 				"playwright": "^1.8.0",
 				"source-map": "^0.7.3",
 				"strip-comments": "^2.0.1",
@@ -2529,9 +2529,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.2.tgz",
-			"integrity": "sha512-TfHLMeru23IOtPWbZprVQJDmntAvDhZ99AflkWq7T1N2adUVpmg87O1tzlV/8T3EvEDLnVsam5quOvY0Y7mumw==",
+			"version": "0.14.3-pre.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.3-pre.0.tgz",
+			"integrity": "sha512-D/D3OAmJDPWjNKpGMaYowfDeWTcpgdMjYcpXdWDr+1Tw/mzavWWHIlCrnMkcaL5IDgmIHStQ9NaJeIBMh1mrOw==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -5396,9 +5396,9 @@
 			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
 		},
 		"playground-elements": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.2.tgz",
-			"integrity": "sha512-TfHLMeru23IOtPWbZprVQJDmntAvDhZ99AflkWq7T1N2adUVpmg87O1tzlV/8T3EvEDLnVsam5quOvY0Y7mumw==",
+			"version": "0.14.3-pre.0",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.14.3-pre.0.tgz",
+			"integrity": "sha512-D/D3OAmJDPWjNKpGMaYowfDeWTcpgdMjYcpXdWDr+1Tw/mzavWWHIlCrnMkcaL5IDgmIHStQ9NaJeIBMh1mrOw==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-tools/package.json
+++ b/packages/lit-dev-tools/package.json
@@ -21,7 +21,7 @@
     "jsdom": "^17.0.0",
     "minisearch": "^3.0.4",
     "outdent": "^0.8.0",
-    "playground-elements": "^0.14.2",
+    "playground-elements": "^0.14.3-pre.0",
     "playwright": "^1.8.0",
     "source-map": "^0.7.3",
     "strip-comments": "^2.0.1",


### PR DESCRIPTION
Brings in the changes from https://github.com/google/playground-elements/pull/218