### PR TITLE
Clarify that Open WC uses the lit package

### DIFF
--- a/packages/lit-dev-content/site/docs/getting-started.md
+++ b/packages/lit-dev-content/site/docs/getting-started.md
@@ -49,4 +49,4 @@ See [Adding Lit to an existing project](/docs/tools/adding-lit) for instructions
 
 ## Open WC project generator
 
-The Open WC project has a [project generator](https://open-wc.org/docs/development/generator/) that can scaffold out an application project using LitElement.
+The Open WC project has a [project generator](https://open-wc.org/docs/development/generator/) that can scaffold out an application project using Lit.


### PR DESCRIPTION
I initially thought the distinction (LitElement) was intentional, and the generator outdated, since the previous version of the library is at https://lit-element.polymer-project.org vs the new version at https://lit.dev.