### PR TITLE
Fix broken mobile nav

### DIFF
--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -100,6 +100,7 @@ export default [
     input: [
       'lib/global/apply-mods.js',
       'lib/global/initialize-typescript-attribute.js',
+      'lib/global/mobile-drawer.js',
     ],
     output: {
       dir: 'rollupout',

--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -14,6 +14,7 @@
     {% inlinecss "mods.css" %}
     {% inlinejs "global/apply-mods.js" %}
     {% inlinejs "global/initialize-typescript-attribute.js" %}
+    {% inlinejs "global/mobile-drawer.js" %}
 
     <!-- We need to load litdev-search first because @lion/core loads the
          scoped-custom-element-registry polyfill. If MWC components are loaded

--- a/packages/lit-dev-content/site/_includes/header.html
+++ b/packages/lit-dev-content/site/_includes/header.html
@@ -11,7 +11,6 @@
     <mwc-icon-button
       id="mobileMenuButton"
       label="Open menu"
-      onclick="document.querySelector('mwc-drawer').open=true"
     >
       <svg height="24" width="24" fill="currentcolor">
         <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />

--- a/packages/lit-dev-content/src/global/mobile-drawer.ts
+++ b/packages/lit-dev-content/src/global/mobile-drawer.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// TODO(aomarks) This is pretty hacky. There is currently a loose coupling
+// between the mobile menu button and the mobile menu itself (one is defined in
+// default.html, the other in header.html). They could be one custom element
+// instead.
+document.querySelector('#mobileMenuButton')?.addEventListener('click', () => {
+  const drawer = document.querySelector('mwc-drawer');
+  if (drawer) {
+    drawer.open = true;
+  }
+});


### PR DESCRIPTION
Turns out there was a CSP error that I missed that only affected mobile view. An inline `onclick` handler on the mobile nav open button.

This is a quick hack to roll forward that turns the onclick handler into an inlined script, which gets automatically hashed for CSP. Better solution would probably be to make a custom element that contains both the button and the drawer, and hook things up with a lit template.