### PR TITLE
Show banner and version selector for old docs

### DIFF
--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -31,6 +31,7 @@ export default [
   {
     input: [
       'lib/components/copy-button.js',
+      'lib/components/litdev-banner.js',
       'lib/components/litdev-drawer.js',
       'lib/components/litdev-example.js',
       'lib/components/litdev-switchable-sample.js',

--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -32,6 +32,7 @@ export default [
     input: [
       'lib/components/copy-button.js',
       'lib/components/litdev-banner.js',
+      'lib/components/litdev-version-selector.js',
       'lib/components/litdev-drawer.js',
       'lib/components/litdev-example.js',
       'lib/components/litdev-switchable-sample.js',

--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -16,6 +16,10 @@
     {% inlinejs "global/initialize-typescript-attribute.js" %}
     {% inlinejs "global/mobile-drawer.js" %}
 
+    {% if showOldDocsBanner %}
+      {% inlinejs "components/litdev-banner.js" %}
+    {% endif %}
+
     <!-- We need to load litdev-search first because @lion/core loads the
          scoped-custom-element-registry polyfill. If MWC components are loaded
          first the polyfill currently throws errors. -->
@@ -56,6 +60,13 @@
     </mwc-drawer>
 
     {% include 'header.html' %}
+
+    {% if showOldDocsBanner %}
+      <litdev-banner>
+        You're viewing docs for an older version of Lit. Click
+        <a href="/docs/">here</a> for the latest version.
+      </litdev-banner>
+    {% endif %}
 
     <main {% if not page.url.includes('/docs/')
             and not page.url.includes('/playground/') %}

--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -26,6 +26,7 @@
     <script type="module" src="{{ site.baseurl }}/js/components/litdev-search.js"></script>
 
     <script type="module" src="{{ site.baseurl }}/js/global/mobile-nav.js"></script>
+    <script type="module" src="{{ site.baseurl }}/js/components/litdev-version-selector.js"></script>
 
     <!-- Preload common chunks we always need. Note <link rel="modulepreload">
          isn't yet supported in Firefox or Safari. -->
@@ -64,7 +65,8 @@
     {% if showOldDocsBanner %}
       <litdev-banner>
         You're viewing docs for an older version of Lit. Click
-        <a href="/docs/">here</a> for the latest version.
+        <a href="{{ versions[latestVersion].path }}">here</a>
+        for the latest version.
       </litdev-banner>
     {% endif %}
 

--- a/packages/lit-dev-content/site/_includes/site-nav.html
+++ b/packages/lit-dev-content/site/_includes/site-nav.html
@@ -1,5 +1,22 @@
 <li class="navItem{% if page.url.includes('/docs') %} active{% endif %}">
-   <a href="{{ site.baseurl }}/docs/">Documentation</a></li>
+   <a href="{{ site.baseurl }}/docs/">Documentation</a>
+
+   <litdev-version-selector>
+      <select name="version">
+        {% for version, versionData in versions %}
+          <option value="{{ key }}"
+            {% if version == selectedVersion %}
+              selected
+            {% else %}
+              data-path="{{ versionData.path }}/"
+            {% endif %}>
+            {{ versionData.label }}
+          </option>
+        {% endfor %}
+      </select>
+    </litdev-version-selector>
+</li>
+
 <li class="navItem{% if page.url.includes('/tutorial') %} active{% endif %}">
    <a href="{{ site.baseurl }}/tutorial/">Tutorial</a></li>
 <li class="navItem{% if page.url.includes('/playground') %} active{% endif %}">

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -627,6 +627,28 @@ td {
 }
 
 /* ------------------------------------
+ * Old version of docs banner
+ * ------------------------------------ */
+
+litdev-banner {
+  display: block;
+  background: #ffe133;
+  padding: 8px 24px;
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
+  position: sticky;
+  top: var(--header-nav-height);
+  z-index: 4;
+  box-sizing: border-box;
+}
+
+litdev-banner > a {
+  color: blue;
+  text-decoration: underline;
+}
+
+/* ------------------------------------
  * Narrow layouts
  * ------------------------------------ */
 

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -23,7 +23,7 @@ main {
   --docs-article-min-width: 30em;
   --docs-article-max-width: 49em;
   --docs-article-margin-horizontal: 3em;
-  --docs-margin-top: 2em;
+  --docs-margin-top: 32px;
 
   display: grid;
   grid-template-columns:
@@ -37,6 +37,7 @@ main {
   font-family: "Open Sans", sans-serif;
 
   background: var(--color-light-gray);
+  padding-top: var(--docs-margin-top);
 }
 
 /* ------------------------------------
@@ -51,7 +52,6 @@ article {
   font-size: 0.88889em; /* 16px / 18px basis */
   color: #3e3e3e;
   background: white;
-  margin: var(--docs-margin-top) 0;
   box-shadow: 0 0 5px 0 rgb(0 0 0 / 10%);
   margin-right: 2em;
   /* For when linking to #content via nav bypass. */
@@ -431,7 +431,7 @@ td {
 
 #docsNavWrapper {
   position: sticky;
-  top: calc(var(--header-height) + var(--docs-margin-top) - 0.5em);
+  top: calc(var(--header-height) + var(--docs-margin-top));
   margin-bottom: 1.5em;
   height: calc(100vh - var(--header-height));
   display: flex;
@@ -454,7 +454,7 @@ td {
 #docsNav > ol {
   list-style: none;
   padding-left: 0;
-  margin-top: 0.5em;
+  margin-top: 0;
   padding-bottom: 1.5em;
 }
 #docsNav > ol > li:not(:first-of-type) {
@@ -545,9 +545,9 @@ td {
 }
 
 #rhsToc {
-  padding: calc(var(--docs-margin-top) + 0.3em) 1em 0 0;
+  padding: 10px 1em 0 0;
   position: sticky;
-  top: var(--header-height);
+  top: calc(var(--header-height) + var(--docs-margin-top));
 }
 
 /* "Contents" heading */
@@ -699,6 +699,7 @@ td {
   main {
     /* Remove grid */
     display: block;
+    padding-top: 0;
   }
   #docsNavWrapper {
     display: none;

--- a/packages/lit-dev-content/site/css/global.css
+++ b/packages/lit-dev-content/site/css/global.css
@@ -10,7 +10,14 @@
 
 html {
   font-size: 18px;
-  --header-height: 60px;
+  --header-nav-height: 60px;
+  /* The litdev-banner component will automatically update this variable if
+     there is a banner present. */
+  --banner-height: 0px;
+  /* It's helpful to consider the banner part of the header, because the
+     --header-height variable is used in many places to determine where the main
+     content begins (e.g. other sticky elements, scroll-margin-top). */
+  --header-height: calc(var(--header-nav-height) + var(--banner-height));
   --footer-top-height: 12rem;
   --footer-bottom-height: 6rem;
   --content-max-width: 76rem;

--- a/packages/lit-dev-content/site/css/global.css
+++ b/packages/lit-dev-content/site/css/global.css
@@ -7,6 +7,7 @@
 @import url('./colors.css');
 @import url('./codemirror.css');
 @import url('./code.css');
+@import url('./version-selector.css');
 
 html {
   font-size: 18px;

--- a/packages/lit-dev-content/site/css/header.css
+++ b/packages/lit-dev-content/site/css/header.css
@@ -1,7 +1,7 @@
 header {
   position: sticky;
   top: 0;
-  height: var(--header-height);
+  height: var(--header-nav-height);
   /* CodeMirrors have a very high z-index for some reason. */
   z-index: 4;
   background: white;

--- a/packages/lit-dev-content/site/css/mods.css
+++ b/packages/lit-dev-content/site/css/mods.css
@@ -32,3 +32,7 @@ litdev-playground-share-button {
 .gists #shareButton {
   display: none;
 }
+
+body:not(.old-docs) litdev-version-selector {
+  display: none;
+}

--- a/packages/lit-dev-content/site/css/version-selector.css
+++ b/packages/lit-dev-content/site/css/version-selector.css
@@ -1,0 +1,23 @@
+litdev-version-selector > select {
+  background: #d5d5d5aa;
+  border-radius: 8px;
+  border: none;
+  color: #636363;
+  cursor: pointer;
+  font-family: 'Manrope', sans-serif;
+  font-weight: 600;
+  margin-left: -3px;
+  padding: 2px 3px;
+}
+
+litdev-version-selector > select:hover,
+litdev-version-selector > select:focus,
+.active > litdev-version-selector > select {
+  color: var(--color-blue);
+}
+
+#mobileSiteNav litdev-version-selector > select {
+  background: #0000004f;
+  color: #fff;
+  margin-left: 5px;
+}

--- a/packages/lit-dev-content/site/docs/v1/v1.json
+++ b/packages/lit-dev-content/site/docs/v1/v1.json
@@ -1,3 +1,4 @@
 {
-  "collection": "docs-v1"
+  "collection": "docs-v1",
+  "showOldDocsBanner": true
 }

--- a/packages/lit-dev-content/site/docs/v1/v1.json
+++ b/packages/lit-dev-content/site/docs/v1/v1.json
@@ -1,4 +1,5 @@
 {
   "collection": "docs-v1",
+  "selectedVersion": "v1",
   "showOldDocsBanner": true
 }

--- a/packages/lit-dev-content/site/site.json
+++ b/packages/lit-dev-content/site/site.json
@@ -1,0 +1,14 @@
+{
+  "selectedVersion": "v2",
+  "latestVersion": "v2",
+  "versions": {
+    "v1": {
+      "path": "/docs/v1/",
+      "label": "v1"
+    },
+    "v2": {
+      "path": "/docs/",
+      "label": "v2"
+    }
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-banner.ts
+++ b/packages/lit-dev-content/src/components/litdev-banner.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * A sticky banner that displays underneath the main header.
+ *
+ * The purpose of this component is to synchronize the --banner-height CSS
+ * custom property with the current height of the banner.
+ *
+ * The height of the banner is dynamic because in narrow layouts its content
+ * might take up multiple lines.
+ *
+ * We need to know the height of the banner because it has position sticky, and
+ * other sticky elements beneath it (e.g. the docs nav columns) need to account
+ * for its height for their own positioning. We also need to account for it in
+ * scroll-margin-top, so that headings don't get hidden under the banner when
+ * navigating to an anchor.
+ *
+ * Note this component is inlined so that the --banner-height property gets set
+ * as early as possible to minimize layout shift. It should not depend on lit or
+ * other dependencies to keep its size minimal.
+ */
+export class LitDevBanner extends HTMLElement {
+  private _observer: ResizeObserver | undefined;
+
+  connectedCallback() {
+    this._observer = new ResizeObserver((entries) => {
+      const size = entries.find((entry) => entry.target === this)
+        ?.borderBoxSize[0];
+      if (size) {
+        document.documentElement.style.setProperty(
+          '--banner-height',
+          `${size.blockSize}px`
+        );
+      }
+    });
+    this._observer.observe(this);
+  }
+
+  disconnectedCallback() {
+    this._observer?.disconnect();
+    this._observer = undefined;
+  }
+}
+
+customElements.define('litdev-banner', LitDevBanner);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'litdev-banner': LitDevBanner;
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-version-selector.ts
+++ b/packages/lit-dev-content/src/components/litdev-version-selector.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {addModsParameterToUrlIfNeeded} from '../mods.js';
+
+/**
+ * Jumps between different versions of the Lit docs.
+ */
+@customElement('litdev-version-selector')
+export class LitDevVersionSelector extends LitElement {
+  override render() {
+    return html`<slot @change=${this._onSelect}></slot>`;
+  }
+
+  private _onSelect(event: Event) {
+    const select = event.target as HTMLSelectElement;
+    const path = select.item(select.selectedIndex)?.dataset['path'];
+    if (path) {
+      document.location.href = addModsParameterToUrlIfNeeded(path);
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'litdev-version-selector': LitDevVersionSelector;
+  }
+}


### PR DESCRIPTION
Adds a "You're viewing docs for an older version of Lit" banner to the top of the `/v1/` docs, and a Version selector in the top-left.

Version selector is hidden behind the `?mods=old-docs` mod for now.

Also fixes a CSS bug where the margin above the LHS nav was wrong when the content was too short (affected the first page of the old docs, and also the Community page of the new docs).

<!--
<img src="https://user-images.githubusercontent.com/48894/144485734-28b22b8b-0f76-449a-8f10-b9c08503ccc1.png" width="600px">
-->

<img src="https://user-images.githubusercontent.com/48894/144511348-4f3306e4-92b3-4886-b72e-066f33fb2f32.png" width="800px">

Currently when we switch versions, we always jump to the first page of the docs. In a follow up PR, I'll make it jump to the more specific matching page.

Plan:

- [X] Serve old article content
- [X] Serve old API content
- [X] Add a "these are old docs" banner  (this PR)
- [X] Add a version switcher  (this PR)
- [ ] Make switching versions bring you to the matching page
- [ ] Set up redirects by checking the `Host` header
- [ ] Point old domains at new Cloud project