### PR TITLE
Check origin of GitHub code postMessages

### DIFF
--- a/packages/lit-dev-content/src/github/github-signin-receiver-page.ts
+++ b/packages/lit-dev-content/src/github/github-signin-receiver-page.ts
@@ -28,6 +28,10 @@ if (opener) {
   } else {
     message = {code};
   }
+  // Note the default postMessage targetOrigin is "/"
+  // (https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages)
+  // so by leaving it unspecified we ensure that we will only post codes to our
+  // expected same-origin.
   opener.postMessage(message);
 } else {
   const p = document.createElement('p');

--- a/packages/lit-dev-content/src/github/github-signin.ts
+++ b/packages/lit-dev-content/src/github/github-signin.ts
@@ -122,8 +122,11 @@ const receiveCodeFromPopup = (
       'message',
       (event) => {
         // Note we must check source because our popup might not be the only
-        // source of "message" events. This is also why we can't set "once".
-        if (event.source === popup) {
+        // source of "message" events. This is also why we can't set "once". We
+        // also check the origin because we expect GitHub to redirect to the
+        // receiver page running on the same origin as this page; any other
+        // origin would be suspicious (or a misconfiguration).
+        if (event.source === popup && event.origin === window.location.origin) {
           resolve(event.data);
           abort();
         }


### PR DESCRIPTION
It would be suspicious if we received a GitHub code postMessage from any origin other than our own.

Part of https://github.com/lit/lit.dev/issues/533