### PR TITLE
Fix link to SAP UI5 reference to lit-html

### DIFF
--- a/packages/lit-dev-content/site/home/5-who-is-using.html
+++ b/packages/lit-dev-content/site/home/5-who-is-using.html
@@ -102,7 +102,7 @@
         </div>
       </a>
 
-      <a target="_blank" rel="noopener" href="https://github.com/SAP/ui5-webcomponents/blob/master/docs/dev/Developing%20Web%20Components.md#:~:text=lit-html">
+      <a target="_blank" rel="noopener" href="https://github.com/SAP/ui5-webcomponents/blob/master/docs/5-development/02-custom-UI5-Web-Components.md#:~:text=lit-html">
         <svg role="img">
           <title>SAP</title>
           <use xlink:href="{{ site.baseurl }}/images/logos/sap.svg#logo"></use>


### PR DESCRIPTION
Their documentation recently moved around.