### PR TITLE
Add Labs section. Fixes #557.

### DIFF
--- a/packages/lit-dev-content/site/docs/libraries/labs.md
+++ b/packages/lit-dev-content/site/docs/libraries/labs.md
@@ -1,14 +1,14 @@
 ---
-title: Labs projects
+title: Lit Labs
 eleventyNavigation:
-  key: Labs projects
+  key: Lit Labs
   parent: Related libraries
   order: 3
 ---
 
-The Lit team has a number of  <strong>Labs</strong> projects that can be used with Lit. These projects are in active development and may not be ready for production release: for example, they may be missing features, or subject to breaking changes. Labs projects are published under the `@lit-labs` npm scope.
+Lit Labs is an umbrella for projects related to Lit that aren't quite ready for production. These projects may be experimental or incomplete, and they're subject to breaking changes. Lit Labs projects are published under the `@lit-labs` npm scope.
 
-Current Labs projects include:
+Current Lit Labs projects include:
 
 * [Motion](https://github.com/lit/lit/blob/main/packages/labs/motion/README.md#lit-labsmotion). Animation helpers for Lit templates. The `@lit-labs/motion` package includes an `animate` directive for adding tweening animations when an element changes state, as well as an `AnimateController` class for programmatically controlling and coordinating animations. You can find a number of motion examples in the [Playground](https://lit.dev/playground/#sample=examples/motion-simple).
 * [React](https://github.com/lit/lit/tree/main/packages/labs/react#lit-labsreact). React integration helpers for custom elements and reactive controllers.
@@ -16,3 +16,4 @@ Current Labs projects include:
 * [SSR](https://github.com/lit/lit/tree/main/packages/labs/ssr#lit-labsssr). A package for server-side rendering Lit templates and components.
 * [Task](https://github.com/lit/lit/blob/main/packages/labs/task/README.md#lit-labstask). A reactive controller for handling asynchronous tasks.
 
+When a Lit Labs project is ready for production it may be migrated to a new location outside of Lit Labs. For example, the [`@lit/localize`](https://www.npmjs.com/package/@lit/localize) package started out as a Lit Labs project.

--- a/packages/lit-dev-content/site/docs/libraries/labs.md
+++ b/packages/lit-dev-content/site/docs/libraries/labs.md
@@ -1,0 +1,18 @@
+---
+title: Labs projects
+eleventyNavigation:
+  key: Labs projects
+  parent: Related libraries
+  order: 3
+---
+
+The Lit team has a number of  <strong>Labs</strong> projects that can be used with Lit. These projects are in active development and may not be ready for production release: for example, they may be missing features, or subject to breaking changes. Labs projects are published under the `@lit-labs` npm scope.
+
+Current Labs projects include:
+
+* [Motion](https://github.com/lit/lit/blob/main/packages/labs/motion/README.md#lit-labsmotion). Animation helpers for Lit templates. The `@lit-labs/motion` package includes an `animate` directive for adding tweening animations when an element changes state, as well as an `AnimateController` class for programmatically controlling and coordinating animations. You can find a number of motion examples in the [Playground](https://lit.dev/playground/#sample=examples/motion-simple).
+* [React](https://github.com/lit/lit/tree/main/packages/labs/react#lit-labsreact). React integration helpers for custom elements and reactive controllers.
+* [scoped-registry-mixin](https://github.com/lit/lit/tree/main/packages/labs/scoped-registry-mixin#lit-labsscoped-registry-mixin) Mixin for Lit that integrates with the speculative [Scoped CustomElementRegistry polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/scoped-custom-element-registry).
+* [SSR](https://github.com/lit/lit/tree/main/packages/labs/ssr#lit-labsssr). A package for server-side rendering Lit templates and components.
+* [Task](https://github.com/lit/lit/blob/main/packages/labs/task/README.md#lit-labstask). A reactive controller for handling asynchronous tasks.
+

--- a/packages/lit-dev-content/site/docs/libraries/labs.md
+++ b/packages/lit-dev-content/site/docs/libraries/labs.md
@@ -16,4 +16,4 @@ Current Lit Labs projects include:
 * [SSR](https://github.com/lit/lit/tree/main/packages/labs/ssr#lit-labsssr). A package for server-side rendering Lit templates and components.
 * [Task](https://github.com/lit/lit/blob/main/packages/labs/task/README.md#lit-labstask). A reactive controller for handling asynchronous tasks.
 
-When a Lit Labs project is ready for production it may be migrated to a new location outside of Lit Labs. For example, the [`@lit/localize`](https://www.npmjs.com/package/@lit/localize) package started out as a Lit Labs project.
+When a Lit Labs project is ready for production it may be migrated to a new location outside of Lit Labs. For example, the [`@lit/localize`](/docs/localization/overview/) package started out as a Lit Labs project.


### PR DESCRIPTION
Just a bare-bones section for now to aid in discoverability.

Linked to the Motion examples because we have quite a few there.

After we fix the Task example (#559) we might want to add a link to that, as well.