### PR TITLE
Enforce CSP

### DIFF
--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -201,9 +201,7 @@ export const contentSecurityPolicyMiddleware = (
     } else {
       policy = strictFallbackCsp;
     }
-    // TODO(aomarks) Remove -Report-Only suffix when we are confident the
-    // policy is working.
-    ctx.set('Content-Security-Policy-Report-Only', policy);
+    ctx.set('Content-Security-Policy', policy);
     return next();
   };
 };


### PR DESCRIPTION
Switches our Content Security Policy from report-only mode to enforced mode.

According to our internal dashboard, it looks like CSP violation numbers dropped very sharply on October 1, which is the day https://github.com/lit/lit.dev/pull/540 landed. There do seem to be a few reports coming in as recently as October 5, but if so it is a very small number. Could be due to caching? Browser extensions injecting scripts/images etc. will also cause ongoing CSP violations, that's expected behavior.

Fixes https://github.com/lit/lit.dev/issues/517

Filed https://github.com/lit/lit.dev/issues/550 to track the most important improvement, which we can't do until https://bugs.chromium.org/p/chromium/issues/detail?id=1253267 is fixed.