### PR TITLE
Hide content in playground example drawer when closed

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-drawer.ts
+++ b/packages/lit-dev-content/src/components/litdev-drawer.ts
@@ -49,6 +49,10 @@ export class LitDevDrawer extends LitElement {
       overflow-y: hidden !important;
     }
 
+    :host(:not([open])) > #content {
+      display: none;
+    }
+
     #header {
       flex: 0 0 var(--litdev-drawer-header-height);
       box-sizing: border-box;


### PR DESCRIPTION
Otherwise the examples are still visible to screen readers and are keyboard focusable.