### PR TITLE
Pin kaniko to earlier version because of permissions bug

### DIFF
--- a/cloudbuild-main.yaml
+++ b/cloudbuild-main.yaml
@@ -9,7 +9,9 @@ steps:
   # https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/docker
   # https://cloud.google.com/build/docs/kaniko-cache
   - id: build
-    name: gcr.io/kaniko-project/executor
+    # Kaniko pinned to earlier version due to
+    # https://github.com/GoogleContainerTools/kaniko/issues/1786
+    name: gcr.io/kaniko-project/executor:v1.6.0
     args:
       - --dockerfile=./Dockerfile
       - --destination=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,7 +13,9 @@ steps:
   # https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/docker
   # https://cloud.google.com/build/docs/kaniko-cache
   - id: build
-    name: gcr.io/kaniko-project/executor
+    # Kaniko pinned to earlier version due to
+    # https://github.com/GoogleContainerTools/kaniko/issues/1786
+    name: gcr.io/kaniko-project/executor:v1.6.0
     args:
       - --dockerfile=./Dockerfile
       - --destination=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA


### PR DESCRIPTION
The latest version of kaniko (https://cloud.google.com/build/docs/kaniko-cache) is failing to build lit.dev with a permissions error. Many other users are seeing the same thing today. Downgrading temporarily works.

See https://github.com/GoogleContainerTools/kaniko/issues/1786