### PR TITLE
Restore target:esnext to samples tsconfig

### DIFF
--- a/packages/lit-dev-content/samples/tsconfig.json
+++ b/packages/lit-dev-content/samples/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "esnext",
     "rootDir": ".",
     "outDir": "js",
     "types": [],


### PR DESCRIPTION
Fixes a regression from https://github.com/lit/lit.dev/pull/560 where we accidentally dropped from `"target": "esnext"` to `"target": "es2020"` in the `tsconfig.json` for sample files (I made a common `tsconfig.base.json` which defaults to `es2020` but forgot to override that in the samples one). We want `esnext` output for samples because we want to emit standard static class fields (note that `@lit/ts-transformers` switches instance class field initializers to be constructor-initialized if they are decorated with `@property`, to avoid that incompatibility).

Current regressed state:
```js
import {LitElement, html} from 'lit';

class NameTag extends LitElement {
  render() {
    return html`Hello I'm ${this.name}.`;
  }
}
NameTag.properties = {
  name: {},
};
customElements.define('name-tag', NameTag);
```

With fix:
```js
import {LitElement, html} from 'lit';

class NameTag extends LitElement {
  static properties = {
    name: {},
  };

  render() {
    return html`Hello I'm ${this.name}.`;
  }
}
customElements.define('name-tag', NameTag);

```