### PR TITLE
Go to the closest matching page when switching docs versions

### DIFF
--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -2,9 +2,12 @@
   {
     "slug": "LitElement",
     "title": "LitElement",
+    "versionLinks": {
+      "v1": "api/lit-element/LitElement/"
+    },
     "items": [
       {
-        "id": 709,
+        "id": 3319,
         "name": "LitElement",
         "kind": 128,
         "kindString": "Class",
@@ -15,7 +18,7 @@
         },
         "children": [
           {
-            "id": 757,
+            "id": 3367,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -23,14 +26,14 @@
             "children": [],
             "signatures": [
               {
-                "id": 758,
+                "id": 3368,
                 "name": "new LitElement",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 709,
+                  "id": 3319,
                   "name": "LitElement",
                   "location": {
                     "page": "LitElement",
@@ -39,14 +42,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1700,
+                  "id": 4310,
                   "name": "ReactiveElement.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1699,
+              "id": 4309,
               "name": "ReactiveElement.constructor",
               "location": {
                 "page": "ReactiveElement",
@@ -68,7 +71,7 @@
             }
           },
           {
-            "id": 774,
+            "id": 3384,
             "name": "hasUpdated",
             "kind": 1024,
             "kindString": "Property",
@@ -90,7 +93,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1705,
+              "id": 4315,
               "name": "ReactiveElement.hasUpdated",
               "location": {
                 "page": "ReactiveElement",
@@ -112,7 +115,7 @@
             }
           },
           {
-            "id": 773,
+            "id": 3383,
             "name": "isUpdatePending",
             "kind": 1024,
             "kindString": "Property",
@@ -134,7 +137,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1704,
+              "id": 4314,
               "name": "ReactiveElement.isUpdatePending",
               "location": {
                 "page": "ReactiveElement",
@@ -156,7 +159,7 @@
             }
           },
           {
-            "id": 759,
+            "id": 3369,
             "name": "renderOptions",
             "kind": 1024,
             "kindString": "Property",
@@ -176,7 +179,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2586,
+              "id": 5196,
               "name": "RenderOptions",
               "location": {
                 "page": "LitElement",
@@ -198,7 +201,7 @@
             }
           },
           {
-            "id": 772,
+            "id": 3382,
             "name": "renderRoot",
             "kind": 1024,
             "kindString": "Property",
@@ -239,7 +242,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1701,
+              "id": 4311,
               "name": "ReactiveElement.renderRoot",
               "location": {
                 "page": "ReactiveElement",
@@ -261,7 +264,7 @@
             }
           },
           {
-            "id": 717,
+            "id": 3327,
             "name": "disableWarning",
             "kind": 1024,
             "kindString": "Property",
@@ -292,14 +295,14 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 718,
+                "id": 3328,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 719,
+                    "id": 3329,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -320,14 +323,14 @@
                     },
                     "parameters": [
                       {
-                        "id": 720,
+                        "id": 3330,
                         "name": "warningKind",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1645,
+                          "id": 4255,
                           "name": "WarningKind",
                           "location": {
                             "page": "misc",
@@ -346,7 +349,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1656,
+              "id": 4266,
               "name": "ReactiveElement.disableWarning",
               "location": {
                 "page": "ReactiveElement",
@@ -368,7 +371,7 @@
             }
           },
           {
-            "id": 725,
+            "id": 3335,
             "name": "elementProperties",
             "kind": 1024,
             "kindString": "Property",
@@ -400,7 +403,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1665,
+              "id": 4275,
               "name": "ReactiveElement.elementProperties",
               "location": {
                 "page": "ReactiveElement",
@@ -422,7 +425,7 @@
             }
           },
           {
-            "id": 727,
+            "id": 3337,
             "name": "elementStyles",
             "kind": 1024,
             "kindString": "Property",
@@ -452,7 +455,7 @@
               "type": "array",
               "elementType": {
                 "type": "reference",
-                "id": 2526,
+                "id": 5136,
                 "name": "CSSResultOrNative",
                 "location": {
                   "page": "styles",
@@ -462,7 +465,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1667,
+              "id": 4277,
               "name": "ReactiveElement.elementStyles",
               "location": {
                 "page": "ReactiveElement",
@@ -484,7 +487,7 @@
             }
           },
           {
-            "id": 713,
+            "id": 3323,
             "name": "enableWarning",
             "kind": 1024,
             "kindString": "Property",
@@ -515,14 +518,14 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 714,
+                "id": 3324,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 715,
+                    "id": 3325,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -543,14 +546,14 @@
                     },
                     "parameters": [
                       {
-                        "id": 716,
+                        "id": 3326,
                         "name": "warningKind",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1645,
+                          "id": 4255,
                           "name": "WarningKind",
                           "location": {
                             "page": "misc",
@@ -569,7 +572,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1652,
+              "id": 4262,
               "name": "ReactiveElement.enableWarning",
               "location": {
                 "page": "ReactiveElement",
@@ -591,7 +594,7 @@
             }
           },
           {
-            "id": 712,
+            "id": 3322,
             "name": "enabledWarnings",
             "kind": 1024,
             "kindString": "Property",
@@ -623,7 +626,7 @@
               "type": "array",
               "elementType": {
                 "type": "reference",
-                "id": 1645,
+                "id": 4255,
                 "name": "WarningKind",
                 "location": {
                   "page": "misc",
@@ -633,7 +636,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1651,
+              "id": 4261,
               "name": "ReactiveElement.enabledWarnings",
               "location": {
                 "page": "ReactiveElement",
@@ -655,7 +658,7 @@
             }
           },
           {
-            "id": 710,
+            "id": 3320,
             "name": "finalized",
             "kind": 1024,
             "kindString": "Property",
@@ -683,7 +686,7 @@
             },
             "overwrites": {
               "type": "reference",
-              "id": 1698,
+              "id": 4308,
               "name": "ReactiveElement.finalized",
               "location": {
                 "page": "ReactiveElement",
@@ -705,7 +708,7 @@
             }
           },
           {
-            "id": 726,
+            "id": 3336,
             "name": "properties",
             "kind": 1024,
             "kindString": "Property",
@@ -734,7 +737,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 1631,
+              "id": 4241,
               "name": "PropertyDeclarations",
               "location": {
                 "page": "ReactiveElement",
@@ -743,7 +746,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1666,
+              "id": 4276,
               "name": "ReactiveElement.properties",
               "location": {
                 "page": "ReactiveElement",
@@ -765,7 +768,7 @@
             }
           },
           {
-            "id": 753,
+            "id": 3363,
             "name": "shadowRootOptions",
             "kind": 1024,
             "kindString": "Property",
@@ -801,7 +804,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1693,
+              "id": 4303,
               "name": "ReactiveElement.shadowRootOptions",
               "location": {
                 "page": "ReactiveElement",
@@ -823,7 +826,7 @@
             }
           },
           {
-            "id": 728,
+            "id": 3338,
             "name": "styles",
             "kind": 1024,
             "kindString": "Property",
@@ -852,7 +855,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2528,
+              "id": 5138,
               "name": "CSSResultGroup",
               "location": {
                 "page": "styles",
@@ -861,7 +864,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 1668,
+              "id": 4278,
               "name": "ReactiveElement.styles",
               "location": {
                 "page": "ReactiveElement",
@@ -883,7 +886,7 @@
             }
           },
           {
-            "id": 801,
+            "id": 3411,
             "name": "updateComplete",
             "kind": 262144,
             "kindString": "Accessor",
@@ -915,7 +918,7 @@
             },
             "getSignature": [
               {
-                "id": 802,
+                "id": 3412,
                 "name": "updateComplete",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -945,7 +948,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1745,
+              "id": 4355,
               "name": "ReactiveElement.updateComplete",
               "location": {
                 "page": "ReactiveElement",
@@ -967,7 +970,7 @@
             }
           },
           {
-            "id": 729,
+            "id": 3339,
             "name": "observedAttributes",
             "kind": 262144,
             "kindString": "Accessor",
@@ -1002,7 +1005,7 @@
             },
             "getSignature": [
               {
-                "id": 730,
+                "id": 3340,
                 "name": "observedAttributes",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -1031,7 +1034,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1669,
+              "id": 4279,
               "name": "ReactiveElement.observedAttributes",
               "location": {
                 "page": "ReactiveElement",
@@ -1053,7 +1056,7 @@
             }
           },
           {
-            "id": 775,
+            "id": 3385,
             "name": "addController",
             "kind": 2048,
             "kindString": "Method",
@@ -1070,7 +1073,7 @@
             ],
             "signatures": [
               {
-                "id": 776,
+                "id": 3386,
                 "name": "addController",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1078,14 +1081,14 @@
                 "comment": {},
                 "parameters": [
                   {
-                    "id": 777,
+                    "id": 3387,
                     "name": "controller",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1588,
+                      "id": 4198,
                       "name": "ReactiveController",
                       "location": {
                         "page": "controllers",
@@ -1100,14 +1103,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1710,
+                  "id": 4320,
                   "name": "ReactiveElement.addController"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1709,
+              "id": 4319,
               "name": "ReactiveElement.addController",
               "location": {
                 "page": "ReactiveElement",
@@ -1129,7 +1132,7 @@
             }
           },
           {
-            "id": 784,
+            "id": 3394,
             "name": "attributeChangedCallback",
             "kind": 2048,
             "kindString": "Method",
@@ -1149,7 +1152,7 @@
             ],
             "signatures": [
               {
-                "id": 785,
+                "id": 3395,
                 "name": "attributeChangedCallback",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1159,7 +1162,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 786,
+                    "id": 3396,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1170,7 +1173,7 @@
                     }
                   },
                   {
-                    "id": 787,
+                    "id": 3397,
                     "name": "_old",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1190,7 +1193,7 @@
                     }
                   },
                   {
-                    "id": 788,
+                    "id": 3398,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1216,14 +1219,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1726,
+                  "id": 4336,
                   "name": "ReactiveElement.attributeChangedCallback"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1725,
+              "id": 4335,
               "name": "ReactiveElement.attributeChangedCallback",
               "location": {
                 "page": "ReactiveElement",
@@ -1245,7 +1248,7 @@
             }
           },
           {
-            "id": 766,
+            "id": 3376,
             "name": "connectedCallback",
             "kind": 2048,
             "kindString": "Method",
@@ -1262,7 +1265,7 @@
             ],
             "signatures": [
               {
-                "id": 767,
+                "id": 3377,
                 "name": "connectedCallback",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1274,14 +1277,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 1719,
+                  "id": 4329,
                   "name": "ReactiveElement.connectedCallback"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 1718,
+              "id": 4328,
               "name": "ReactiveElement.connectedCallback",
               "location": {
                 "page": "ReactiveElement",
@@ -1303,7 +1306,7 @@
             }
           },
           {
-            "id": 761,
+            "id": 3371,
             "name": "createRenderRoot",
             "kind": 2048,
             "kindString": "Method",
@@ -1322,7 +1325,7 @@
             ],
             "signatures": [
               {
-                "id": 762,
+                "id": 3372,
                 "name": "createRenderRoot",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1349,14 +1352,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 1717,
+                  "id": 4327,
                   "name": "ReactiveElement.createRenderRoot"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 1716,
+              "id": 4326,
               "name": "ReactiveElement.createRenderRoot",
               "location": {
                 "page": "ReactiveElement",
@@ -1378,7 +1381,7 @@
             }
           },
           {
-            "id": 768,
+            "id": 3378,
             "name": "disconnectedCallback",
             "kind": 2048,
             "kindString": "Method",
@@ -1395,7 +1398,7 @@
             ],
             "signatures": [
               {
-                "id": 769,
+                "id": 3379,
                 "name": "disconnectedCallback",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1407,14 +1410,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 1724,
+                  "id": 4334,
                   "name": "ReactiveElement.disconnectedCallback"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 1723,
+              "id": 4333,
               "name": "ReactiveElement.disconnectedCallback",
               "location": {
                 "page": "ReactiveElement",
@@ -1436,7 +1439,7 @@
             }
           },
           {
-            "id": 781,
+            "id": 3391,
             "name": "enableUpdating",
             "kind": 2048,
             "kindString": "Method",
@@ -1458,7 +1461,7 @@
             ],
             "signatures": [
               {
-                "id": 782,
+                "id": 3392,
                 "name": "enableUpdating",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1468,7 +1471,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 783,
+                    "id": 3393,
                     "name": "_requestedUpdate",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1485,14 +1488,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1721,
+                  "id": 4331,
                   "name": "ReactiveElement.enableUpdating"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1720,
+              "id": 4330,
               "name": "ReactiveElement.enableUpdating",
               "location": {
                 "page": "ReactiveElement",
@@ -1514,7 +1517,7 @@
             }
           },
           {
-            "id": 811,
+            "id": 3421,
             "name": "firstUpdated",
             "kind": 2048,
             "kindString": "Method",
@@ -1537,7 +1540,7 @@
             ],
             "signatures": [
               {
-                "id": 812,
+                "id": 3422,
                 "name": "firstUpdated",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1548,7 +1551,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 813,
+                    "id": 3423,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1591,14 +1594,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1759,
+                  "id": 4369,
                   "name": "ReactiveElement.firstUpdated"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1758,
+              "id": 4368,
               "name": "ReactiveElement.firstUpdated",
               "location": {
                 "page": "ReactiveElement",
@@ -1620,7 +1623,7 @@
             }
           },
           {
-            "id": 803,
+            "id": 3413,
             "name": "getUpdateComplete",
             "kind": 2048,
             "kindString": "Method",
@@ -1644,7 +1647,7 @@
             ],
             "signatures": [
               {
-                "id": 804,
+                "id": 3414,
                 "name": "getUpdateComplete",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1666,14 +1669,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1748,
+                  "id": 4358,
                   "name": "ReactiveElement.getUpdateComplete"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1747,
+              "id": 4357,
               "name": "ReactiveElement.getUpdateComplete",
               "location": {
                 "page": "ReactiveElement",
@@ -1695,7 +1698,7 @@
             }
           },
           {
-            "id": 796,
+            "id": 3406,
             "name": "performUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -1718,7 +1721,7 @@
             ],
             "signatures": [
               {
-                "id": 797,
+                "id": 3407,
                 "name": "performUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1748,14 +1751,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1740,
+                  "id": 4350,
                   "name": "ReactiveElement.performUpdate"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1739,
+              "id": 4349,
               "name": "ReactiveElement.performUpdate",
               "location": {
                 "page": "ReactiveElement",
@@ -1777,7 +1780,7 @@
             }
           },
           {
-            "id": 778,
+            "id": 3388,
             "name": "removeController",
             "kind": 2048,
             "kindString": "Method",
@@ -1794,7 +1797,7 @@
             ],
             "signatures": [
               {
-                "id": 779,
+                "id": 3389,
                 "name": "removeController",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1802,14 +1805,14 @@
                 "comment": {},
                 "parameters": [
                   {
-                    "id": 780,
+                    "id": 3390,
                     "name": "controller",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1588,
+                      "id": 4198,
                       "name": "ReactiveController",
                       "location": {
                         "page": "controllers",
@@ -1824,14 +1827,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1713,
+                  "id": 4323,
                   "name": "ReactiveElement.removeController"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1712,
+              "id": 4322,
               "name": "ReactiveElement.removeController",
               "location": {
                 "page": "ReactiveElement",
@@ -1853,7 +1856,7 @@
             }
           },
           {
-            "id": 770,
+            "id": 3380,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -1875,7 +1878,7 @@
             ],
             "signatures": [
               {
-                "id": 771,
+                "id": 3381,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1904,7 +1907,7 @@
             }
           },
           {
-            "id": 789,
+            "id": 3399,
             "name": "requestUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -1924,7 +1927,7 @@
             ],
             "signatures": [
               {
-                "id": 790,
+                "id": 3400,
                 "name": "requestUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1934,7 +1937,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 791,
+                    "id": 3401,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1950,7 +1953,7 @@
                     }
                   },
                   {
-                    "id": 792,
+                    "id": 3402,
                     "name": "oldValue",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1966,7 +1969,7 @@
                     }
                   },
                   {
-                    "id": 793,
+                    "id": 3403,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -1978,7 +1981,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -2003,14 +2006,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1732,
+                  "id": 4342,
                   "name": "ReactiveElement.requestUpdate"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1731,
+              "id": 4341,
               "name": "ReactiveElement.requestUpdate",
               "location": {
                 "page": "ReactiveElement",
@@ -2032,7 +2035,7 @@
             }
           },
           {
-            "id": 794,
+            "id": 3404,
             "name": "scheduleUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -2055,7 +2058,7 @@
             ],
             "signatures": [
               {
-                "id": 795,
+                "id": 3405,
                 "name": "scheduleUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2085,14 +2088,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1738,
+                  "id": 4348,
                   "name": "ReactiveElement.scheduleUpdate"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1737,
+              "id": 4347,
               "name": "ReactiveElement.scheduleUpdate",
               "location": {
                 "page": "ReactiveElement",
@@ -2114,7 +2117,7 @@
             }
           },
           {
-            "id": 805,
+            "id": 3415,
             "name": "shouldUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -2136,7 +2139,7 @@
             ],
             "signatures": [
               {
-                "id": 806,
+                "id": 3416,
                 "name": "shouldUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2146,7 +2149,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 807,
+                    "id": 3417,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2189,14 +2192,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1750,
+                  "id": 4360,
                   "name": "ReactiveElement.shouldUpdate"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1749,
+              "id": 4359,
               "name": "ReactiveElement.shouldUpdate",
               "location": {
                 "page": "ReactiveElement",
@@ -2218,7 +2221,7 @@
             }
           },
           {
-            "id": 763,
+            "id": 3373,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -2240,7 +2243,7 @@
             ],
             "signatures": [
               {
-                "id": 764,
+                "id": 3374,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2250,7 +2253,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 765,
+                    "id": 3375,
                     "name": "changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2293,14 +2296,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 1753,
+                  "id": 4363,
                   "name": "ReactiveElement.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 1752,
+              "id": 4362,
               "name": "ReactiveElement.update",
               "location": {
                 "page": "ReactiveElement",
@@ -2322,7 +2325,7 @@
             }
           },
           {
-            "id": 808,
+            "id": 3418,
             "name": "updated",
             "kind": 2048,
             "kindString": "Method",
@@ -2345,7 +2348,7 @@
             ],
             "signatures": [
               {
-                "id": 809,
+                "id": 3419,
                 "name": "updated",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2356,7 +2359,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 810,
+                    "id": 3420,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2399,14 +2402,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1756,
+                  "id": 4366,
                   "name": "ReactiveElement.updated"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1755,
+              "id": 4365,
               "name": "ReactiveElement.updated",
               "location": {
                 "page": "ReactiveElement",
@@ -2428,7 +2431,7 @@
             }
           },
           {
-            "id": 798,
+            "id": 3408,
             "name": "willUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -2445,7 +2448,7 @@
             ],
             "signatures": [
               {
-                "id": 799,
+                "id": 3409,
                 "name": "willUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2453,7 +2456,7 @@
                 "comment": {},
                 "parameters": [
                   {
-                    "id": 800,
+                    "id": 3410,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2493,14 +2496,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1742,
+                  "id": 4352,
                   "name": "ReactiveElement.willUpdate"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1741,
+              "id": 4351,
               "name": "ReactiveElement.willUpdate",
               "location": {
                 "page": "ReactiveElement",
@@ -2522,7 +2525,7 @@
             }
           },
           {
-            "id": 721,
+            "id": 3331,
             "name": "addInitializer",
             "kind": 2048,
             "kindString": "Method",
@@ -2541,7 +2544,7 @@
             ],
             "signatures": [
               {
-                "id": 722,
+                "id": 3332,
                 "name": "addInitializer",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2556,14 +2559,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 723,
+                    "id": 3333,
                     "name": "initializer",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1646,
+                      "id": 4256,
                       "name": "Initializer",
                       "location": {
                         "page": "misc",
@@ -2578,14 +2581,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1661,
+                  "id": 4271,
                   "name": "ReactiveElement.addInitializer"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1660,
+              "id": 4270,
               "name": "ReactiveElement.addInitializer",
               "location": {
                 "page": "ReactiveElement",
@@ -2607,7 +2610,7 @@
             }
           },
           {
-            "id": 731,
+            "id": 3341,
             "name": "createProperty",
             "kind": 2048,
             "kindString": "Method",
@@ -2636,7 +2639,7 @@
             ],
             "signatures": [
               {
-                "id": 732,
+                "id": 3342,
                 "name": "createProperty",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2653,7 +2656,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 733,
+                    "id": 3343,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2664,7 +2667,7 @@
                     }
                   },
                   {
-                    "id": 734,
+                    "id": 3344,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2673,7 +2676,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -2698,14 +2701,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1672,
+                  "id": 4282,
                   "name": "ReactiveElement.createProperty"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1671,
+              "id": 4281,
               "name": "ReactiveElement.createProperty",
               "location": {
                 "page": "ReactiveElement",
@@ -2727,7 +2730,7 @@
             }
           },
           {
-            "id": 751,
+            "id": 3361,
             "name": "finalize",
             "kind": 2048,
             "kindString": "Method",
@@ -2756,7 +2759,7 @@
             ],
             "signatures": [
               {
-                "id": 752,
+                "id": 3362,
                 "name": "finalize",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2776,14 +2779,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1692,
+                  "id": 4302,
                   "name": "ReactiveElement.finalize"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1691,
+              "id": 4301,
               "name": "ReactiveElement.finalize",
               "location": {
                 "page": "ReactiveElement",
@@ -2805,7 +2808,7 @@
             }
           },
           {
-            "id": 754,
+            "id": 3364,
             "name": "finalizeStyles",
             "kind": 2048,
             "kindString": "Method",
@@ -2835,7 +2838,7 @@
             ],
             "signatures": [
               {
-                "id": 755,
+                "id": 3365,
                 "name": "finalizeStyles",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2852,7 +2855,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 756,
+                    "id": 3366,
                     "name": "styles",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2861,7 +2864,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 2528,
+                      "id": 5138,
                       "name": "CSSResultGroup",
                       "location": {
                         "page": "styles",
@@ -2874,7 +2877,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 2526,
+                    "id": 5136,
                     "name": "CSSResultOrNative",
                     "location": {
                       "page": "styles",
@@ -2884,14 +2887,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1695,
+                  "id": 4305,
                   "name": "ReactiveElement.finalizeStyles"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1694,
+              "id": 4304,
               "name": "ReactiveElement.finalizeStyles",
               "location": {
                 "page": "ReactiveElement",
@@ -2913,7 +2916,7 @@
             }
           },
           {
-            "id": 735,
+            "id": 3345,
             "name": "getPropertyDescriptor",
             "kind": 2048,
             "kindString": "Method",
@@ -2943,7 +2946,7 @@
             ],
             "signatures": [
               {
-                "id": 736,
+                "id": 3346,
                 "name": "getPropertyDescriptor",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -2960,7 +2963,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 737,
+                    "id": 3347,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2971,7 +2974,7 @@
                     }
                   },
                   {
-                    "id": 738,
+                    "id": 3348,
                     "name": "key",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2991,14 +2994,14 @@
                     }
                   },
                   {
-                    "id": 739,
+                    "id": 3349,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -3020,14 +3023,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 740,
+                    "id": 3350,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "children": [
                       {
-                        "id": 746,
+                        "id": 3356,
                         "name": "configurable",
                         "kind": 1024,
                         "kindString": "Property",
@@ -3045,7 +3048,7 @@
                         }
                       },
                       {
-                        "id": 747,
+                        "id": 3357,
                         "name": "enumerable",
                         "kind": 1024,
                         "kindString": "Property",
@@ -3063,14 +3066,14 @@
                         }
                       },
                       {
-                        "id": 741,
+                        "id": 3351,
                         "name": "get",
                         "kind": 2048,
                         "kindString": "Method",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 742,
+                            "id": 3352,
                             "name": "get",
                             "kind": 4096,
                             "kindString": "Call signature",
@@ -3083,21 +3086,21 @@
                         ]
                       },
                       {
-                        "id": 743,
+                        "id": 3353,
                         "name": "set",
                         "kind": 2048,
                         "kindString": "Method",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 744,
+                            "id": 3354,
                             "name": "set",
                             "kind": 4096,
                             "kindString": "Call signature",
                             "flags": {},
                             "parameters": [
                               {
-                                "id": 745,
+                                "id": 3355,
                                 "name": "value",
                                 "kind": 32768,
                                 "kindString": "Parameter",
@@ -3121,16 +3124,16 @@
                         "title": "Properties",
                         "kind": 1024,
                         "children": [
-                          746,
-                          747
+                          3356,
+                          3357
                         ]
                       },
                       {
                         "title": "Methods",
                         "kind": 2048,
                         "children": [
-                          741,
-                          743
+                          3351,
+                          3353
                         ]
                       }
                     ]
@@ -3138,14 +3141,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1676,
+                  "id": 4286,
                   "name": "ReactiveElement.getPropertyDescriptor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1675,
+              "id": 4285,
               "name": "ReactiveElement.getPropertyDescriptor",
               "location": {
                 "page": "ReactiveElement",
@@ -3167,7 +3170,7 @@
             }
           },
           {
-            "id": 748,
+            "id": 3358,
             "name": "getPropertyOptions",
             "kind": 2048,
             "kindString": "Method",
@@ -3201,7 +3204,7 @@
             ],
             "signatures": [
               {
-                "id": 749,
+                "id": 3359,
                 "name": "getPropertyOptions",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -3222,7 +3225,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 750,
+                    "id": 3360,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -3235,7 +3238,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 1618,
+                  "id": 4228,
                   "typeArguments": [
                     {
                       "type": "intrinsic",
@@ -3254,14 +3257,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1689,
+                  "id": 4299,
                   "name": "ReactiveElement.getPropertyOptions"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 1688,
+              "id": 4298,
               "name": "ReactiveElement.getPropertyOptions",
               "location": {
                 "page": "ReactiveElement",
@@ -3288,501 +3291,501 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              757
+              3367
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              1096,
-              1097,
-              1098,
-              1099,
-              1100,
-              1101,
-              1102,
-              1103,
-              1104,
-              1105,
-              1106,
-              1107,
-              1108,
-              1109,
-              1110,
-              1111,
-              1112,
-              1113,
-              760,
-              814,
-              815,
-              1117,
-              1118,
-              1119,
-              1120,
-              1121,
-              1122,
-              1123,
-              1124,
-              1125,
-              1126,
-              1127,
-              1128,
-              1129,
-              1130,
-              1131,
-              1132,
-              1133,
-              1134,
-              1135,
-              1136,
-              1137,
-              1138,
-              1139,
-              1140,
-              1141,
-              1142,
-              1143,
-              1144,
-              1145,
-              1146,
-              1147,
-              1148,
-              1149,
-              1150,
-              1151,
-              1152,
-              1207,
-              859,
-              816,
-              1034,
-              1174,
-              1035,
-              1175,
-              860,
-              861,
-              862,
-              863,
-              864,
-              865,
-              1221,
-              1570,
-              817,
-              818,
-              1222,
-              1036,
-              1176,
-              774,
-              819,
-              866,
-              1171,
-              820,
-              1223,
-              1037,
-              1224,
-              773,
-              821,
-              1038,
-              1177,
-              867,
-              868,
-              1172,
-              1039,
-              1040,
-              1041,
-              1042,
-              1571,
-              822,
-              823,
-              824,
-              825,
-              826,
-              1225,
-              1229,
-              1233,
-              1237,
-              1241,
-              1245,
-              1249,
-              1253,
-              1257,
-              1261,
-              1265,
-              1269,
-              1273,
-              1208,
-              1277,
-              1212,
-              1281,
-              1285,
-              1289,
-              1293,
-              1297,
-              1301,
-              1305,
-              1309,
-              1313,
-              1317,
-              1321,
-              1325,
-              1326,
-              1330,
-              869,
-              873,
-              1334,
-              1338,
-              1342,
-              1346,
-              1350,
-              1354,
-              1358,
-              1362,
-              1366,
-              1370,
-              1374,
-              1378,
-              1382,
-              1386,
-              1390,
-              1394,
-              1398,
-              1402,
-              1216,
-              1406,
-              1410,
-              1414,
-              1418,
-              1422,
-              1426,
-              1430,
-              1434,
-              1438,
-              1442,
-              1446,
-              1450,
-              1454,
-              1458,
-              1462,
-              1466,
-              1470,
-              1474,
-              1478,
-              1482,
-              1486,
-              1490,
-              1494,
-              1498,
-              1502,
-              1506,
-              1510,
-              1514,
-              1518,
-              1522,
-              1526,
-              1530,
-              1534,
-              1538,
-              1542,
-              1546,
-              1550,
-              1554,
-              1558,
-              1562,
-              1566,
-              877,
-              827,
-              878,
-              1043,
-              1044,
-              879,
-              880,
-              1173,
-              1045,
-              759,
-              772,
-              881,
-              882,
-              883,
-              884,
-              885,
-              886,
-              828,
-              1220,
-              1572,
-              887,
-              1046,
-              829,
-              830,
-              711,
-              724,
-              717,
-              725,
-              727,
-              713,
-              712,
-              710,
-              726,
-              753,
-              728
+              3706,
+              3707,
+              3708,
+              3709,
+              3710,
+              3711,
+              3712,
+              3713,
+              3714,
+              3715,
+              3716,
+              3717,
+              3718,
+              3719,
+              3720,
+              3721,
+              3722,
+              3723,
+              3370,
+              3424,
+              3425,
+              3727,
+              3728,
+              3729,
+              3730,
+              3731,
+              3732,
+              3733,
+              3734,
+              3735,
+              3736,
+              3737,
+              3738,
+              3739,
+              3740,
+              3741,
+              3742,
+              3743,
+              3744,
+              3745,
+              3746,
+              3747,
+              3748,
+              3749,
+              3750,
+              3751,
+              3752,
+              3753,
+              3754,
+              3755,
+              3756,
+              3757,
+              3758,
+              3759,
+              3760,
+              3761,
+              3762,
+              3817,
+              3469,
+              3426,
+              3644,
+              3784,
+              3645,
+              3785,
+              3470,
+              3471,
+              3472,
+              3473,
+              3474,
+              3475,
+              3831,
+              4180,
+              3427,
+              3428,
+              3832,
+              3646,
+              3786,
+              3384,
+              3429,
+              3476,
+              3781,
+              3430,
+              3833,
+              3647,
+              3834,
+              3383,
+              3431,
+              3648,
+              3787,
+              3477,
+              3478,
+              3782,
+              3649,
+              3650,
+              3651,
+              3652,
+              4181,
+              3432,
+              3433,
+              3434,
+              3435,
+              3436,
+              3835,
+              3839,
+              3843,
+              3847,
+              3851,
+              3855,
+              3859,
+              3863,
+              3867,
+              3871,
+              3875,
+              3879,
+              3883,
+              3818,
+              3887,
+              3822,
+              3891,
+              3895,
+              3899,
+              3903,
+              3907,
+              3911,
+              3915,
+              3919,
+              3923,
+              3927,
+              3931,
+              3935,
+              3936,
+              3940,
+              3479,
+              3483,
+              3944,
+              3948,
+              3952,
+              3956,
+              3960,
+              3964,
+              3968,
+              3972,
+              3976,
+              3980,
+              3984,
+              3988,
+              3992,
+              3996,
+              4000,
+              4004,
+              4008,
+              4012,
+              3826,
+              4016,
+              4020,
+              4024,
+              4028,
+              4032,
+              4036,
+              4040,
+              4044,
+              4048,
+              4052,
+              4056,
+              4060,
+              4064,
+              4068,
+              4072,
+              4076,
+              4080,
+              4084,
+              4088,
+              4092,
+              4096,
+              4100,
+              4104,
+              4108,
+              4112,
+              4116,
+              4120,
+              4124,
+              4128,
+              4132,
+              4136,
+              4140,
+              4144,
+              4148,
+              4152,
+              4156,
+              4160,
+              4164,
+              4168,
+              4172,
+              4176,
+              3487,
+              3437,
+              3488,
+              3653,
+              3654,
+              3489,
+              3490,
+              3783,
+              3655,
+              3369,
+              3382,
+              3491,
+              3492,
+              3493,
+              3494,
+              3495,
+              3496,
+              3438,
+              3830,
+              4182,
+              3497,
+              3656,
+              3439,
+              3440,
+              3321,
+              3334,
+              3327,
+              3335,
+              3337,
+              3323,
+              3322,
+              3320,
+              3336,
+              3363,
+              3338
             ],
             "categories": [
               {
                 "title": "Other",
                 "children": [
-                  1096,
-                  1097,
-                  1098,
-                  1099,
-                  1100,
-                  1101,
-                  1102,
-                  1103,
-                  1104,
-                  1105,
-                  1106,
-                  1107,
-                  1108,
-                  1109,
-                  1110,
-                  1111,
-                  1112,
-                  1113,
-                  760,
-                  814,
-                  815,
-                  1117,
-                  1118,
-                  1119,
-                  1120,
-                  1121,
-                  1122,
-                  1123,
-                  1124,
-                  1125,
-                  1126,
-                  1127,
-                  1128,
-                  1129,
-                  1130,
-                  1131,
-                  1132,
-                  1133,
-                  1134,
-                  1135,
-                  1136,
-                  1137,
-                  1138,
-                  1139,
-                  1140,
-                  1141,
-                  1142,
-                  1143,
-                  1144,
-                  1145,
-                  1146,
-                  1147,
-                  1148,
-                  1149,
-                  1150,
-                  1151,
-                  1152,
-                  1207,
-                  859,
-                  816,
-                  1034,
-                  1174,
-                  1035,
-                  1175,
-                  860,
-                  861,
-                  862,
-                  863,
-                  864,
-                  865,
-                  1221,
-                  1570,
-                  817,
-                  818,
-                  1222,
-                  1036,
-                  1176,
-                  819,
-                  866,
-                  1171,
-                  820,
-                  1223,
-                  1037,
-                  1224,
-                  821,
-                  1038,
-                  1177,
-                  867,
-                  868,
-                  1172,
-                  1039,
-                  1040,
-                  1041,
-                  1042,
-                  1571,
-                  822,
-                  823,
-                  824,
-                  825,
-                  826,
-                  1225,
-                  1229,
-                  1233,
-                  1237,
-                  1241,
-                  1245,
-                  1249,
-                  1253,
-                  1257,
-                  1261,
-                  1265,
-                  1269,
-                  1273,
-                  1208,
-                  1277,
-                  1212,
-                  1281,
-                  1285,
-                  1289,
-                  1293,
-                  1297,
-                  1301,
-                  1305,
-                  1309,
-                  1313,
-                  1317,
-                  1321,
-                  1325,
-                  1326,
-                  1330,
-                  869,
-                  873,
-                  1334,
-                  1338,
-                  1342,
-                  1346,
-                  1350,
-                  1354,
-                  1358,
-                  1362,
-                  1366,
-                  1370,
-                  1374,
-                  1378,
-                  1382,
-                  1386,
-                  1390,
-                  1394,
-                  1398,
-                  1402,
-                  1216,
-                  1406,
-                  1410,
-                  1414,
-                  1418,
-                  1422,
-                  1426,
-                  1430,
-                  1434,
-                  1438,
-                  1442,
-                  1446,
-                  1450,
-                  1454,
-                  1458,
-                  1462,
-                  1466,
-                  1470,
-                  1474,
-                  1478,
-                  1482,
-                  1486,
-                  1490,
-                  1494,
-                  1498,
-                  1502,
-                  1506,
-                  1510,
-                  1514,
-                  1518,
-                  1522,
-                  1526,
-                  1530,
-                  1534,
-                  1538,
-                  1542,
-                  1546,
-                  1550,
-                  1554,
-                  1558,
-                  1562,
-                  1566,
-                  877,
-                  827,
-                  878,
-                  1043,
-                  1044,
-                  879,
-                  880,
-                  1173,
-                  1045,
-                  881,
-                  882,
-                  883,
-                  884,
-                  885,
-                  886,
-                  828,
-                  1220,
-                  1572,
-                  887,
-                  1046,
-                  829,
-                  830,
-                  711,
-                  724,
-                  710
+                  3706,
+                  3707,
+                  3708,
+                  3709,
+                  3710,
+                  3711,
+                  3712,
+                  3713,
+                  3714,
+                  3715,
+                  3716,
+                  3717,
+                  3718,
+                  3719,
+                  3720,
+                  3721,
+                  3722,
+                  3723,
+                  3370,
+                  3424,
+                  3425,
+                  3727,
+                  3728,
+                  3729,
+                  3730,
+                  3731,
+                  3732,
+                  3733,
+                  3734,
+                  3735,
+                  3736,
+                  3737,
+                  3738,
+                  3739,
+                  3740,
+                  3741,
+                  3742,
+                  3743,
+                  3744,
+                  3745,
+                  3746,
+                  3747,
+                  3748,
+                  3749,
+                  3750,
+                  3751,
+                  3752,
+                  3753,
+                  3754,
+                  3755,
+                  3756,
+                  3757,
+                  3758,
+                  3759,
+                  3760,
+                  3761,
+                  3762,
+                  3817,
+                  3469,
+                  3426,
+                  3644,
+                  3784,
+                  3645,
+                  3785,
+                  3470,
+                  3471,
+                  3472,
+                  3473,
+                  3474,
+                  3475,
+                  3831,
+                  4180,
+                  3427,
+                  3428,
+                  3832,
+                  3646,
+                  3786,
+                  3429,
+                  3476,
+                  3781,
+                  3430,
+                  3833,
+                  3647,
+                  3834,
+                  3431,
+                  3648,
+                  3787,
+                  3477,
+                  3478,
+                  3782,
+                  3649,
+                  3650,
+                  3651,
+                  3652,
+                  4181,
+                  3432,
+                  3433,
+                  3434,
+                  3435,
+                  3436,
+                  3835,
+                  3839,
+                  3843,
+                  3847,
+                  3851,
+                  3855,
+                  3859,
+                  3863,
+                  3867,
+                  3871,
+                  3875,
+                  3879,
+                  3883,
+                  3818,
+                  3887,
+                  3822,
+                  3891,
+                  3895,
+                  3899,
+                  3903,
+                  3907,
+                  3911,
+                  3915,
+                  3919,
+                  3923,
+                  3927,
+                  3931,
+                  3935,
+                  3936,
+                  3940,
+                  3479,
+                  3483,
+                  3944,
+                  3948,
+                  3952,
+                  3956,
+                  3960,
+                  3964,
+                  3968,
+                  3972,
+                  3976,
+                  3980,
+                  3984,
+                  3988,
+                  3992,
+                  3996,
+                  4000,
+                  4004,
+                  4008,
+                  4012,
+                  3826,
+                  4016,
+                  4020,
+                  4024,
+                  4028,
+                  4032,
+                  4036,
+                  4040,
+                  4044,
+                  4048,
+                  4052,
+                  4056,
+                  4060,
+                  4064,
+                  4068,
+                  4072,
+                  4076,
+                  4080,
+                  4084,
+                  4088,
+                  4092,
+                  4096,
+                  4100,
+                  4104,
+                  4108,
+                  4112,
+                  4116,
+                  4120,
+                  4124,
+                  4128,
+                  4132,
+                  4136,
+                  4140,
+                  4144,
+                  4148,
+                  4152,
+                  4156,
+                  4160,
+                  4164,
+                  4168,
+                  4172,
+                  4176,
+                  3487,
+                  3437,
+                  3488,
+                  3653,
+                  3654,
+                  3489,
+                  3490,
+                  3783,
+                  3655,
+                  3491,
+                  3492,
+                  3493,
+                  3494,
+                  3495,
+                  3496,
+                  3438,
+                  3830,
+                  4182,
+                  3497,
+                  3656,
+                  3439,
+                  3440,
+                  3321,
+                  3334,
+                  3320
                 ]
               },
               {
                 "title": "dev-mode",
                 "children": [
-                  717,
-                  713,
-                  712
+                  3327,
+                  3323,
+                  3322
                 ]
               },
               {
                 "title": "properties",
                 "children": [
-                  725,
-                  726
+                  3335,
+                  3336
                 ]
               },
               {
                 "title": "rendering",
                 "children": [
-                  759,
-                  772,
-                  753
+                  3369,
+                  3382,
+                  3363
                 ]
               },
               {
                 "title": "styles",
                 "children": [
-                  727,
-                  728
+                  3337,
+                  3338
                 ]
               },
               {
                 "title": "updates",
                 "children": [
-                  774,
-                  773
+                  3384,
+                  3383
                 ]
               }
             ]
@@ -3791,20 +3794,20 @@
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              801,
-              729
+              3411,
+              3339
             ],
             "categories": [
               {
                 "title": "attributes",
                 "children": [
-                  729
+                  3339
                 ]
               },
               {
                 "title": "updates",
                 "children": [
-                  801
+                  3411
                 ]
               }
             ]
@@ -3813,230 +3816,230 @@
             "title": "Methods",
             "kind": 2048,
             "children": [
-              775,
-              833,
-              1160,
-              1153,
-              1178,
-              1047,
-              888,
-              784,
-              1163,
-              1573,
-              831,
-              1051,
-              891,
-              1054,
-              766,
-              1057,
-              761,
-              768,
-              1114,
-              781,
-              811,
-              1575,
-              1157,
-              901,
-              904,
-              908,
-              910,
-              913,
-              917,
-              919,
-              921,
-              924,
-              933,
-              1060,
-              803,
-              943,
-              946,
-              950,
-              1063,
-              952,
-              955,
-              959,
-              963,
-              1065,
-              1070,
-              1073,
-              1076,
-              1079,
-              1082,
-              967,
-              1085,
-              796,
-              1181,
-              1184,
-              1194,
-              970,
-              1166,
-              973,
-              976,
-              980,
-              1087,
-              778,
-              846,
-              770,
-              1091,
-              1204,
-              1168,
-              983,
-              986,
-              789,
-              794,
-              988,
-              994,
-              1000,
-              1003,
-              1009,
-              1013,
-              1018,
-              1021,
-              1024,
-              805,
-              1027,
-              763,
-              808,
-              1031,
-              798,
-              721,
-              731,
-              751,
-              754,
-              735,
-              748
+              3385,
+              3443,
+              3770,
+              3763,
+              3788,
+              3657,
+              3498,
+              3394,
+              3773,
+              4183,
+              3441,
+              3661,
+              3501,
+              3664,
+              3376,
+              3667,
+              3371,
+              3378,
+              3724,
+              3391,
+              3421,
+              4185,
+              3767,
+              3511,
+              3514,
+              3518,
+              3520,
+              3523,
+              3527,
+              3529,
+              3531,
+              3534,
+              3543,
+              3670,
+              3413,
+              3553,
+              3556,
+              3560,
+              3673,
+              3562,
+              3565,
+              3569,
+              3573,
+              3675,
+              3680,
+              3683,
+              3686,
+              3689,
+              3692,
+              3577,
+              3695,
+              3406,
+              3791,
+              3794,
+              3804,
+              3580,
+              3776,
+              3583,
+              3586,
+              3590,
+              3697,
+              3388,
+              3456,
+              3380,
+              3701,
+              3814,
+              3778,
+              3593,
+              3596,
+              3399,
+              3404,
+              3598,
+              3604,
+              3610,
+              3613,
+              3619,
+              3623,
+              3628,
+              3631,
+              3634,
+              3415,
+              3637,
+              3373,
+              3418,
+              3641,
+              3408,
+              3331,
+              3341,
+              3361,
+              3364,
+              3345,
+              3358
             ],
             "categories": [
               {
                 "title": "Other",
                 "children": [
-                  833,
-                  1160,
-                  1153,
-                  1178,
-                  1047,
-                  888,
-                  1163,
-                  1573,
-                  831,
-                  1051,
-                  891,
-                  1054,
-                  1057,
-                  1114,
-                  1575,
-                  1157,
-                  901,
-                  904,
-                  908,
-                  910,
-                  913,
-                  917,
-                  919,
-                  921,
-                  924,
-                  933,
-                  1060,
-                  943,
-                  946,
-                  950,
-                  1063,
-                  952,
-                  955,
-                  959,
-                  963,
-                  1065,
-                  1070,
-                  1073,
-                  1076,
-                  1079,
-                  1082,
-                  967,
-                  1085,
-                  1181,
-                  1184,
-                  1194,
-                  970,
-                  1166,
-                  973,
-                  976,
-                  980,
-                  1087,
-                  846,
-                  1091,
-                  1204,
-                  1168,
-                  983,
-                  986,
-                  988,
-                  994,
-                  1000,
-                  1003,
-                  1009,
-                  1013,
-                  1018,
-                  1021,
-                  1024,
-                  1027,
-                  1031,
-                  721,
-                  751
+                  3443,
+                  3770,
+                  3763,
+                  3788,
+                  3657,
+                  3498,
+                  3773,
+                  4183,
+                  3441,
+                  3661,
+                  3501,
+                  3664,
+                  3667,
+                  3724,
+                  4185,
+                  3767,
+                  3511,
+                  3514,
+                  3518,
+                  3520,
+                  3523,
+                  3527,
+                  3529,
+                  3531,
+                  3534,
+                  3543,
+                  3670,
+                  3553,
+                  3556,
+                  3560,
+                  3673,
+                  3562,
+                  3565,
+                  3569,
+                  3573,
+                  3675,
+                  3680,
+                  3683,
+                  3686,
+                  3689,
+                  3692,
+                  3577,
+                  3695,
+                  3791,
+                  3794,
+                  3804,
+                  3580,
+                  3776,
+                  3583,
+                  3586,
+                  3590,
+                  3697,
+                  3456,
+                  3701,
+                  3814,
+                  3778,
+                  3593,
+                  3596,
+                  3598,
+                  3604,
+                  3610,
+                  3613,
+                  3619,
+                  3623,
+                  3628,
+                  3631,
+                  3634,
+                  3637,
+                  3641,
+                  3331,
+                  3361
                 ]
               },
               {
                 "title": "attributes",
                 "children": [
-                  784
+                  3394
                 ]
               },
               {
                 "title": "controllers",
                 "children": [
-                  775,
-                  778
+                  3385,
+                  3388
                 ]
               },
               {
                 "title": "lifecycle",
                 "children": [
-                  766,
-                  768
+                  3376,
+                  3378
                 ]
               },
               {
                 "title": "properties",
                 "children": [
-                  731,
-                  735,
-                  748
+                  3341,
+                  3345,
+                  3358
                 ]
               },
               {
                 "title": "rendering",
                 "children": [
-                  761,
-                  770
+                  3371,
+                  3380
                 ]
               },
               {
                 "title": "styles",
                 "children": [
-                  754
+                  3364
                 ]
               },
               {
                 "title": "updates",
                 "children": [
-                  781,
-                  811,
-                  803,
-                  796,
-                  789,
-                  794,
-                  805,
-                  763,
-                  808,
-                  798
+                  3391,
+                  3421,
+                  3413,
+                  3406,
+                  3399,
+                  3404,
+                  3415,
+                  3373,
+                  3418,
+                  3408
                 ]
               }
             ]
@@ -4054,7 +4057,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 1650,
+            "id": 4260,
             "name": "ReactiveElement",
             "location": {
               "page": "ReactiveElement",
@@ -4078,7 +4081,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 1650,
+            "id": 4260,
             "name": "ReactiveElement",
             "location": {
               "page": "ReactiveElement",
@@ -4099,7 +4102,7 @@
             "title": "Attributes",
             "children": [
               {
-                "id": 784,
+                "id": 3394,
                 "name": "attributeChangedCallback",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4119,7 +4122,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 785,
+                    "id": 3395,
                     "name": "attributeChangedCallback",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -4129,7 +4132,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 786,
+                        "id": 3396,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -4140,7 +4143,7 @@
                         }
                       },
                       {
-                        "id": 787,
+                        "id": 3397,
                         "name": "_old",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -4160,7 +4163,7 @@
                         }
                       },
                       {
-                        "id": 788,
+                        "id": 3398,
                         "name": "value",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -4186,14 +4189,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1726,
+                      "id": 4336,
                       "name": "ReactiveElement.attributeChangedCallback"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1725,
+                  "id": 4335,
                   "name": "ReactiveElement.attributeChangedCallback",
                   "location": {
                     "page": "ReactiveElement",
@@ -4215,7 +4218,7 @@
                 }
               },
               {
-                "id": 729,
+                "id": 3339,
                 "name": "observedAttributes",
                 "kind": 262144,
                 "kindString": "Accessor",
@@ -4250,7 +4253,7 @@
                 },
                 "getSignature": [
                   {
-                    "id": 730,
+                    "id": 3340,
                     "name": "observedAttributes",
                     "kind": 524288,
                     "kindString": "Get signature",
@@ -4279,7 +4282,7 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1669,
+                  "id": 4279,
                   "name": "ReactiveElement.observedAttributes",
                   "location": {
                     "page": "ReactiveElement",
@@ -4307,7 +4310,7 @@
             "title": "Controllers",
             "children": [
               {
-                "id": 775,
+                "id": 3385,
                 "name": "addController",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4324,7 +4327,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 776,
+                    "id": 3386,
                     "name": "addController",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -4332,14 +4335,14 @@
                     "comment": {},
                     "parameters": [
                       {
-                        "id": 777,
+                        "id": 3387,
                         "name": "controller",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1588,
+                          "id": 4198,
                           "name": "ReactiveController",
                           "location": {
                             "page": "controllers",
@@ -4354,14 +4357,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1710,
+                      "id": 4320,
                       "name": "ReactiveElement.addController"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1709,
+                  "id": 4319,
                   "name": "ReactiveElement.addController",
                   "location": {
                     "page": "ReactiveElement",
@@ -4383,7 +4386,7 @@
                 }
               },
               {
-                "id": 778,
+                "id": 3388,
                 "name": "removeController",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4400,7 +4403,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 779,
+                    "id": 3389,
                     "name": "removeController",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -4408,14 +4411,14 @@
                     "comment": {},
                     "parameters": [
                       {
-                        "id": 780,
+                        "id": 3390,
                         "name": "controller",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1588,
+                          "id": 4198,
                           "name": "ReactiveController",
                           "location": {
                             "page": "controllers",
@@ -4430,14 +4433,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1713,
+                      "id": 4323,
                       "name": "ReactiveElement.removeController"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1712,
+                  "id": 4322,
                   "name": "ReactiveElement.removeController",
                   "location": {
                     "page": "ReactiveElement",
@@ -4465,7 +4468,7 @@
             "title": "Dev mode",
             "children": [
               {
-                "id": 717,
+                "id": 3327,
                 "name": "disableWarning",
                 "kind": 1024,
                 "kindString": "Property",
@@ -4496,14 +4499,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 718,
+                    "id": 3328,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 719,
+                        "id": 3329,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
@@ -4524,14 +4527,14 @@
                         },
                         "parameters": [
                           {
-                            "id": 720,
+                            "id": 3330,
                             "name": "warningKind",
                             "kind": 32768,
                             "kindString": "Parameter",
                             "flags": {},
                             "type": {
                               "type": "reference",
-                              "id": 1645,
+                              "id": 4255,
                               "name": "WarningKind",
                               "location": {
                                 "page": "misc",
@@ -4550,7 +4553,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1656,
+                  "id": 4266,
                   "name": "ReactiveElement.disableWarning",
                   "location": {
                     "page": "ReactiveElement",
@@ -4572,7 +4575,7 @@
                 }
               },
               {
-                "id": 712,
+                "id": 3322,
                 "name": "enabledWarnings",
                 "kind": 1024,
                 "kindString": "Property",
@@ -4604,7 +4607,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 1645,
+                    "id": 4255,
                     "name": "WarningKind",
                     "location": {
                       "page": "misc",
@@ -4614,7 +4617,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1651,
+                  "id": 4261,
                   "name": "ReactiveElement.enabledWarnings",
                   "location": {
                     "page": "ReactiveElement",
@@ -4636,7 +4639,7 @@
                 }
               },
               {
-                "id": 713,
+                "id": 3323,
                 "name": "enableWarning",
                 "kind": 1024,
                 "kindString": "Property",
@@ -4667,14 +4670,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 714,
+                    "id": 3324,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 715,
+                        "id": 3325,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
@@ -4695,14 +4698,14 @@
                         },
                         "parameters": [
                           {
-                            "id": 716,
+                            "id": 3326,
                             "name": "warningKind",
                             "kind": 32768,
                             "kindString": "Parameter",
                             "flags": {},
                             "type": {
                               "type": "reference",
-                              "id": 1645,
+                              "id": 4255,
                               "name": "WarningKind",
                               "location": {
                                 "page": "misc",
@@ -4721,7 +4724,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1652,
+                  "id": 4262,
                   "name": "ReactiveElement.enableWarning",
                   "location": {
                     "page": "ReactiveElement",
@@ -4749,7 +4752,7 @@
             "title": "Lifecycle",
             "children": [
               {
-                "id": 766,
+                "id": 3376,
                 "name": "connectedCallback",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4766,7 +4769,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 767,
+                    "id": 3377,
                     "name": "connectedCallback",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -4778,14 +4781,14 @@
                     },
                     "overwrites": {
                       "type": "reference",
-                      "id": 1719,
+                      "id": 4329,
                       "name": "ReactiveElement.connectedCallback"
                     }
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "id": 1718,
+                  "id": 4328,
                   "name": "ReactiveElement.connectedCallback",
                   "location": {
                     "page": "ReactiveElement",
@@ -4807,7 +4810,7 @@
                 }
               },
               {
-                "id": 768,
+                "id": 3378,
                 "name": "disconnectedCallback",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4824,7 +4827,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 769,
+                    "id": 3379,
                     "name": "disconnectedCallback",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -4836,14 +4839,14 @@
                     },
                     "overwrites": {
                       "type": "reference",
-                      "id": 1724,
+                      "id": 4334,
                       "name": "ReactiveElement.disconnectedCallback"
                     }
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "id": 1723,
+                  "id": 4333,
                   "name": "ReactiveElement.disconnectedCallback",
                   "location": {
                     "page": "ReactiveElement",
@@ -4871,7 +4874,7 @@
             "title": "Other",
             "children": [
               {
-                "id": 721,
+                "id": 3331,
                 "name": "addInitializer",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4890,7 +4893,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 722,
+                    "id": 3332,
                     "name": "addInitializer",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -4905,14 +4908,14 @@
                     },
                     "parameters": [
                       {
-                        "id": 723,
+                        "id": 3333,
                         "name": "initializer",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1646,
+                          "id": 4256,
                           "name": "Initializer",
                           "location": {
                             "page": "misc",
@@ -4927,14 +4930,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1661,
+                      "id": 4271,
                       "name": "ReactiveElement.addInitializer"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1660,
+                  "id": 4270,
                   "name": "ReactiveElement.addInitializer",
                   "location": {
                     "page": "ReactiveElement",
@@ -4956,7 +4959,7 @@
                 }
               },
               {
-                "id": 751,
+                "id": 3361,
                 "name": "finalize",
                 "kind": 2048,
                 "kindString": "Method",
@@ -4985,7 +4988,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 752,
+                    "id": 3362,
                     "name": "finalize",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -5005,14 +5008,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1692,
+                      "id": 4302,
                       "name": "ReactiveElement.finalize"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1691,
+                  "id": 4301,
                   "name": "ReactiveElement.finalize",
                   "location": {
                     "page": "ReactiveElement",
@@ -5034,7 +5037,7 @@
                 }
               },
               {
-                "id": 710,
+                "id": 3320,
                 "name": "finalized",
                 "kind": 1024,
                 "kindString": "Property",
@@ -5062,7 +5065,7 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 1698,
+                  "id": 4308,
                   "name": "ReactiveElement.finalized",
                   "location": {
                     "page": "ReactiveElement",
@@ -5090,7 +5093,7 @@
             "title": "Properties",
             "children": [
               {
-                "id": 731,
+                "id": 3341,
                 "name": "createProperty",
                 "kind": 2048,
                 "kindString": "Method",
@@ -5119,7 +5122,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 732,
+                    "id": 3342,
                     "name": "createProperty",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -5136,7 +5139,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 733,
+                        "id": 3343,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -5147,7 +5150,7 @@
                         }
                       },
                       {
-                        "id": 734,
+                        "id": 3344,
                         "name": "options",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -5156,7 +5159,7 @@
                         },
                         "type": {
                           "type": "reference",
-                          "id": 1618,
+                          "id": 4228,
                           "typeArguments": [
                             {
                               "type": "intrinsic",
@@ -5181,14 +5184,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1672,
+                      "id": 4282,
                       "name": "ReactiveElement.createProperty"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1671,
+                  "id": 4281,
                   "name": "ReactiveElement.createProperty",
                   "location": {
                     "page": "ReactiveElement",
@@ -5210,7 +5213,7 @@
                 }
               },
               {
-                "id": 725,
+                "id": 3335,
                 "name": "elementProperties",
                 "kind": 1024,
                 "kindString": "Property",
@@ -5242,7 +5245,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1665,
+                  "id": 4275,
                   "name": "ReactiveElement.elementProperties",
                   "location": {
                     "page": "ReactiveElement",
@@ -5264,7 +5267,7 @@
                 }
               },
               {
-                "id": 735,
+                "id": 3345,
                 "name": "getPropertyDescriptor",
                 "kind": 2048,
                 "kindString": "Method",
@@ -5294,7 +5297,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 736,
+                    "id": 3346,
                     "name": "getPropertyDescriptor",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -5311,7 +5314,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 737,
+                        "id": 3347,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -5322,7 +5325,7 @@
                         }
                       },
                       {
-                        "id": 738,
+                        "id": 3348,
                         "name": "key",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -5342,14 +5345,14 @@
                         }
                       },
                       {
-                        "id": 739,
+                        "id": 3349,
                         "name": "options",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1618,
+                          "id": 4228,
                           "typeArguments": [
                             {
                               "type": "intrinsic",
@@ -5371,14 +5374,14 @@
                     "type": {
                       "type": "reflection",
                       "declaration": {
-                        "id": 740,
+                        "id": 3350,
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
                         "flags": {},
                         "children": [
                           {
-                            "id": 746,
+                            "id": 3356,
                             "name": "configurable",
                             "kind": 1024,
                             "kindString": "Property",
@@ -5396,7 +5399,7 @@
                             }
                           },
                           {
-                            "id": 747,
+                            "id": 3357,
                             "name": "enumerable",
                             "kind": 1024,
                             "kindString": "Property",
@@ -5414,14 +5417,14 @@
                             }
                           },
                           {
-                            "id": 741,
+                            "id": 3351,
                             "name": "get",
                             "kind": 2048,
                             "kindString": "Method",
                             "flags": {},
                             "signatures": [
                               {
-                                "id": 742,
+                                "id": 3352,
                                 "name": "get",
                                 "kind": 4096,
                                 "kindString": "Call signature",
@@ -5434,21 +5437,21 @@
                             ]
                           },
                           {
-                            "id": 743,
+                            "id": 3353,
                             "name": "set",
                             "kind": 2048,
                             "kindString": "Method",
                             "flags": {},
                             "signatures": [
                               {
-                                "id": 744,
+                                "id": 3354,
                                 "name": "set",
                                 "kind": 4096,
                                 "kindString": "Call signature",
                                 "flags": {},
                                 "parameters": [
                                   {
-                                    "id": 745,
+                                    "id": 3355,
                                     "name": "value",
                                     "kind": 32768,
                                     "kindString": "Parameter",
@@ -5472,16 +5475,16 @@
                             "title": "Properties",
                             "kind": 1024,
                             "children": [
-                              746,
-                              747
+                              3356,
+                              3357
                             ]
                           },
                           {
                             "title": "Methods",
                             "kind": 2048,
                             "children": [
-                              741,
-                              743
+                              3351,
+                              3353
                             ]
                           }
                         ]
@@ -5489,14 +5492,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1676,
+                      "id": 4286,
                       "name": "ReactiveElement.getPropertyDescriptor"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1675,
+                  "id": 4285,
                   "name": "ReactiveElement.getPropertyDescriptor",
                   "location": {
                     "page": "ReactiveElement",
@@ -5518,7 +5521,7 @@
                 }
               },
               {
-                "id": 748,
+                "id": 3358,
                 "name": "getPropertyOptions",
                 "kind": 2048,
                 "kindString": "Method",
@@ -5552,7 +5555,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 749,
+                    "id": 3359,
                     "name": "getPropertyOptions",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -5573,7 +5576,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 750,
+                        "id": 3360,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -5586,7 +5589,7 @@
                     ],
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -5605,14 +5608,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1689,
+                      "id": 4299,
                       "name": "ReactiveElement.getPropertyOptions"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1688,
+                  "id": 4298,
                   "name": "ReactiveElement.getPropertyOptions",
                   "location": {
                     "page": "ReactiveElement",
@@ -5634,7 +5637,7 @@
                 }
               },
               {
-                "id": 726,
+                "id": 3336,
                 "name": "properties",
                 "kind": 1024,
                 "kindString": "Property",
@@ -5663,7 +5666,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 1631,
+                  "id": 4241,
                   "name": "PropertyDeclarations",
                   "location": {
                     "page": "ReactiveElement",
@@ -5672,7 +5675,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1666,
+                  "id": 4276,
                   "name": "ReactiveElement.properties",
                   "location": {
                     "page": "ReactiveElement",
@@ -5700,7 +5703,7 @@
             "title": "Rendering",
             "children": [
               {
-                "id": 761,
+                "id": 3371,
                 "name": "createRenderRoot",
                 "kind": 2048,
                 "kindString": "Method",
@@ -5719,7 +5722,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 762,
+                    "id": 3372,
                     "name": "createRenderRoot",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -5746,14 +5749,14 @@
                     },
                     "overwrites": {
                       "type": "reference",
-                      "id": 1717,
+                      "id": 4327,
                       "name": "ReactiveElement.createRenderRoot"
                     }
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "id": 1716,
+                  "id": 4326,
                   "name": "ReactiveElement.createRenderRoot",
                   "location": {
                     "page": "ReactiveElement",
@@ -5775,7 +5778,7 @@
                 }
               },
               {
-                "id": 770,
+                "id": 3380,
                 "name": "render",
                 "kind": 2048,
                 "kindString": "Method",
@@ -5797,7 +5800,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 771,
+                    "id": 3381,
                     "name": "render",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -5826,7 +5829,7 @@
                 }
               },
               {
-                "id": 759,
+                "id": 3369,
                 "name": "renderOptions",
                 "kind": 1024,
                 "kindString": "Property",
@@ -5846,7 +5849,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -5868,7 +5871,7 @@
                 }
               },
               {
-                "id": 772,
+                "id": 3382,
                 "name": "renderRoot",
                 "kind": 1024,
                 "kindString": "Property",
@@ -5909,7 +5912,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1701,
+                  "id": 4311,
                   "name": "ReactiveElement.renderRoot",
                   "location": {
                     "page": "ReactiveElement",
@@ -5931,7 +5934,7 @@
                 }
               },
               {
-                "id": 753,
+                "id": 3363,
                 "name": "shadowRootOptions",
                 "kind": 1024,
                 "kindString": "Property",
@@ -5967,7 +5970,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1693,
+                  "id": 4303,
                   "name": "ReactiveElement.shadowRootOptions",
                   "location": {
                     "page": "ReactiveElement",
@@ -5995,7 +5998,7 @@
             "title": "Styles",
             "children": [
               {
-                "id": 727,
+                "id": 3337,
                 "name": "elementStyles",
                 "kind": 1024,
                 "kindString": "Property",
@@ -6025,7 +6028,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 2526,
+                    "id": 5136,
                     "name": "CSSResultOrNative",
                     "location": {
                       "page": "styles",
@@ -6035,7 +6038,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1667,
+                  "id": 4277,
                   "name": "ReactiveElement.elementStyles",
                   "location": {
                     "page": "ReactiveElement",
@@ -6057,7 +6060,7 @@
                 }
               },
               {
-                "id": 754,
+                "id": 3364,
                 "name": "finalizeStyles",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6087,7 +6090,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 755,
+                    "id": 3365,
                     "name": "finalizeStyles",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6104,7 +6107,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 756,
+                        "id": 3366,
                         "name": "styles",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6113,7 +6116,7 @@
                         },
                         "type": {
                           "type": "reference",
-                          "id": 2528,
+                          "id": 5138,
                           "name": "CSSResultGroup",
                           "location": {
                             "page": "styles",
@@ -6126,7 +6129,7 @@
                       "type": "array",
                       "elementType": {
                         "type": "reference",
-                        "id": 2526,
+                        "id": 5136,
                         "name": "CSSResultOrNative",
                         "location": {
                           "page": "styles",
@@ -6136,14 +6139,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1695,
+                      "id": 4305,
                       "name": "ReactiveElement.finalizeStyles"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1694,
+                  "id": 4304,
                   "name": "ReactiveElement.finalizeStyles",
                   "location": {
                     "page": "ReactiveElement",
@@ -6165,7 +6168,7 @@
                 }
               },
               {
-                "id": 728,
+                "id": 3338,
                 "name": "styles",
                 "kind": 1024,
                 "kindString": "Property",
@@ -6194,7 +6197,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 2528,
+                  "id": 5138,
                   "name": "CSSResultGroup",
                   "location": {
                     "page": "styles",
@@ -6203,7 +6206,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1668,
+                  "id": 4278,
                   "name": "ReactiveElement.styles",
                   "location": {
                     "page": "ReactiveElement",
@@ -6231,7 +6234,7 @@
             "title": "Updates",
             "children": [
               {
-                "id": 781,
+                "id": 3391,
                 "name": "enableUpdating",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6253,7 +6256,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 782,
+                    "id": 3392,
                     "name": "enableUpdating",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6263,7 +6266,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 783,
+                        "id": 3393,
                         "name": "_requestedUpdate",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6280,14 +6283,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1721,
+                      "id": 4331,
                       "name": "ReactiveElement.enableUpdating"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1720,
+                  "id": 4330,
                   "name": "ReactiveElement.enableUpdating",
                   "location": {
                     "page": "ReactiveElement",
@@ -6309,7 +6312,7 @@
                 }
               },
               {
-                "id": 811,
+                "id": 3421,
                 "name": "firstUpdated",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6332,7 +6335,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 812,
+                    "id": 3422,
                     "name": "firstUpdated",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6343,7 +6346,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 813,
+                        "id": 3423,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6386,14 +6389,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1759,
+                      "id": 4369,
                       "name": "ReactiveElement.firstUpdated"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1758,
+                  "id": 4368,
                   "name": "ReactiveElement.firstUpdated",
                   "location": {
                     "page": "ReactiveElement",
@@ -6415,7 +6418,7 @@
                 }
               },
               {
-                "id": 803,
+                "id": 3413,
                 "name": "getUpdateComplete",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6439,7 +6442,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 804,
+                    "id": 3414,
                     "name": "getUpdateComplete",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6461,14 +6464,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1748,
+                      "id": 4358,
                       "name": "ReactiveElement.getUpdateComplete"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1747,
+                  "id": 4357,
                   "name": "ReactiveElement.getUpdateComplete",
                   "location": {
                     "page": "ReactiveElement",
@@ -6490,7 +6493,7 @@
                 }
               },
               {
-                "id": 774,
+                "id": 3384,
                 "name": "hasUpdated",
                 "kind": 1024,
                 "kindString": "Property",
@@ -6512,7 +6515,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1705,
+                  "id": 4315,
                   "name": "ReactiveElement.hasUpdated",
                   "location": {
                     "page": "ReactiveElement",
@@ -6534,7 +6537,7 @@
                 }
               },
               {
-                "id": 773,
+                "id": 3383,
                 "name": "isUpdatePending",
                 "kind": 1024,
                 "kindString": "Property",
@@ -6556,7 +6559,7 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1704,
+                  "id": 4314,
                   "name": "ReactiveElement.isUpdatePending",
                   "location": {
                     "page": "ReactiveElement",
@@ -6578,7 +6581,7 @@
                 }
               },
               {
-                "id": 796,
+                "id": 3406,
                 "name": "performUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6601,7 +6604,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 797,
+                    "id": 3407,
                     "name": "performUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6631,14 +6634,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1740,
+                      "id": 4350,
                       "name": "ReactiveElement.performUpdate"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1739,
+                  "id": 4349,
                   "name": "ReactiveElement.performUpdate",
                   "location": {
                     "page": "ReactiveElement",
@@ -6660,7 +6663,7 @@
                 }
               },
               {
-                "id": 789,
+                "id": 3399,
                 "name": "requestUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6680,7 +6683,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 790,
+                    "id": 3400,
                     "name": "requestUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6690,7 +6693,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 791,
+                        "id": 3401,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6706,7 +6709,7 @@
                         }
                       },
                       {
-                        "id": 792,
+                        "id": 3402,
                         "name": "oldValue",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6722,7 +6725,7 @@
                         }
                       },
                       {
-                        "id": 793,
+                        "id": 3403,
                         "name": "options",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6734,7 +6737,7 @@
                         },
                         "type": {
                           "type": "reference",
-                          "id": 1618,
+                          "id": 4228,
                           "typeArguments": [
                             {
                               "type": "intrinsic",
@@ -6759,14 +6762,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1732,
+                      "id": 4342,
                       "name": "ReactiveElement.requestUpdate"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1731,
+                  "id": 4341,
                   "name": "ReactiveElement.requestUpdate",
                   "location": {
                     "page": "ReactiveElement",
@@ -6788,7 +6791,7 @@
                 }
               },
               {
-                "id": 794,
+                "id": 3404,
                 "name": "scheduleUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6811,7 +6814,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 795,
+                    "id": 3405,
                     "name": "scheduleUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6841,14 +6844,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1738,
+                      "id": 4348,
                       "name": "ReactiveElement.scheduleUpdate"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1737,
+                  "id": 4347,
                   "name": "ReactiveElement.scheduleUpdate",
                   "location": {
                     "page": "ReactiveElement",
@@ -6870,7 +6873,7 @@
                 }
               },
               {
-                "id": 805,
+                "id": 3415,
                 "name": "shouldUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6892,7 +6895,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 806,
+                    "id": 3416,
                     "name": "shouldUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -6902,7 +6905,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 807,
+                        "id": 3417,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -6945,14 +6948,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1750,
+                      "id": 4360,
                       "name": "ReactiveElement.shouldUpdate"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1749,
+                  "id": 4359,
                   "name": "ReactiveElement.shouldUpdate",
                   "location": {
                     "page": "ReactiveElement",
@@ -6974,7 +6977,7 @@
                 }
               },
               {
-                "id": 763,
+                "id": 3373,
                 "name": "update",
                 "kind": 2048,
                 "kindString": "Method",
@@ -6996,7 +6999,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 764,
+                    "id": 3374,
                     "name": "update",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -7006,7 +7009,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 765,
+                        "id": 3375,
                         "name": "changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -7049,14 +7052,14 @@
                     },
                     "overwrites": {
                       "type": "reference",
-                      "id": 1753,
+                      "id": 4363,
                       "name": "ReactiveElement.update"
                     }
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "id": 1752,
+                  "id": 4362,
                   "name": "ReactiveElement.update",
                   "location": {
                     "page": "ReactiveElement",
@@ -7078,7 +7081,7 @@
                 }
               },
               {
-                "id": 801,
+                "id": 3411,
                 "name": "updateComplete",
                 "kind": 262144,
                 "kindString": "Accessor",
@@ -7110,7 +7113,7 @@
                 },
                 "getSignature": [
                   {
-                    "id": 802,
+                    "id": 3412,
                     "name": "updateComplete",
                     "kind": 524288,
                     "kindString": "Get signature",
@@ -7140,7 +7143,7 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1745,
+                  "id": 4355,
                   "name": "ReactiveElement.updateComplete",
                   "location": {
                     "page": "ReactiveElement",
@@ -7162,7 +7165,7 @@
                 }
               },
               {
-                "id": 808,
+                "id": 3418,
                 "name": "updated",
                 "kind": 2048,
                 "kindString": "Method",
@@ -7185,7 +7188,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 809,
+                    "id": 3419,
                     "name": "updated",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -7196,7 +7199,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 810,
+                        "id": 3420,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -7239,14 +7242,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1756,
+                      "id": 4366,
                       "name": "ReactiveElement.updated"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1755,
+                  "id": 4365,
                   "name": "ReactiveElement.updated",
                   "location": {
                     "page": "ReactiveElement",
@@ -7268,7 +7271,7 @@
                 }
               },
               {
-                "id": 798,
+                "id": 3408,
                 "name": "willUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -7285,7 +7288,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 799,
+                    "id": 3409,
                     "name": "willUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -7293,7 +7296,7 @@
                     "comment": {},
                     "parameters": [
                       {
-                        "id": 800,
+                        "id": 3410,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -7333,14 +7336,14 @@
                     },
                     "inheritedFrom": {
                       "type": "reference",
-                      "id": 1742,
+                      "id": 4352,
                       "name": "ReactiveElement.willUpdate"
                     }
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 1741,
+                  "id": 4351,
                   "name": "ReactiveElement.willUpdate",
                   "location": {
                     "page": "ReactiveElement",
@@ -7366,7 +7369,7 @@
         ]
       },
       {
-        "id": 2586,
+        "id": 5196,
         "name": "RenderOptions",
         "kind": 256,
         "kindString": "Interface",
@@ -7376,7 +7379,7 @@
         },
         "children": [
           {
-            "id": 2589,
+            "id": 5199,
             "name": "creationScope",
             "kind": 1024,
             "kindString": "Property",
@@ -7399,28 +7402,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 2590,
+                "id": 5200,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "children": [
                   {
-                    "id": 2591,
+                    "id": 5201,
                     "name": "importNode",
                     "kind": 2048,
                     "kindString": "Method",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 2592,
+                        "id": 5202,
                         "name": "importNode",
                         "kind": 4096,
                         "kindString": "Call signature",
                         "flags": {},
                         "parameters": [
                           {
-                            "id": 2593,
+                            "id": 5203,
                             "name": "node",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -7431,7 +7434,7 @@
                             }
                           },
                           {
-                            "id": 2594,
+                            "id": 5204,
                             "name": "deep",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -7457,7 +7460,7 @@
                     "title": "Methods",
                     "kind": 2048,
                     "children": [
-                      2591
+                      5201
                     ]
                   }
                 ]
@@ -7478,7 +7481,7 @@
             }
           },
           {
-            "id": 2587,
+            "id": 5197,
             "name": "host",
             "kind": 1024,
             "kindString": "Property",
@@ -7517,7 +7520,7 @@
             }
           },
           {
-            "id": 2595,
+            "id": 5205,
             "name": "isConnected",
             "kind": 1024,
             "kindString": "Property",
@@ -7556,7 +7559,7 @@
             }
           },
           {
-            "id": 2588,
+            "id": 5198,
             "name": "renderBefore",
             "kind": 1024,
             "kindString": "Property",
@@ -7609,10 +7612,10 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2589,
-              2587,
-              2595,
-              2588
+              5199,
+              5197,
+              5205,
+              5198
             ]
           }
         ],
@@ -7644,9 +7647,12 @@
   {
     "slug": "ReactiveElement",
     "title": "ReactiveElement",
+    "versionLinks": {
+      "v1": "api/lit-element/UpdatingElement/"
+    },
     "items": [
       {
-        "id": 1650,
+        "id": 4260,
         "name": "ReactiveElement",
         "kind": 128,
         "kindString": "Class",
@@ -7664,7 +7670,7 @@
         },
         "children": [
           {
-            "id": 1699,
+            "id": 4309,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -7679,14 +7685,14 @@
             ],
             "signatures": [
               {
-                "id": 1700,
+                "id": 4310,
                 "name": "new ReactiveElement",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 1650,
+                  "id": 4260,
                   "name": "ReactiveElement",
                   "location": {
                     "page": "ReactiveElement",
@@ -7718,7 +7724,7 @@
             }
           },
           {
-            "id": 1705,
+            "id": 4315,
             "name": "hasUpdated",
             "kind": 1024,
             "kindString": "Property",
@@ -7753,7 +7759,7 @@
             }
           },
           {
-            "id": 1704,
+            "id": 4314,
             "name": "isUpdatePending",
             "kind": 1024,
             "kindString": "Property",
@@ -7788,7 +7794,7 @@
             }
           },
           {
-            "id": 1701,
+            "id": 4311,
             "name": "renderRoot",
             "kind": 1024,
             "kindString": "Property",
@@ -7842,7 +7848,7 @@
             }
           },
           {
-            "id": 1656,
+            "id": 4266,
             "name": "disableWarning",
             "kind": 1024,
             "kindString": "Property",
@@ -7873,14 +7879,14 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 1657,
+                "id": 4267,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 1658,
+                    "id": 4268,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -7901,14 +7907,14 @@
                     },
                     "parameters": [
                       {
-                        "id": 1659,
+                        "id": 4269,
                         "name": "warningKind",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1645,
+                          "id": 4255,
                           "name": "WarningKind",
                           "location": {
                             "page": "misc",
@@ -7940,7 +7946,7 @@
             }
           },
           {
-            "id": 1665,
+            "id": 4275,
             "name": "elementProperties",
             "kind": 1024,
             "kindString": "Property",
@@ -7985,7 +7991,7 @@
             }
           },
           {
-            "id": 1667,
+            "id": 4277,
             "name": "elementStyles",
             "kind": 1024,
             "kindString": "Property",
@@ -8015,7 +8021,7 @@
               "type": "array",
               "elementType": {
                 "type": "reference",
-                "id": 2526,
+                "id": 5136,
                 "name": "CSSResultOrNative",
                 "location": {
                   "page": "styles",
@@ -8038,7 +8044,7 @@
             }
           },
           {
-            "id": 1652,
+            "id": 4262,
             "name": "enableWarning",
             "kind": 1024,
             "kindString": "Property",
@@ -8069,14 +8075,14 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 1653,
+                "id": 4263,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 1654,
+                    "id": 4264,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -8097,14 +8103,14 @@
                     },
                     "parameters": [
                       {
-                        "id": 1655,
+                        "id": 4265,
                         "name": "warningKind",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1645,
+                          "id": 4255,
                           "name": "WarningKind",
                           "location": {
                             "page": "misc",
@@ -8136,7 +8142,7 @@
             }
           },
           {
-            "id": 1651,
+            "id": 4261,
             "name": "enabledWarnings",
             "kind": 1024,
             "kindString": "Property",
@@ -8168,7 +8174,7 @@
               "type": "array",
               "elementType": {
                 "type": "reference",
-                "id": 1645,
+                "id": 4255,
                 "name": "WarningKind",
                 "location": {
                   "page": "misc",
@@ -8191,7 +8197,7 @@
             }
           },
           {
-            "id": 1698,
+            "id": 4308,
             "name": "finalized",
             "kind": 1024,
             "kindString": "Property",
@@ -8231,7 +8237,7 @@
             }
           },
           {
-            "id": 1666,
+            "id": 4276,
             "name": "properties",
             "kind": 1024,
             "kindString": "Property",
@@ -8260,7 +8266,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 1631,
+              "id": 4241,
               "name": "PropertyDeclarations",
               "location": {
                 "page": "ReactiveElement",
@@ -8282,7 +8288,7 @@
             }
           },
           {
-            "id": 1693,
+            "id": 4303,
             "name": "shadowRootOptions",
             "kind": 1024,
             "kindString": "Property",
@@ -8331,7 +8337,7 @@
             }
           },
           {
-            "id": 1668,
+            "id": 4278,
             "name": "styles",
             "kind": 1024,
             "kindString": "Property",
@@ -8360,7 +8366,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2528,
+              "id": 5138,
               "name": "CSSResultGroup",
               "location": {
                 "page": "styles",
@@ -8382,7 +8388,7 @@
             }
           },
           {
-            "id": 1745,
+            "id": 4355,
             "name": "updateComplete",
             "kind": 262144,
             "kindString": "Accessor",
@@ -8414,7 +8420,7 @@
             },
             "getSignature": [
               {
-                "id": 1746,
+                "id": 4356,
                 "name": "updateComplete",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -8442,7 +8448,7 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1606,
+                  "id": 4216,
                   "name": "ReactiveControllerHost.updateComplete",
                   "location": {
                     "page": "controllers",
@@ -8453,7 +8459,7 @@
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 1606,
+              "id": 4216,
               "name": "ReactiveControllerHost.updateComplete",
               "location": {
                 "page": "controllers",
@@ -8475,7 +8481,7 @@
             }
           },
           {
-            "id": 1669,
+            "id": 4279,
             "name": "observedAttributes",
             "kind": 262144,
             "kindString": "Accessor",
@@ -8510,7 +8516,7 @@
             },
             "getSignature": [
               {
-                "id": 1670,
+                "id": 4280,
                 "name": "observedAttributes",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -8552,7 +8558,7 @@
             }
           },
           {
-            "id": 1709,
+            "id": 4319,
             "name": "addController",
             "kind": 2048,
             "kindString": "Method",
@@ -8569,7 +8575,7 @@
             ],
             "signatures": [
               {
-                "id": 1710,
+                "id": 4320,
                 "name": "addController",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8577,14 +8583,14 @@
                 "comment": {},
                 "parameters": [
                   {
-                    "id": 1711,
+                    "id": 4321,
                     "name": "controller",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1588,
+                      "id": 4198,
                       "name": "ReactiveController",
                       "location": {
                         "page": "controllers",
@@ -8599,14 +8605,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1599,
+                  "id": 4209,
                   "name": "ReactiveControllerHost.addController"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 1598,
+              "id": 4208,
               "name": "ReactiveControllerHost.addController",
               "location": {
                 "page": "controllers",
@@ -8628,7 +8634,7 @@
             }
           },
           {
-            "id": 1725,
+            "id": 4335,
             "name": "attributeChangedCallback",
             "kind": 2048,
             "kindString": "Method",
@@ -8648,7 +8654,7 @@
             ],
             "signatures": [
               {
-                "id": 1726,
+                "id": 4336,
                 "name": "attributeChangedCallback",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8658,7 +8664,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1727,
+                    "id": 4337,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8669,7 +8675,7 @@
                     }
                   },
                   {
-                    "id": 1728,
+                    "id": 4338,
                     "name": "_old",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8689,7 +8695,7 @@
                     }
                   },
                   {
-                    "id": 1729,
+                    "id": 4339,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8730,7 +8736,7 @@
             }
           },
           {
-            "id": 1718,
+            "id": 4328,
             "name": "connectedCallback",
             "kind": 2048,
             "kindString": "Method",
@@ -8750,7 +8756,7 @@
             ],
             "signatures": [
               {
-                "id": 1719,
+                "id": 4329,
                 "name": "connectedCallback",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8779,7 +8785,7 @@
             }
           },
           {
-            "id": 1716,
+            "id": 4326,
             "name": "createRenderRoot",
             "kind": 2048,
             "kindString": "Method",
@@ -8802,7 +8808,7 @@
             ],
             "signatures": [
               {
-                "id": 1717,
+                "id": 4327,
                 "name": "createRenderRoot",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8847,7 +8853,7 @@
             }
           },
           {
-            "id": 1723,
+            "id": 4333,
             "name": "disconnectedCallback",
             "kind": 2048,
             "kindString": "Method",
@@ -8867,7 +8873,7 @@
             ],
             "signatures": [
               {
-                "id": 1724,
+                "id": 4334,
                 "name": "disconnectedCallback",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8896,7 +8902,7 @@
             }
           },
           {
-            "id": 1720,
+            "id": 4330,
             "name": "enableUpdating",
             "kind": 2048,
             "kindString": "Method",
@@ -8918,7 +8924,7 @@
             ],
             "signatures": [
               {
-                "id": 1721,
+                "id": 4331,
                 "name": "enableUpdating",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8928,7 +8934,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1722,
+                    "id": 4332,
                     "name": "_requestedUpdate",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8960,7 +8966,7 @@
             }
           },
           {
-            "id": 1758,
+            "id": 4368,
             "name": "firstUpdated",
             "kind": 2048,
             "kindString": "Method",
@@ -8983,7 +8989,7 @@
             ],
             "signatures": [
               {
-                "id": 1759,
+                "id": 4369,
                 "name": "firstUpdated",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8994,7 +9000,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1760,
+                    "id": 4370,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9052,7 +9058,7 @@
             }
           },
           {
-            "id": 1747,
+            "id": 4357,
             "name": "getUpdateComplete",
             "kind": 2048,
             "kindString": "Method",
@@ -9076,7 +9082,7 @@
             ],
             "signatures": [
               {
-                "id": 1748,
+                "id": 4358,
                 "name": "getUpdateComplete",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9113,7 +9119,7 @@
             }
           },
           {
-            "id": 1739,
+            "id": 4349,
             "name": "performUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -9136,7 +9142,7 @@
             ],
             "signatures": [
               {
-                "id": 1740,
+                "id": 4350,
                 "name": "performUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9181,7 +9187,7 @@
             }
           },
           {
-            "id": 1712,
+            "id": 4322,
             "name": "removeController",
             "kind": 2048,
             "kindString": "Method",
@@ -9198,7 +9204,7 @@
             ],
             "signatures": [
               {
-                "id": 1713,
+                "id": 4323,
                 "name": "removeController",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9206,14 +9212,14 @@
                 "comment": {},
                 "parameters": [
                   {
-                    "id": 1714,
+                    "id": 4324,
                     "name": "controller",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1588,
+                      "id": 4198,
                       "name": "ReactiveController",
                       "location": {
                         "page": "controllers",
@@ -9228,14 +9234,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1602,
+                  "id": 4212,
                   "name": "ReactiveControllerHost.removeController"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 1601,
+              "id": 4211,
               "name": "ReactiveControllerHost.removeController",
               "location": {
                 "page": "controllers",
@@ -9257,7 +9263,7 @@
             }
           },
           {
-            "id": 1731,
+            "id": 4341,
             "name": "requestUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -9277,7 +9283,7 @@
             ],
             "signatures": [
               {
-                "id": 1732,
+                "id": 4342,
                 "name": "requestUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9287,7 +9293,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1733,
+                    "id": 4343,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9303,7 +9309,7 @@
                     }
                   },
                   {
-                    "id": 1734,
+                    "id": 4344,
                     "name": "oldValue",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9319,7 +9325,7 @@
                     }
                   },
                   {
-                    "id": 1735,
+                    "id": 4345,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9331,7 +9337,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -9356,14 +9362,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1605,
+                  "id": 4215,
                   "name": "ReactiveControllerHost.requestUpdate"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 1604,
+              "id": 4214,
               "name": "ReactiveControllerHost.requestUpdate",
               "location": {
                 "page": "controllers",
@@ -9385,7 +9391,7 @@
             }
           },
           {
-            "id": 1737,
+            "id": 4347,
             "name": "scheduleUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -9408,7 +9414,7 @@
             ],
             "signatures": [
               {
-                "id": 1738,
+                "id": 4348,
                 "name": "scheduleUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9453,7 +9459,7 @@
             }
           },
           {
-            "id": 1749,
+            "id": 4359,
             "name": "shouldUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -9475,7 +9481,7 @@
             ],
             "signatures": [
               {
-                "id": 1750,
+                "id": 4360,
                 "name": "shouldUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9485,7 +9491,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1751,
+                    "id": 4361,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9543,7 +9549,7 @@
             }
           },
           {
-            "id": 1752,
+            "id": 4362,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -9565,7 +9571,7 @@
             ],
             "signatures": [
               {
-                "id": 1753,
+                "id": 4363,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9575,7 +9581,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1754,
+                    "id": 4364,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9633,7 +9639,7 @@
             }
           },
           {
-            "id": 1755,
+            "id": 4365,
             "name": "updated",
             "kind": 2048,
             "kindString": "Method",
@@ -9656,7 +9662,7 @@
             ],
             "signatures": [
               {
-                "id": 1756,
+                "id": 4366,
                 "name": "updated",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9667,7 +9673,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1757,
+                    "id": 4367,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9725,7 +9731,7 @@
             }
           },
           {
-            "id": 1741,
+            "id": 4351,
             "name": "willUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -9742,7 +9748,7 @@
             ],
             "signatures": [
               {
-                "id": 1742,
+                "id": 4352,
                 "name": "willUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9750,7 +9756,7 @@
                 "comment": {},
                 "parameters": [
                   {
-                    "id": 1743,
+                    "id": 4353,
                     "name": "_changedProperties",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9805,7 +9811,7 @@
             }
           },
           {
-            "id": 1660,
+            "id": 4270,
             "name": "addInitializer",
             "kind": 2048,
             "kindString": "Method",
@@ -9824,7 +9830,7 @@
             ],
             "signatures": [
               {
-                "id": 1661,
+                "id": 4271,
                 "name": "addInitializer",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9839,14 +9845,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 1662,
+                    "id": 4272,
                     "name": "initializer",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1646,
+                      "id": 4256,
                       "name": "Initializer",
                       "location": {
                         "page": "misc",
@@ -9876,7 +9882,7 @@
             }
           },
           {
-            "id": 1671,
+            "id": 4281,
             "name": "createProperty",
             "kind": 2048,
             "kindString": "Method",
@@ -9905,7 +9911,7 @@
             ],
             "signatures": [
               {
-                "id": 1672,
+                "id": 4282,
                 "name": "createProperty",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9922,7 +9928,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1673,
+                    "id": 4283,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9933,7 +9939,7 @@
                     }
                   },
                   {
-                    "id": 1674,
+                    "id": 4284,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -9942,7 +9948,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -9982,7 +9988,7 @@
             }
           },
           {
-            "id": 1691,
+            "id": 4301,
             "name": "finalize",
             "kind": 2048,
             "kindString": "Method",
@@ -10011,7 +10017,7 @@
             ],
             "signatures": [
               {
-                "id": 1692,
+                "id": 4302,
                 "name": "finalize",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -10046,7 +10052,7 @@
             }
           },
           {
-            "id": 1694,
+            "id": 4304,
             "name": "finalizeStyles",
             "kind": 2048,
             "kindString": "Method",
@@ -10076,7 +10082,7 @@
             ],
             "signatures": [
               {
-                "id": 1695,
+                "id": 4305,
                 "name": "finalizeStyles",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -10093,7 +10099,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1696,
+                    "id": 4306,
                     "name": "styles",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -10102,7 +10108,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 2528,
+                      "id": 5138,
                       "name": "CSSResultGroup",
                       "location": {
                         "page": "styles",
@@ -10115,7 +10121,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 2526,
+                    "id": 5136,
                     "name": "CSSResultOrNative",
                     "location": {
                       "page": "styles",
@@ -10140,7 +10146,7 @@
             }
           },
           {
-            "id": 1675,
+            "id": 4285,
             "name": "getPropertyDescriptor",
             "kind": 2048,
             "kindString": "Method",
@@ -10170,7 +10176,7 @@
             ],
             "signatures": [
               {
-                "id": 1676,
+                "id": 4286,
                 "name": "getPropertyDescriptor",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -10187,7 +10193,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1677,
+                    "id": 4287,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -10198,7 +10204,7 @@
                     }
                   },
                   {
-                    "id": 1678,
+                    "id": 4288,
                     "name": "key",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -10218,14 +10224,14 @@
                     }
                   },
                   {
-                    "id": 1679,
+                    "id": 4289,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -10247,14 +10253,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 1680,
+                    "id": 4290,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "children": [
                       {
-                        "id": 1686,
+                        "id": 4296,
                         "name": "configurable",
                         "kind": 1024,
                         "kindString": "Property",
@@ -10272,7 +10278,7 @@
                         }
                       },
                       {
-                        "id": 1687,
+                        "id": 4297,
                         "name": "enumerable",
                         "kind": 1024,
                         "kindString": "Property",
@@ -10290,14 +10296,14 @@
                         }
                       },
                       {
-                        "id": 1681,
+                        "id": 4291,
                         "name": "get",
                         "kind": 2048,
                         "kindString": "Method",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 1682,
+                            "id": 4292,
                             "name": "get",
                             "kind": 4096,
                             "kindString": "Call signature",
@@ -10310,21 +10316,21 @@
                         ]
                       },
                       {
-                        "id": 1683,
+                        "id": 4293,
                         "name": "set",
                         "kind": 2048,
                         "kindString": "Method",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 1684,
+                            "id": 4294,
                             "name": "set",
                             "kind": 4096,
                             "kindString": "Call signature",
                             "flags": {},
                             "parameters": [
                               {
-                                "id": 1685,
+                                "id": 4295,
                                 "name": "value",
                                 "kind": 32768,
                                 "kindString": "Parameter",
@@ -10348,16 +10354,16 @@
                         "title": "Properties",
                         "kind": 1024,
                         "children": [
-                          1686,
-                          1687
+                          4296,
+                          4297
                         ]
                       },
                       {
                         "title": "Methods",
                         "kind": 2048,
                         "children": [
-                          1681,
-                          1683
+                          4291,
+                          4293
                         ]
                       }
                     ]
@@ -10380,7 +10386,7 @@
             }
           },
           {
-            "id": 1688,
+            "id": 4298,
             "name": "getPropertyOptions",
             "kind": 2048,
             "kindString": "Method",
@@ -10414,7 +10420,7 @@
             ],
             "signatures": [
               {
-                "id": 1689,
+                "id": 4299,
                 "name": "getPropertyOptions",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -10435,7 +10441,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1690,
+                    "id": 4300,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -10448,7 +10454,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 1618,
+                  "id": 4228,
                   "typeArguments": [
                     {
                       "type": "intrinsic",
@@ -10487,517 +10493,517 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              1699
+              4309
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2043,
-              2044,
-              2045,
-              2046,
-              2047,
-              2048,
-              2049,
-              2050,
-              2051,
-              2052,
-              2053,
-              2054,
-              2055,
-              2056,
-              2057,
-              2058,
-              2059,
-              2060,
-              1708,
-              1736,
-              1702,
-              1744,
-              1730,
-              1706,
-              1707,
-              1715,
-              1703,
-              1761,
-              1762,
-              2064,
-              2065,
-              2066,
-              2067,
-              2068,
-              2069,
-              2070,
-              2071,
-              2072,
-              2073,
-              2074,
-              2075,
-              2076,
-              2077,
-              2078,
-              2079,
-              2080,
-              2081,
-              2082,
-              2083,
-              2084,
-              2085,
-              2086,
-              2087,
-              2088,
-              2089,
-              2090,
-              2091,
-              2092,
-              2093,
-              2094,
-              2095,
-              2096,
-              2097,
-              2098,
-              2099,
-              2154,
-              1806,
-              1763,
-              1981,
-              2121,
-              1982,
-              2122,
-              1807,
-              1808,
-              1809,
-              1810,
-              1811,
-              1812,
-              2168,
-              2517,
-              1764,
-              1765,
-              2169,
-              1983,
-              2123,
-              1705,
-              1766,
-              1813,
-              2118,
-              1767,
-              2170,
-              1984,
-              2171,
-              1704,
-              1768,
-              1985,
-              2124,
-              1814,
-              1815,
-              2119,
-              1986,
-              1987,
-              1988,
-              1989,
-              2518,
-              1769,
-              1770,
-              1771,
-              1772,
-              1773,
-              2172,
-              2176,
-              2180,
-              2184,
-              2188,
-              2192,
-              2196,
-              2200,
-              2204,
-              2208,
-              2212,
-              2216,
-              2220,
-              2155,
-              2224,
-              2159,
-              2228,
-              2232,
-              2236,
-              2240,
-              2244,
-              2248,
-              2252,
-              2256,
-              2260,
-              2264,
-              2268,
-              2272,
-              2273,
-              2277,
-              1816,
-              1820,
-              2281,
-              2285,
-              2289,
-              2293,
-              2297,
-              2301,
-              2305,
-              2309,
-              2313,
-              2317,
-              2321,
-              2325,
-              2329,
-              2333,
-              2337,
-              2341,
-              2345,
-              2349,
-              2163,
-              2353,
-              2357,
-              2361,
-              2365,
-              2369,
-              2373,
-              2377,
-              2381,
-              2385,
-              2389,
-              2393,
-              2397,
-              2401,
-              2405,
-              2409,
-              2413,
-              2417,
-              2421,
-              2425,
-              2429,
-              2433,
-              2437,
-              2441,
-              2445,
-              2449,
-              2453,
-              2457,
-              2461,
-              2465,
-              2469,
-              2473,
-              2477,
-              2481,
-              2485,
-              2489,
-              2493,
-              2497,
-              2501,
-              2505,
-              2509,
-              2513,
-              1824,
-              1774,
-              1825,
-              1990,
-              1991,
-              1826,
-              1827,
-              2120,
-              1992,
-              1701,
-              1828,
-              1829,
-              1830,
-              1831,
-              1832,
-              1833,
-              1775,
-              2167,
-              2519,
-              1834,
-              1993,
-              1776,
-              1777,
-              1697,
-              1664,
-              1663,
-              1656,
-              1665,
-              1667,
-              1652,
-              1651,
-              1698,
-              1666,
-              1693,
-              1668
+              4653,
+              4654,
+              4655,
+              4656,
+              4657,
+              4658,
+              4659,
+              4660,
+              4661,
+              4662,
+              4663,
+              4664,
+              4665,
+              4666,
+              4667,
+              4668,
+              4669,
+              4670,
+              4318,
+              4346,
+              4312,
+              4354,
+              4340,
+              4316,
+              4317,
+              4325,
+              4313,
+              4371,
+              4372,
+              4674,
+              4675,
+              4676,
+              4677,
+              4678,
+              4679,
+              4680,
+              4681,
+              4682,
+              4683,
+              4684,
+              4685,
+              4686,
+              4687,
+              4688,
+              4689,
+              4690,
+              4691,
+              4692,
+              4693,
+              4694,
+              4695,
+              4696,
+              4697,
+              4698,
+              4699,
+              4700,
+              4701,
+              4702,
+              4703,
+              4704,
+              4705,
+              4706,
+              4707,
+              4708,
+              4709,
+              4764,
+              4416,
+              4373,
+              4591,
+              4731,
+              4592,
+              4732,
+              4417,
+              4418,
+              4419,
+              4420,
+              4421,
+              4422,
+              4778,
+              5127,
+              4374,
+              4375,
+              4779,
+              4593,
+              4733,
+              4315,
+              4376,
+              4423,
+              4728,
+              4377,
+              4780,
+              4594,
+              4781,
+              4314,
+              4378,
+              4595,
+              4734,
+              4424,
+              4425,
+              4729,
+              4596,
+              4597,
+              4598,
+              4599,
+              5128,
+              4379,
+              4380,
+              4381,
+              4382,
+              4383,
+              4782,
+              4786,
+              4790,
+              4794,
+              4798,
+              4802,
+              4806,
+              4810,
+              4814,
+              4818,
+              4822,
+              4826,
+              4830,
+              4765,
+              4834,
+              4769,
+              4838,
+              4842,
+              4846,
+              4850,
+              4854,
+              4858,
+              4862,
+              4866,
+              4870,
+              4874,
+              4878,
+              4882,
+              4883,
+              4887,
+              4426,
+              4430,
+              4891,
+              4895,
+              4899,
+              4903,
+              4907,
+              4911,
+              4915,
+              4919,
+              4923,
+              4927,
+              4931,
+              4935,
+              4939,
+              4943,
+              4947,
+              4951,
+              4955,
+              4959,
+              4773,
+              4963,
+              4967,
+              4971,
+              4975,
+              4979,
+              4983,
+              4987,
+              4991,
+              4995,
+              4999,
+              5003,
+              5007,
+              5011,
+              5015,
+              5019,
+              5023,
+              5027,
+              5031,
+              5035,
+              5039,
+              5043,
+              5047,
+              5051,
+              5055,
+              5059,
+              5063,
+              5067,
+              5071,
+              5075,
+              5079,
+              5083,
+              5087,
+              5091,
+              5095,
+              5099,
+              5103,
+              5107,
+              5111,
+              5115,
+              5119,
+              5123,
+              4434,
+              4384,
+              4435,
+              4600,
+              4601,
+              4436,
+              4437,
+              4730,
+              4602,
+              4311,
+              4438,
+              4439,
+              4440,
+              4441,
+              4442,
+              4443,
+              4385,
+              4777,
+              5129,
+              4444,
+              4603,
+              4386,
+              4387,
+              4307,
+              4274,
+              4273,
+              4266,
+              4275,
+              4277,
+              4262,
+              4261,
+              4308,
+              4276,
+              4303,
+              4278
             ],
             "categories": [
               {
                 "title": "Other",
                 "children": [
-                  2043,
-                  2044,
-                  2045,
-                  2046,
-                  2047,
-                  2048,
-                  2049,
-                  2050,
-                  2051,
-                  2052,
-                  2053,
-                  2054,
-                  2055,
-                  2056,
-                  2057,
-                  2058,
-                  2059,
-                  2060,
-                  1708,
-                  1736,
-                  1702,
-                  1744,
-                  1730,
-                  1706,
-                  1707,
-                  1715,
-                  1703,
-                  1761,
-                  1762,
-                  2064,
-                  2065,
-                  2066,
-                  2067,
-                  2068,
-                  2069,
-                  2070,
-                  2071,
-                  2072,
-                  2073,
-                  2074,
-                  2075,
-                  2076,
-                  2077,
-                  2078,
-                  2079,
-                  2080,
-                  2081,
-                  2082,
-                  2083,
-                  2084,
-                  2085,
-                  2086,
-                  2087,
-                  2088,
-                  2089,
-                  2090,
-                  2091,
-                  2092,
-                  2093,
-                  2094,
-                  2095,
-                  2096,
-                  2097,
-                  2098,
-                  2099,
-                  2154,
-                  1806,
-                  1763,
-                  1981,
-                  2121,
-                  1982,
-                  2122,
-                  1807,
-                  1808,
-                  1809,
-                  1810,
-                  1811,
-                  1812,
-                  2168,
-                  2517,
-                  1764,
-                  1765,
-                  2169,
-                  1983,
-                  2123,
-                  1766,
-                  1813,
-                  2118,
-                  1767,
-                  2170,
-                  1984,
-                  2171,
-                  1768,
-                  1985,
-                  2124,
-                  1814,
-                  1815,
-                  2119,
-                  1986,
-                  1987,
-                  1988,
-                  1989,
-                  2518,
-                  1769,
-                  1770,
-                  1771,
-                  1772,
-                  1773,
-                  2172,
-                  2176,
-                  2180,
-                  2184,
-                  2188,
-                  2192,
-                  2196,
-                  2200,
-                  2204,
-                  2208,
-                  2212,
-                  2216,
-                  2220,
-                  2155,
-                  2224,
-                  2159,
-                  2228,
-                  2232,
-                  2236,
-                  2240,
-                  2244,
-                  2248,
-                  2252,
-                  2256,
-                  2260,
-                  2264,
-                  2268,
-                  2272,
-                  2273,
-                  2277,
-                  1816,
-                  1820,
-                  2281,
-                  2285,
-                  2289,
-                  2293,
-                  2297,
-                  2301,
-                  2305,
-                  2309,
-                  2313,
-                  2317,
-                  2321,
-                  2325,
-                  2329,
-                  2333,
-                  2337,
-                  2341,
-                  2345,
-                  2349,
-                  2163,
-                  2353,
-                  2357,
-                  2361,
-                  2365,
-                  2369,
-                  2373,
-                  2377,
-                  2381,
-                  2385,
-                  2389,
-                  2393,
-                  2397,
-                  2401,
-                  2405,
-                  2409,
-                  2413,
-                  2417,
-                  2421,
-                  2425,
-                  2429,
-                  2433,
-                  2437,
-                  2441,
-                  2445,
-                  2449,
-                  2453,
-                  2457,
-                  2461,
-                  2465,
-                  2469,
-                  2473,
-                  2477,
-                  2481,
-                  2485,
-                  2489,
-                  2493,
-                  2497,
-                  2501,
-                  2505,
-                  2509,
-                  2513,
-                  1824,
-                  1774,
-                  1825,
-                  1990,
-                  1991,
-                  1826,
-                  1827,
-                  2120,
-                  1992,
-                  1828,
-                  1829,
-                  1830,
-                  1831,
-                  1832,
-                  1833,
-                  1775,
-                  2167,
-                  2519,
-                  1834,
-                  1993,
-                  1776,
-                  1777,
-                  1697,
-                  1664,
-                  1663,
-                  1698
+                  4653,
+                  4654,
+                  4655,
+                  4656,
+                  4657,
+                  4658,
+                  4659,
+                  4660,
+                  4661,
+                  4662,
+                  4663,
+                  4664,
+                  4665,
+                  4666,
+                  4667,
+                  4668,
+                  4669,
+                  4670,
+                  4318,
+                  4346,
+                  4312,
+                  4354,
+                  4340,
+                  4316,
+                  4317,
+                  4325,
+                  4313,
+                  4371,
+                  4372,
+                  4674,
+                  4675,
+                  4676,
+                  4677,
+                  4678,
+                  4679,
+                  4680,
+                  4681,
+                  4682,
+                  4683,
+                  4684,
+                  4685,
+                  4686,
+                  4687,
+                  4688,
+                  4689,
+                  4690,
+                  4691,
+                  4692,
+                  4693,
+                  4694,
+                  4695,
+                  4696,
+                  4697,
+                  4698,
+                  4699,
+                  4700,
+                  4701,
+                  4702,
+                  4703,
+                  4704,
+                  4705,
+                  4706,
+                  4707,
+                  4708,
+                  4709,
+                  4764,
+                  4416,
+                  4373,
+                  4591,
+                  4731,
+                  4592,
+                  4732,
+                  4417,
+                  4418,
+                  4419,
+                  4420,
+                  4421,
+                  4422,
+                  4778,
+                  5127,
+                  4374,
+                  4375,
+                  4779,
+                  4593,
+                  4733,
+                  4376,
+                  4423,
+                  4728,
+                  4377,
+                  4780,
+                  4594,
+                  4781,
+                  4378,
+                  4595,
+                  4734,
+                  4424,
+                  4425,
+                  4729,
+                  4596,
+                  4597,
+                  4598,
+                  4599,
+                  5128,
+                  4379,
+                  4380,
+                  4381,
+                  4382,
+                  4383,
+                  4782,
+                  4786,
+                  4790,
+                  4794,
+                  4798,
+                  4802,
+                  4806,
+                  4810,
+                  4814,
+                  4818,
+                  4822,
+                  4826,
+                  4830,
+                  4765,
+                  4834,
+                  4769,
+                  4838,
+                  4842,
+                  4846,
+                  4850,
+                  4854,
+                  4858,
+                  4862,
+                  4866,
+                  4870,
+                  4874,
+                  4878,
+                  4882,
+                  4883,
+                  4887,
+                  4426,
+                  4430,
+                  4891,
+                  4895,
+                  4899,
+                  4903,
+                  4907,
+                  4911,
+                  4915,
+                  4919,
+                  4923,
+                  4927,
+                  4931,
+                  4935,
+                  4939,
+                  4943,
+                  4947,
+                  4951,
+                  4955,
+                  4959,
+                  4773,
+                  4963,
+                  4967,
+                  4971,
+                  4975,
+                  4979,
+                  4983,
+                  4987,
+                  4991,
+                  4995,
+                  4999,
+                  5003,
+                  5007,
+                  5011,
+                  5015,
+                  5019,
+                  5023,
+                  5027,
+                  5031,
+                  5035,
+                  5039,
+                  5043,
+                  5047,
+                  5051,
+                  5055,
+                  5059,
+                  5063,
+                  5067,
+                  5071,
+                  5075,
+                  5079,
+                  5083,
+                  5087,
+                  5091,
+                  5095,
+                  5099,
+                  5103,
+                  5107,
+                  5111,
+                  5115,
+                  5119,
+                  5123,
+                  4434,
+                  4384,
+                  4435,
+                  4600,
+                  4601,
+                  4436,
+                  4437,
+                  4730,
+                  4602,
+                  4438,
+                  4439,
+                  4440,
+                  4441,
+                  4442,
+                  4443,
+                  4385,
+                  4777,
+                  5129,
+                  4444,
+                  4603,
+                  4386,
+                  4387,
+                  4307,
+                  4274,
+                  4273,
+                  4308
                 ]
               },
               {
                 "title": "dev-mode",
                 "children": [
-                  1656,
-                  1652,
-                  1651
+                  4266,
+                  4262,
+                  4261
                 ]
               },
               {
                 "title": "properties",
                 "children": [
-                  1665,
-                  1666
+                  4275,
+                  4276
                 ]
               },
               {
                 "title": "rendering",
                 "children": [
-                  1701,
-                  1693
+                  4311,
+                  4303
                 ]
               },
               {
                 "title": "styles",
                 "children": [
-                  1667,
-                  1668
+                  4277,
+                  4278
                 ]
               },
               {
                 "title": "updates",
                 "children": [
-                  1705,
-                  1704
+                  4315,
+                  4314
                 ]
               }
             ]
@@ -11006,20 +11012,20 @@
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              1745,
-              1669
+              4355,
+              4279
             ],
             "categories": [
               {
                 "title": "attributes",
                 "children": [
-                  1669
+                  4279
                 ]
               },
               {
                 "title": "updates",
                 "children": [
-                  1745
+                  4355
                 ]
               }
             ]
@@ -11028,228 +11034,228 @@
             "title": "Methods",
             "kind": 2048,
             "children": [
-              1709,
-              1780,
-              2107,
-              2100,
-              2125,
-              1994,
-              1835,
-              1725,
-              2110,
-              2520,
-              1778,
-              1998,
-              1838,
-              2001,
-              1718,
-              2004,
-              1716,
-              1723,
-              2061,
-              1720,
-              1758,
-              2522,
-              2104,
-              1848,
-              1851,
-              1855,
-              1857,
-              1860,
-              1864,
-              1866,
-              1868,
-              1871,
-              1880,
-              2007,
-              1747,
-              1890,
-              1893,
-              1897,
-              2010,
-              1899,
-              1902,
-              1906,
-              1910,
-              2012,
-              2017,
-              2020,
-              2023,
-              2026,
-              2029,
-              1914,
-              2032,
-              1739,
-              2128,
-              2131,
-              2141,
-              1917,
-              2113,
-              1920,
-              1923,
-              1927,
-              2034,
-              1712,
-              1793,
-              2038,
-              2151,
-              2115,
-              1930,
-              1933,
-              1731,
-              1737,
-              1935,
-              1941,
-              1947,
-              1950,
-              1956,
-              1960,
-              1965,
-              1968,
-              1971,
-              1749,
-              1974,
-              1752,
-              1755,
-              1978,
-              1741,
-              1660,
-              1671,
-              1691,
-              1694,
-              1675,
-              1688
+              4319,
+              4390,
+              4717,
+              4710,
+              4735,
+              4604,
+              4445,
+              4335,
+              4720,
+              5130,
+              4388,
+              4608,
+              4448,
+              4611,
+              4328,
+              4614,
+              4326,
+              4333,
+              4671,
+              4330,
+              4368,
+              5132,
+              4714,
+              4458,
+              4461,
+              4465,
+              4467,
+              4470,
+              4474,
+              4476,
+              4478,
+              4481,
+              4490,
+              4617,
+              4357,
+              4500,
+              4503,
+              4507,
+              4620,
+              4509,
+              4512,
+              4516,
+              4520,
+              4622,
+              4627,
+              4630,
+              4633,
+              4636,
+              4639,
+              4524,
+              4642,
+              4349,
+              4738,
+              4741,
+              4751,
+              4527,
+              4723,
+              4530,
+              4533,
+              4537,
+              4644,
+              4322,
+              4403,
+              4648,
+              4761,
+              4725,
+              4540,
+              4543,
+              4341,
+              4347,
+              4545,
+              4551,
+              4557,
+              4560,
+              4566,
+              4570,
+              4575,
+              4578,
+              4581,
+              4359,
+              4584,
+              4362,
+              4365,
+              4588,
+              4351,
+              4270,
+              4281,
+              4301,
+              4304,
+              4285,
+              4298
             ],
             "categories": [
               {
                 "title": "Other",
                 "children": [
-                  1780,
-                  2107,
-                  2100,
-                  2125,
-                  1994,
-                  1835,
-                  2110,
-                  2520,
-                  1778,
-                  1998,
-                  1838,
-                  2001,
-                  2004,
-                  2061,
-                  2522,
-                  2104,
-                  1848,
-                  1851,
-                  1855,
-                  1857,
-                  1860,
-                  1864,
-                  1866,
-                  1868,
-                  1871,
-                  1880,
-                  2007,
-                  1890,
-                  1893,
-                  1897,
-                  2010,
-                  1899,
-                  1902,
-                  1906,
-                  1910,
-                  2012,
-                  2017,
-                  2020,
-                  2023,
-                  2026,
-                  2029,
-                  1914,
-                  2032,
-                  2128,
-                  2131,
-                  2141,
-                  1917,
-                  2113,
-                  1920,
-                  1923,
-                  1927,
-                  2034,
-                  1793,
-                  2038,
-                  2151,
-                  2115,
-                  1930,
-                  1933,
-                  1935,
-                  1941,
-                  1947,
-                  1950,
-                  1956,
-                  1960,
-                  1965,
-                  1968,
-                  1971,
-                  1974,
-                  1978,
-                  1660,
-                  1691
+                  4390,
+                  4717,
+                  4710,
+                  4735,
+                  4604,
+                  4445,
+                  4720,
+                  5130,
+                  4388,
+                  4608,
+                  4448,
+                  4611,
+                  4614,
+                  4671,
+                  5132,
+                  4714,
+                  4458,
+                  4461,
+                  4465,
+                  4467,
+                  4470,
+                  4474,
+                  4476,
+                  4478,
+                  4481,
+                  4490,
+                  4617,
+                  4500,
+                  4503,
+                  4507,
+                  4620,
+                  4509,
+                  4512,
+                  4516,
+                  4520,
+                  4622,
+                  4627,
+                  4630,
+                  4633,
+                  4636,
+                  4639,
+                  4524,
+                  4642,
+                  4738,
+                  4741,
+                  4751,
+                  4527,
+                  4723,
+                  4530,
+                  4533,
+                  4537,
+                  4644,
+                  4403,
+                  4648,
+                  4761,
+                  4725,
+                  4540,
+                  4543,
+                  4545,
+                  4551,
+                  4557,
+                  4560,
+                  4566,
+                  4570,
+                  4575,
+                  4578,
+                  4581,
+                  4584,
+                  4588,
+                  4270,
+                  4301
                 ]
               },
               {
                 "title": "attributes",
                 "children": [
-                  1725
+                  4335
                 ]
               },
               {
                 "title": "controllers",
                 "children": [
-                  1709,
-                  1712
+                  4319,
+                  4322
                 ]
               },
               {
                 "title": "lifecycle",
                 "children": [
-                  1718,
-                  1723
+                  4328,
+                  4333
                 ]
               },
               {
                 "title": "properties",
                 "children": [
-                  1671,
-                  1675,
-                  1688
+                  4281,
+                  4285,
+                  4298
                 ]
               },
               {
                 "title": "rendering",
                 "children": [
-                  1716
+                  4326
                 ]
               },
               {
                 "title": "styles",
                 "children": [
-                  1694
+                  4304
                 ]
               },
               {
                 "title": "updates",
                 "children": [
-                  1720,
-                  1758,
-                  1747,
-                  1739,
-                  1731,
-                  1737,
-                  1749,
-                  1752,
-                  1755,
-                  1741
+                  4330,
+                  4368,
+                  4357,
+                  4349,
+                  4341,
+                  4347,
+                  4359,
+                  4362,
+                  4365,
+                  4351
                 ]
               }
             ]
@@ -11276,7 +11282,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 709,
+            "id": 3319,
             "name": "LitElement",
             "location": {
               "page": "LitElement",
@@ -11287,7 +11293,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 1597,
+            "id": 4207,
             "name": "ReactiveControllerHost",
             "location": {
               "page": "controllers",
@@ -11323,7 +11329,7 @@
             "title": "Attributes",
             "children": [
               {
-                "id": 1725,
+                "id": 4335,
                 "name": "attributeChangedCallback",
                 "kind": 2048,
                 "kindString": "Method",
@@ -11343,7 +11349,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1726,
+                    "id": 4336,
                     "name": "attributeChangedCallback",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -11353,7 +11359,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1727,
+                        "id": 4337,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -11364,7 +11370,7 @@
                         }
                       },
                       {
-                        "id": 1728,
+                        "id": 4338,
                         "name": "_old",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -11384,7 +11390,7 @@
                         }
                       },
                       {
-                        "id": 1729,
+                        "id": 4339,
                         "name": "value",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -11425,7 +11431,7 @@
                 }
               },
               {
-                "id": 1669,
+                "id": 4279,
                 "name": "observedAttributes",
                 "kind": 262144,
                 "kindString": "Accessor",
@@ -11460,7 +11466,7 @@
                 },
                 "getSignature": [
                   {
-                    "id": 1670,
+                    "id": 4280,
                     "name": "observedAttributes",
                     "kind": 524288,
                     "kindString": "Get signature",
@@ -11508,7 +11514,7 @@
             "title": "Controllers",
             "children": [
               {
-                "id": 1709,
+                "id": 4319,
                 "name": "addController",
                 "kind": 2048,
                 "kindString": "Method",
@@ -11525,7 +11531,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1710,
+                    "id": 4320,
                     "name": "addController",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -11533,14 +11539,14 @@
                     "comment": {},
                     "parameters": [
                       {
-                        "id": 1711,
+                        "id": 4321,
                         "name": "controller",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1588,
+                          "id": 4198,
                           "name": "ReactiveController",
                           "location": {
                             "page": "controllers",
@@ -11555,14 +11561,14 @@
                     },
                     "implementationOf": {
                       "type": "reference",
-                      "id": 1599,
+                      "id": 4209,
                       "name": "ReactiveControllerHost.addController"
                     }
                   }
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1598,
+                  "id": 4208,
                   "name": "ReactiveControllerHost.addController",
                   "location": {
                     "page": "controllers",
@@ -11584,7 +11590,7 @@
                 }
               },
               {
-                "id": 1712,
+                "id": 4322,
                 "name": "removeController",
                 "kind": 2048,
                 "kindString": "Method",
@@ -11601,7 +11607,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1713,
+                    "id": 4323,
                     "name": "removeController",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -11609,14 +11615,14 @@
                     "comment": {},
                     "parameters": [
                       {
-                        "id": 1714,
+                        "id": 4324,
                         "name": "controller",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1588,
+                          "id": 4198,
                           "name": "ReactiveController",
                           "location": {
                             "page": "controllers",
@@ -11631,14 +11637,14 @@
                     },
                     "implementationOf": {
                       "type": "reference",
-                      "id": 1602,
+                      "id": 4212,
                       "name": "ReactiveControllerHost.removeController"
                     }
                   }
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1601,
+                  "id": 4211,
                   "name": "ReactiveControllerHost.removeController",
                   "location": {
                     "page": "controllers",
@@ -11666,7 +11672,7 @@
             "title": "Dev mode",
             "children": [
               {
-                "id": 1656,
+                "id": 4266,
                 "name": "disableWarning",
                 "kind": 1024,
                 "kindString": "Property",
@@ -11697,14 +11703,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 1657,
+                    "id": 4267,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 1658,
+                        "id": 4268,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
@@ -11725,14 +11731,14 @@
                         },
                         "parameters": [
                           {
-                            "id": 1659,
+                            "id": 4269,
                             "name": "warningKind",
                             "kind": 32768,
                             "kindString": "Parameter",
                             "flags": {},
                             "type": {
                               "type": "reference",
-                              "id": 1645,
+                              "id": 4255,
                               "name": "WarningKind",
                               "location": {
                                 "page": "misc",
@@ -11764,7 +11770,7 @@
                 }
               },
               {
-                "id": 1651,
+                "id": 4261,
                 "name": "enabledWarnings",
                 "kind": 1024,
                 "kindString": "Property",
@@ -11796,7 +11802,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 1645,
+                    "id": 4255,
                     "name": "WarningKind",
                     "location": {
                       "page": "misc",
@@ -11819,7 +11825,7 @@
                 }
               },
               {
-                "id": 1652,
+                "id": 4262,
                 "name": "enableWarning",
                 "kind": 1024,
                 "kindString": "Property",
@@ -11850,14 +11856,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 1653,
+                    "id": 4263,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 1654,
+                        "id": 4264,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
@@ -11878,14 +11884,14 @@
                         },
                         "parameters": [
                           {
-                            "id": 1655,
+                            "id": 4265,
                             "name": "warningKind",
                             "kind": 32768,
                             "kindString": "Parameter",
                             "flags": {},
                             "type": {
                               "type": "reference",
-                              "id": 1645,
+                              "id": 4255,
                               "name": "WarningKind",
                               "location": {
                                 "page": "misc",
@@ -11923,7 +11929,7 @@
             "title": "Lifecycle",
             "children": [
               {
-                "id": 1718,
+                "id": 4328,
                 "name": "connectedCallback",
                 "kind": 2048,
                 "kindString": "Method",
@@ -11943,7 +11949,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1719,
+                    "id": 4329,
                     "name": "connectedCallback",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -11972,7 +11978,7 @@
                 }
               },
               {
-                "id": 1723,
+                "id": 4333,
                 "name": "disconnectedCallback",
                 "kind": 2048,
                 "kindString": "Method",
@@ -11992,7 +11998,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1724,
+                    "id": 4334,
                     "name": "disconnectedCallback",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12027,7 +12033,7 @@
             "title": "Other",
             "children": [
               {
-                "id": 1660,
+                "id": 4270,
                 "name": "addInitializer",
                 "kind": 2048,
                 "kindString": "Method",
@@ -12046,7 +12052,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1661,
+                    "id": 4271,
                     "name": "addInitializer",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12061,14 +12067,14 @@
                     },
                     "parameters": [
                       {
-                        "id": 1662,
+                        "id": 4272,
                         "name": "initializer",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1646,
+                          "id": 4256,
                           "name": "Initializer",
                           "location": {
                             "page": "misc",
@@ -12098,7 +12104,7 @@
                 }
               },
               {
-                "id": 1691,
+                "id": 4301,
                 "name": "finalize",
                 "kind": 2048,
                 "kindString": "Method",
@@ -12127,7 +12133,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1692,
+                    "id": 4302,
                     "name": "finalize",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12162,7 +12168,7 @@
                 }
               },
               {
-                "id": 1698,
+                "id": 4308,
                 "name": "finalized",
                 "kind": 1024,
                 "kindString": "Property",
@@ -12208,7 +12214,7 @@
             "title": "Properties",
             "children": [
               {
-                "id": 1671,
+                "id": 4281,
                 "name": "createProperty",
                 "kind": 2048,
                 "kindString": "Method",
@@ -12237,7 +12243,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1672,
+                    "id": 4282,
                     "name": "createProperty",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12254,7 +12260,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1673,
+                        "id": 4283,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -12265,7 +12271,7 @@
                         }
                       },
                       {
-                        "id": 1674,
+                        "id": 4284,
                         "name": "options",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -12274,7 +12280,7 @@
                         },
                         "type": {
                           "type": "reference",
-                          "id": 1618,
+                          "id": 4228,
                           "typeArguments": [
                             {
                               "type": "intrinsic",
@@ -12314,7 +12320,7 @@
                 }
               },
               {
-                "id": 1665,
+                "id": 4275,
                 "name": "elementProperties",
                 "kind": 1024,
                 "kindString": "Property",
@@ -12359,7 +12365,7 @@
                 }
               },
               {
-                "id": 1675,
+                "id": 4285,
                 "name": "getPropertyDescriptor",
                 "kind": 2048,
                 "kindString": "Method",
@@ -12389,7 +12395,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1676,
+                    "id": 4286,
                     "name": "getPropertyDescriptor",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12406,7 +12412,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1677,
+                        "id": 4287,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -12417,7 +12423,7 @@
                         }
                       },
                       {
-                        "id": 1678,
+                        "id": 4288,
                         "name": "key",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -12437,14 +12443,14 @@
                         }
                       },
                       {
-                        "id": 1679,
+                        "id": 4289,
                         "name": "options",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 1618,
+                          "id": 4228,
                           "typeArguments": [
                             {
                               "type": "intrinsic",
@@ -12466,14 +12472,14 @@
                     "type": {
                       "type": "reflection",
                       "declaration": {
-                        "id": 1680,
+                        "id": 4290,
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
                         "flags": {},
                         "children": [
                           {
-                            "id": 1686,
+                            "id": 4296,
                             "name": "configurable",
                             "kind": 1024,
                             "kindString": "Property",
@@ -12491,7 +12497,7 @@
                             }
                           },
                           {
-                            "id": 1687,
+                            "id": 4297,
                             "name": "enumerable",
                             "kind": 1024,
                             "kindString": "Property",
@@ -12509,14 +12515,14 @@
                             }
                           },
                           {
-                            "id": 1681,
+                            "id": 4291,
                             "name": "get",
                             "kind": 2048,
                             "kindString": "Method",
                             "flags": {},
                             "signatures": [
                               {
-                                "id": 1682,
+                                "id": 4292,
                                 "name": "get",
                                 "kind": 4096,
                                 "kindString": "Call signature",
@@ -12529,21 +12535,21 @@
                             ]
                           },
                           {
-                            "id": 1683,
+                            "id": 4293,
                             "name": "set",
                             "kind": 2048,
                             "kindString": "Method",
                             "flags": {},
                             "signatures": [
                               {
-                                "id": 1684,
+                                "id": 4294,
                                 "name": "set",
                                 "kind": 4096,
                                 "kindString": "Call signature",
                                 "flags": {},
                                 "parameters": [
                                   {
-                                    "id": 1685,
+                                    "id": 4295,
                                     "name": "value",
                                     "kind": 32768,
                                     "kindString": "Parameter",
@@ -12567,16 +12573,16 @@
                             "title": "Properties",
                             "kind": 1024,
                             "children": [
-                              1686,
-                              1687
+                              4296,
+                              4297
                             ]
                           },
                           {
                             "title": "Methods",
                             "kind": 2048,
                             "children": [
-                              1681,
-                              1683
+                              4291,
+                              4293
                             ]
                           }
                         ]
@@ -12599,7 +12605,7 @@
                 }
               },
               {
-                "id": 1688,
+                "id": 4298,
                 "name": "getPropertyOptions",
                 "kind": 2048,
                 "kindString": "Method",
@@ -12633,7 +12639,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1689,
+                    "id": 4299,
                     "name": "getPropertyOptions",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12654,7 +12660,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1690,
+                        "id": 4300,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -12667,7 +12673,7 @@
                     ],
                     "type": {
                       "type": "reference",
-                      "id": 1618,
+                      "id": 4228,
                       "typeArguments": [
                         {
                           "type": "intrinsic",
@@ -12701,7 +12707,7 @@
                 }
               },
               {
-                "id": 1666,
+                "id": 4276,
                 "name": "properties",
                 "kind": 1024,
                 "kindString": "Property",
@@ -12730,7 +12736,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 1631,
+                  "id": 4241,
                   "name": "PropertyDeclarations",
                   "location": {
                     "page": "ReactiveElement",
@@ -12758,7 +12764,7 @@
             "title": "Rendering",
             "children": [
               {
-                "id": 1716,
+                "id": 4326,
                 "name": "createRenderRoot",
                 "kind": 2048,
                 "kindString": "Method",
@@ -12781,7 +12787,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1717,
+                    "id": 4327,
                     "name": "createRenderRoot",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -12826,7 +12832,7 @@
                 }
               },
               {
-                "id": 1701,
+                "id": 4311,
                 "name": "renderRoot",
                 "kind": 1024,
                 "kindString": "Property",
@@ -12880,7 +12886,7 @@
                 }
               },
               {
-                "id": 1693,
+                "id": 4303,
                 "name": "shadowRootOptions",
                 "kind": 1024,
                 "kindString": "Property",
@@ -12935,7 +12941,7 @@
             "title": "Styles",
             "children": [
               {
-                "id": 1667,
+                "id": 4277,
                 "name": "elementStyles",
                 "kind": 1024,
                 "kindString": "Property",
@@ -12965,7 +12971,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 2526,
+                    "id": 5136,
                     "name": "CSSResultOrNative",
                     "location": {
                       "page": "styles",
@@ -12988,7 +12994,7 @@
                 }
               },
               {
-                "id": 1694,
+                "id": 4304,
                 "name": "finalizeStyles",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13018,7 +13024,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1695,
+                    "id": 4305,
                     "name": "finalizeStyles",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13035,7 +13041,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1696,
+                        "id": 4306,
                         "name": "styles",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13044,7 +13050,7 @@
                         },
                         "type": {
                           "type": "reference",
-                          "id": 2528,
+                          "id": 5138,
                           "name": "CSSResultGroup",
                           "location": {
                             "page": "styles",
@@ -13057,7 +13063,7 @@
                       "type": "array",
                       "elementType": {
                         "type": "reference",
-                        "id": 2526,
+                        "id": 5136,
                         "name": "CSSResultOrNative",
                         "location": {
                           "page": "styles",
@@ -13082,7 +13088,7 @@
                 }
               },
               {
-                "id": 1668,
+                "id": 4278,
                 "name": "styles",
                 "kind": 1024,
                 "kindString": "Property",
@@ -13111,7 +13117,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 2528,
+                  "id": 5138,
                   "name": "CSSResultGroup",
                   "location": {
                     "page": "styles",
@@ -13139,7 +13145,7 @@
             "title": "Updates",
             "children": [
               {
-                "id": 1720,
+                "id": 4330,
                 "name": "enableUpdating",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13161,7 +13167,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1721,
+                    "id": 4331,
                     "name": "enableUpdating",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13171,7 +13177,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1722,
+                        "id": 4332,
                         "name": "_requestedUpdate",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13203,7 +13209,7 @@
                 }
               },
               {
-                "id": 1758,
+                "id": 4368,
                 "name": "firstUpdated",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13226,7 +13232,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1759,
+                    "id": 4369,
                     "name": "firstUpdated",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13237,7 +13243,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1760,
+                        "id": 4370,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13295,7 +13301,7 @@
                 }
               },
               {
-                "id": 1747,
+                "id": 4357,
                 "name": "getUpdateComplete",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13319,7 +13325,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1748,
+                    "id": 4358,
                     "name": "getUpdateComplete",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13356,7 +13362,7 @@
                 }
               },
               {
-                "id": 1705,
+                "id": 4315,
                 "name": "hasUpdated",
                 "kind": 1024,
                 "kindString": "Property",
@@ -13391,7 +13397,7 @@
                 }
               },
               {
-                "id": 1704,
+                "id": 4314,
                 "name": "isUpdatePending",
                 "kind": 1024,
                 "kindString": "Property",
@@ -13426,7 +13432,7 @@
                 }
               },
               {
-                "id": 1739,
+                "id": 4349,
                 "name": "performUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13449,7 +13455,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1740,
+                    "id": 4350,
                     "name": "performUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13494,7 +13500,7 @@
                 }
               },
               {
-                "id": 1731,
+                "id": 4341,
                 "name": "requestUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13514,7 +13520,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1732,
+                    "id": 4342,
                     "name": "requestUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13524,7 +13530,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1733,
+                        "id": 4343,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13540,7 +13546,7 @@
                         }
                       },
                       {
-                        "id": 1734,
+                        "id": 4344,
                         "name": "oldValue",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13556,7 +13562,7 @@
                         }
                       },
                       {
-                        "id": 1735,
+                        "id": 4345,
                         "name": "options",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13568,7 +13574,7 @@
                         },
                         "type": {
                           "type": "reference",
-                          "id": 1618,
+                          "id": 4228,
                           "typeArguments": [
                             {
                               "type": "intrinsic",
@@ -13593,14 +13599,14 @@
                     },
                     "implementationOf": {
                       "type": "reference",
-                      "id": 1605,
+                      "id": 4215,
                       "name": "ReactiveControllerHost.requestUpdate"
                     }
                   }
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1604,
+                  "id": 4214,
                   "name": "ReactiveControllerHost.requestUpdate",
                   "location": {
                     "page": "controllers",
@@ -13622,7 +13628,7 @@
                 }
               },
               {
-                "id": 1737,
+                "id": 4347,
                 "name": "scheduleUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13645,7 +13651,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1738,
+                    "id": 4348,
                     "name": "scheduleUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13690,7 +13696,7 @@
                 }
               },
               {
-                "id": 1749,
+                "id": 4359,
                 "name": "shouldUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13712,7 +13718,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1750,
+                    "id": 4360,
                     "name": "shouldUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13722,7 +13728,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1751,
+                        "id": 4361,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13780,7 +13786,7 @@
                 }
               },
               {
-                "id": 1752,
+                "id": 4362,
                 "name": "update",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13802,7 +13808,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1753,
+                    "id": 4363,
                     "name": "update",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13812,7 +13818,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1754,
+                        "id": 4364,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -13870,7 +13876,7 @@
                 }
               },
               {
-                "id": 1745,
+                "id": 4355,
                 "name": "updateComplete",
                 "kind": 262144,
                 "kindString": "Accessor",
@@ -13902,7 +13908,7 @@
                 },
                 "getSignature": [
                   {
-                    "id": 1746,
+                    "id": 4356,
                     "name": "updateComplete",
                     "kind": 524288,
                     "kindString": "Get signature",
@@ -13930,7 +13936,7 @@
                     },
                     "implementationOf": {
                       "type": "reference",
-                      "id": 1606,
+                      "id": 4216,
                       "name": "ReactiveControllerHost.updateComplete",
                       "location": {
                         "page": "controllers",
@@ -13941,7 +13947,7 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "id": 1606,
+                  "id": 4216,
                   "name": "ReactiveControllerHost.updateComplete",
                   "location": {
                     "page": "controllers",
@@ -13963,7 +13969,7 @@
                 }
               },
               {
-                "id": 1755,
+                "id": 4365,
                 "name": "updated",
                 "kind": 2048,
                 "kindString": "Method",
@@ -13986,7 +13992,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1756,
+                    "id": 4366,
                     "name": "updated",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -13997,7 +14003,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 1757,
+                        "id": 4367,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -14055,7 +14061,7 @@
                 }
               },
               {
-                "id": 1741,
+                "id": 4351,
                 "name": "willUpdate",
                 "kind": 2048,
                 "kindString": "Method",
@@ -14072,7 +14078,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 1742,
+                    "id": 4352,
                     "name": "willUpdate",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -14080,7 +14086,7 @@
                     "comment": {},
                     "parameters": [
                       {
-                        "id": 1743,
+                        "id": 4353,
                         "name": "_changedProperties",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -14139,7 +14145,7 @@
         ]
       },
       {
-        "id": 708,
+        "id": 3318,
         "name": "UpdatingElement",
         "kind": 32,
         "kindString": "Variable",
@@ -14160,7 +14166,7 @@
           "type": "query",
           "queryType": {
             "type": "reference",
-            "id": 1650,
+            "id": 4260,
             "name": "ReactiveElement",
             "location": {
               "page": "ReactiveElement",
@@ -14183,7 +14189,7 @@
         }
       },
       {
-        "id": 1607,
+        "id": 4217,
         "name": "ComplexAttributeConverter",
         "kind": 256,
         "kindString": "Interface",
@@ -14193,7 +14199,7 @@
         },
         "children": [
           {
-            "id": 1608,
+            "id": 4218,
             "name": "fromAttribute",
             "kind": 2048,
             "kindString": "Method",
@@ -14206,7 +14212,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1609,
+                "id": 4219,
                 "name": "fromAttribute",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -14216,7 +14222,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1610,
+                    "id": 4220,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -14236,7 +14242,7 @@
                     }
                   },
                   {
-                    "id": 1611,
+                    "id": 4221,
                     "name": "type",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -14270,7 +14276,7 @@
             }
           },
           {
-            "id": 1612,
+            "id": 4222,
             "name": "toAttribute",
             "kind": 2048,
             "kindString": "Method",
@@ -14284,7 +14290,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1613,
+                "id": 4223,
                 "name": "toAttribute",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -14295,7 +14301,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1614,
+                    "id": 4224,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -14306,7 +14312,7 @@
                     }
                   },
                   {
-                    "id": 1615,
+                    "id": 4225,
                     "name": "type",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -14345,8 +14351,8 @@
             "title": "Methods",
             "kind": 2048,
             "children": [
-              1608,
-              1612
+              4218,
+              4222
             ]
           }
         ],
@@ -14361,7 +14367,7 @@
         ],
         "typeParameter": [
           {
-            "id": 1616,
+            "id": 4226,
             "name": "Type",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -14372,7 +14378,7 @@
             }
           },
           {
-            "id": 1617,
+            "id": 4227,
             "name": "TypeHint",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -14398,7 +14404,7 @@
         }
       },
       {
-        "id": 1618,
+        "id": 4228,
         "name": "PropertyDeclaration",
         "kind": 256,
         "kindString": "Interface",
@@ -14408,7 +14414,7 @@
         },
         "children": [
           {
-            "id": 1620,
+            "id": 4230,
             "name": "attribute",
             "kind": 1024,
             "kindString": "Property",
@@ -14457,7 +14463,7 @@
             }
           },
           {
-            "id": 1622,
+            "id": 4232,
             "name": "converter",
             "kind": 1024,
             "kindString": "Property",
@@ -14507,7 +14513,7 @@
             }
           },
           {
-            "id": 1628,
+            "id": 4238,
             "name": "noAccessor",
             "kind": 1024,
             "kindString": "Property",
@@ -14547,7 +14553,7 @@
             }
           },
           {
-            "id": 1623,
+            "id": 4233,
             "name": "reflect",
             "kind": 1024,
             "kindString": "Property",
@@ -14587,7 +14593,7 @@
             }
           },
           {
-            "id": 1619,
+            "id": 4229,
             "name": "state",
             "kind": 1024,
             "kindString": "Property",
@@ -14627,7 +14633,7 @@
             }
           },
           {
-            "id": 1621,
+            "id": 4231,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -14667,7 +14673,7 @@
             }
           },
           {
-            "id": 1624,
+            "id": 4234,
             "name": "hasChanged",
             "kind": 2048,
             "kindString": "Method",
@@ -14680,7 +14686,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1625,
+                "id": 4235,
                 "name": "hasChanged",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -14690,7 +14696,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 1626,
+                    "id": 4236,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -14701,7 +14707,7 @@
                     }
                   },
                   {
-                    "id": 1627,
+                    "id": 4237,
                     "name": "oldValue",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -14738,19 +14744,19 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              1620,
-              1622,
-              1628,
-              1623,
-              1619,
-              1621
+              4230,
+              4232,
+              4238,
+              4233,
+              4229,
+              4231
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              1624
+              4234
             ]
           }
         ],
@@ -14765,7 +14771,7 @@
         ],
         "typeParameter": [
           {
-            "id": 1629,
+            "id": 4239,
             "name": "Type",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -14776,7 +14782,7 @@
             }
           },
           {
-            "id": 1630,
+            "id": 4240,
             "name": "TypeHint",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -14802,7 +14808,7 @@
         }
       },
       {
-        "id": 1631,
+        "id": 4241,
         "name": "PropertyDeclarations",
         "kind": 256,
         "kindString": "Interface",
@@ -14821,14 +14827,14 @@
           }
         ],
         "indexSignature": {
-          "id": 1632,
+          "id": 4242,
           "name": "__index",
           "kind": 8192,
           "kindString": "Index signature",
           "flags": {},
           "parameters": [
             {
-              "id": 1633,
+              "id": 4243,
               "name": "key",
               "kind": 32768,
               "flags": {},
@@ -14840,7 +14846,7 @@
           ],
           "type": {
             "type": "reference",
-            "id": 1618,
+            "id": 4228,
             "name": "PropertyDeclaration",
             "location": {
               "page": "ReactiveElement",
@@ -14863,7 +14869,7 @@
         }
       },
       {
-        "id": 1634,
+        "id": 4244,
         "name": "PropertyValues",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -14883,7 +14889,7 @@
         ],
         "typeParameter": [
           {
-            "id": 1635,
+            "id": 4245,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -14950,9 +14956,12 @@
   {
     "slug": "templates",
     "title": "Templates",
+    "versionLinks": {
+      "v1": "api/lit-html/templates/"
+    },
     "items": [
       {
-        "id": 2576,
+        "id": 5186,
         "name": "html",
         "kind": 64,
         "kindString": "Function",
@@ -14974,7 +14983,7 @@
         ],
         "signatures": [
           {
-            "id": 2577,
+            "id": 5187,
             "name": "html",
             "kind": 4096,
             "kindString": "Call signature",
@@ -14984,7 +14993,7 @@
             },
             "parameters": [
               {
-                "id": 2578,
+                "id": 5188,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -14995,7 +15004,7 @@
                 }
               },
               {
-                "id": 2579,
+                "id": 5189,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15013,7 +15022,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2562,
+              "id": 5172,
               "typeArguments": [
                 {
                   "type": "literal",
@@ -15043,7 +15052,7 @@
         }
       },
       {
-        "id": 2585,
+        "id": 5195,
         "name": "nothing",
         "kind": 32,
         "kindString": "Variable",
@@ -15086,7 +15095,7 @@
         }
       },
       {
-        "id": 2596,
+        "id": 5206,
         "name": "render",
         "kind": 32,
         "kindString": "Function",
@@ -15109,14 +15118,14 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 2597,
+            "id": 5207,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
             "flags": {},
             "children": [
               {
-                "id": 2601,
+                "id": 5211,
                 "name": "createSanitizer",
                 "kind": 1024,
                 "kindString": "Property",
@@ -15130,7 +15139,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 2552,
+                  "id": 5162,
                   "name": "SanitizerFactory",
                   "location": {
                     "page": "templates",
@@ -15139,7 +15148,7 @@
                 }
               },
               {
-                "id": 2602,
+                "id": 5212,
                 "name": "_testOnlyClearSanitizerFactoryDoNotCallOrElse",
                 "kind": 2048,
                 "kindString": "Method",
@@ -15153,7 +15162,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 2603,
+                    "id": 5213,
                     "name": "_testOnlyClearSanitizerFactoryDoNotCallOrElse",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -15166,7 +15175,7 @@
                 ]
               },
               {
-                "id": 2598,
+                "id": 5208,
                 "name": "setSanitizer",
                 "kind": 2048,
                 "kindString": "Method",
@@ -15180,21 +15189,21 @@
                 ],
                 "signatures": [
                   {
-                    "id": 2599,
+                    "id": 5209,
                     "name": "setSanitizer",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 2600,
+                        "id": 5210,
                         "name": "newSanitizer",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 2552,
+                          "id": 5162,
                           "name": "SanitizerFactory",
                           "location": {
                             "page": "templates",
@@ -15216,15 +15225,15 @@
                 "title": "Properties",
                 "kind": 1024,
                 "children": [
-                  2601
+                  5211
                 ]
               },
               {
                 "title": "Methods",
                 "kind": 2048,
                 "children": [
-                  2602,
-                  2598
+                  5212,
+                  5208
                 ]
               }
             ],
@@ -15237,7 +15246,7 @@
             ],
             "signatures": [
               {
-                "id": 2604,
+                "id": 5214,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -15247,7 +15256,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 2605,
+                    "id": 5215,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -15259,7 +15268,7 @@
                     }
                   },
                   {
-                    "id": 2606,
+                    "id": 5216,
                     "name": "container",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -15286,7 +15295,7 @@
                     }
                   },
                   {
-                    "id": 2607,
+                    "id": 5217,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -15298,7 +15307,7 @@
                     },
                     "type": {
                       "type": "reference",
-                      "id": 2586,
+                      "id": 5196,
                       "name": "RenderOptions",
                       "location": {
                         "page": "LitElement",
@@ -15309,7 +15318,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 2619,
+                  "id": 5229,
                   "name": "RootPart",
                   "location": {
                     "page": "misc",
@@ -15322,7 +15331,7 @@
         },
         "signatures": [
           {
-            "id": 2604,
+            "id": 5214,
             "name": "render",
             "kind": 4096,
             "kindString": "Call signature",
@@ -15332,7 +15341,7 @@
             },
             "parameters": [
               {
-                "id": 2605,
+                "id": 5215,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15344,7 +15353,7 @@
                 }
               },
               {
-                "id": 2606,
+                "id": 5216,
                 "name": "container",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15371,7 +15380,7 @@
                 }
               },
               {
-                "id": 2607,
+                "id": 5217,
                 "name": "options",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15383,7 +15392,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -15394,7 +15403,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2619,
+              "id": 5229,
               "name": "RootPart",
               "location": {
                 "page": "misc",
@@ -15418,7 +15427,7 @@
         }
       },
       {
-        "id": 2580,
+        "id": 5190,
         "name": "svg",
         "kind": 64,
         "kindString": "Function",
@@ -15440,7 +15449,7 @@
         ],
         "signatures": [
           {
-            "id": 2581,
+            "id": 5191,
             "name": "svg",
             "kind": 4096,
             "kindString": "Call signature",
@@ -15450,7 +15459,7 @@
             },
             "parameters": [
               {
-                "id": 2582,
+                "id": 5192,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15461,7 +15470,7 @@
                 }
               },
               {
-                "id": 2583,
+                "id": 5193,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15479,7 +15488,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2562,
+              "id": 5172,
               "typeArguments": [
                 {
                   "type": "literal",
@@ -15509,7 +15518,7 @@
         }
       },
       {
-        "id": 2552,
+        "id": 5162,
         "name": "SanitizerFactory",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -15527,7 +15536,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 2553,
+            "id": 5163,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -15546,7 +15555,7 @@
             ],
             "signatures": [
               {
-                "id": 2554,
+                "id": 5164,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -15558,7 +15567,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 2555,
+                    "id": 5165,
                     "name": "node",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -15572,7 +15581,7 @@
                     }
                   },
                   {
-                    "id": 2556,
+                    "id": 5166,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -15586,7 +15595,7 @@
                     }
                   },
                   {
-                    "id": 2557,
+                    "id": 5167,
                     "name": "type",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -15611,7 +15620,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 2558,
+                  "id": 5168,
                   "name": "ValueSanitizer",
                   "location": {
                     "page": "misc",
@@ -15637,7 +15646,7 @@
         }
       },
       {
-        "id": 2569,
+        "id": 5179,
         "name": "SVGTemplateResult",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -15654,7 +15663,7 @@
         ],
         "type": {
           "type": "reference",
-          "id": 2562,
+          "id": 5172,
           "typeArguments": [
             {
               "type": "query",
@@ -15685,7 +15694,7 @@
         }
       },
       {
-        "id": 2562,
+        "id": 5172,
         "name": "TemplateResult",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -15705,7 +15714,7 @@
         ],
         "typeParameter": [
           {
-            "id": 2567,
+            "id": 5177,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -15723,14 +15732,14 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 2563,
+            "id": 5173,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
             "flags": {},
             "children": [
               {
-                "id": 2564,
+                "id": 5174,
                 "name": "_$litType$",
                 "kind": 1024,
                 "kindString": "Property",
@@ -15748,7 +15757,7 @@
                 }
               },
               {
-                "id": 2565,
+                "id": 5175,
                 "name": "strings",
                 "kind": 1024,
                 "kindString": "Property",
@@ -15766,7 +15775,7 @@
                 }
               },
               {
-                "id": 2566,
+                "id": 5176,
                 "name": "values",
                 "kind": 1024,
                 "kindString": "Property",
@@ -15792,9 +15801,9 @@
                 "title": "Properties",
                 "kind": 1024,
                 "children": [
-                  2564,
-                  2565,
-                  2566
+                  5174,
+                  5175,
+                  5176
                 ]
               }
             ],
@@ -15826,9 +15835,12 @@
   {
     "slug": "styles",
     "title": "Styles",
+    "versionLinks": {
+      "v1": "api/lit-element/styles/"
+    },
     "items": [
       {
-        "id": 2545,
+        "id": 5155,
         "name": "adoptStyles",
         "kind": 64,
         "kindString": "Function",
@@ -15850,7 +15862,7 @@
         ],
         "signatures": [
           {
-            "id": 2546,
+            "id": 5156,
             "name": "adoptStyles",
             "kind": 4096,
             "kindString": "Call signature",
@@ -15860,7 +15872,7 @@
             },
             "parameters": [
               {
-                "id": 2547,
+                "id": 5157,
                 "name": "renderRoot",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15874,7 +15886,7 @@
                 }
               },
               {
-                "id": 2548,
+                "id": 5158,
                 "name": "styles",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15883,7 +15895,7 @@
                   "type": "array",
                   "elementType": {
                     "type": "reference",
-                    "id": 2526,
+                    "id": 5136,
                     "name": "CSSResultOrNative",
                     "location": {
                       "page": "styles",
@@ -15914,7 +15926,7 @@
         }
       },
       {
-        "id": 2541,
+        "id": 5151,
         "name": "css",
         "kind": 64,
         "kindString": "Function",
@@ -15937,7 +15949,7 @@
         ],
         "signatures": [
           {
-            "id": 2542,
+            "id": 5152,
             "name": "css",
             "kind": 4096,
             "kindString": "Call signature",
@@ -15948,7 +15960,7 @@
             },
             "parameters": [
               {
-                "id": 2543,
+                "id": 5153,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15959,7 +15971,7 @@
                 }
               },
               {
-                "id": 2544,
+                "id": 5154,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -15977,7 +15989,7 @@
                       },
                       {
                         "type": "reference",
-                        "id": 2528,
+                        "id": 5138,
                         "name": "CSSResultGroup",
                         "location": {
                           "page": "styles",
@@ -15991,7 +16003,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2529,
+              "id": 5139,
               "name": "CSSResult",
               "location": {
                 "page": "styles",
@@ -16015,7 +16027,7 @@
         }
       },
       {
-        "id": 2529,
+        "id": 5139,
         "name": "CSSResult",
         "kind": 128,
         "kindString": "Class",
@@ -16026,7 +16038,7 @@
         },
         "children": [
           {
-            "id": 2533,
+            "id": 5143,
             "name": "cssText",
             "kind": 1024,
             "kindString": "Property",
@@ -16062,7 +16074,7 @@
             }
           },
           {
-            "id": 2534,
+            "id": 5144,
             "name": "styleSheet",
             "kind": 262144,
             "kindString": "Accessor",
@@ -16095,7 +16107,7 @@
             },
             "getSignature": [
               {
-                "id": 2535,
+                "id": 5145,
                 "name": "styleSheet",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -16133,7 +16145,7 @@
             }
           },
           {
-            "id": 2536,
+            "id": 5146,
             "name": "toString",
             "kind": 2048,
             "kindString": "Method",
@@ -16150,7 +16162,7 @@
             ],
             "signatures": [
               {
-                "id": 2537,
+                "id": 5147,
                 "name": "toString",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -16181,29 +16193,29 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              2530
+              5140
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2532,
-              2533
+              5142,
+              5143
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              2534
+              5144
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              2536
+              5146
             ]
           }
         ],
@@ -16231,7 +16243,7 @@
         }
       },
       {
-        "id": 2549,
+        "id": 5159,
         "name": "getCompatibleStyle",
         "kind": 64,
         "kindString": "Function",
@@ -16250,21 +16262,21 @@
         ],
         "signatures": [
           {
-            "id": 2550,
+            "id": 5160,
             "name": "getCompatibleStyle",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 2551,
+                "id": 5161,
                 "name": "s",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 2526,
+                  "id": 5136,
                   "name": "CSSResultOrNative",
                   "location": {
                     "page": "styles",
@@ -16275,7 +16287,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2526,
+              "id": 5136,
               "name": "CSSResultOrNative",
               "location": {
                 "page": "styles",
@@ -16299,7 +16311,7 @@
         }
       },
       {
-        "id": 2525,
+        "id": 5135,
         "name": "supportsAdoptingStyleSheets",
         "kind": 32,
         "kindString": "Variable",
@@ -16338,7 +16350,7 @@
         }
       },
       {
-        "id": 2538,
+        "id": 5148,
         "name": "unsafeCSS",
         "kind": 64,
         "kindString": "Function",
@@ -16361,7 +16373,7 @@
         ],
         "signatures": [
           {
-            "id": 2539,
+            "id": 5149,
             "name": "unsafeCSS",
             "kind": 4096,
             "kindString": "Call signature",
@@ -16372,7 +16384,7 @@
             },
             "parameters": [
               {
-                "id": 2540,
+                "id": 5150,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -16385,7 +16397,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2529,
+              "id": 5139,
               "name": "CSSResult",
               "location": {
                 "page": "styles",
@@ -16409,7 +16421,7 @@
         }
       },
       {
-        "id": 2527,
+        "id": 5137,
         "name": "CSSResultArray",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -16431,7 +16443,7 @@
             "types": [
               {
                 "type": "reference",
-                "id": 2526,
+                "id": 5136,
                 "name": "CSSResultOrNative",
                 "location": {
                   "page": "styles",
@@ -16440,7 +16452,7 @@
               },
               {
                 "type": "reference",
-                "id": 2527,
+                "id": 5137,
                 "name": "CSSResultArray",
                 "location": {
                   "page": "styles",
@@ -16465,7 +16477,7 @@
         }
       },
       {
-        "id": 2528,
+        "id": 5138,
         "name": "CSSResultGroup",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -16488,7 +16500,7 @@
           "types": [
             {
               "type": "reference",
-              "id": 2526,
+              "id": 5136,
               "name": "CSSResultOrNative",
               "location": {
                 "page": "styles",
@@ -16497,7 +16509,7 @@
             },
             {
               "type": "reference",
-              "id": 2527,
+              "id": 5137,
               "name": "CSSResultArray",
               "location": {
                 "page": "styles",
@@ -16521,7 +16533,7 @@
         }
       },
       {
-        "id": 2526,
+        "id": 5136,
         "name": "CSSResultOrNative",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -16545,7 +16557,7 @@
           "types": [
             {
               "type": "reference",
-              "id": 2529,
+              "id": 5139,
               "name": "CSSResult",
               "location": {
                 "page": "styles",
@@ -16580,9 +16592,12 @@
   {
     "slug": "decorators",
     "title": "Decorators",
+    "versionLinks": {
+      "v1": "api/lit-element/decorators/"
+    },
     "items": [
       {
-        "id": 54,
+        "id": 2664,
         "name": "customElement",
         "kind": 64,
         "kindString": "Function",
@@ -16605,7 +16620,7 @@
         ],
         "signatures": [
           {
-            "id": 55,
+            "id": 2665,
             "name": "customElement",
             "kind": 4096,
             "kindString": "Call signature",
@@ -16616,7 +16631,7 @@
             },
             "parameters": [
               {
-                "id": 56,
+                "id": 2666,
                 "name": "tagName",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -16633,21 +16648,21 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 57,
+                "id": 2667,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 58,
+                    "id": 2668,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 59,
+                        "id": 2669,
                         "name": "classOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -16692,7 +16707,7 @@
         }
       },
       {
-        "id": 80,
+        "id": 2690,
         "name": "eventOptions",
         "kind": 64,
         "kindString": "Function",
@@ -16712,7 +16727,7 @@
         ],
         "signatures": [
           {
-            "id": 81,
+            "id": 2691,
             "name": "eventOptions",
             "kind": 4096,
             "kindString": "Call signature",
@@ -16722,7 +16737,7 @@
             },
             "parameters": [
               {
-                "id": 82,
+                "id": 2692,
                 "name": "options",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -16739,7 +16754,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 83,
+                "id": 2693,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -16753,7 +16768,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 84,
+                    "id": 2694,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -16763,7 +16778,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 85,
+                        "id": 2695,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -16773,7 +16788,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 1650,
+                              "id": 4260,
                               "name": "ReactiveElement",
                               "location": {
                                 "page": "ReactiveElement",
@@ -16788,7 +16803,7 @@
                         }
                       },
                       {
-                        "id": 86,
+                        "id": 2696,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -16826,7 +16841,7 @@
         }
       },
       {
-        "id": 60,
+        "id": 2670,
         "name": "property",
         "kind": 64,
         "kindString": "Function",
@@ -16853,7 +16868,7 @@
         ],
         "signatures": [
           {
-            "id": 61,
+            "id": 2671,
             "name": "property",
             "kind": 4096,
             "kindString": "Call signature",
@@ -16870,7 +16885,7 @@
             },
             "parameters": [
               {
-                "id": 62,
+                "id": 2672,
                 "name": "options",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -16879,7 +16894,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 1618,
+                  "id": 4228,
                   "name": "PropertyDeclaration",
                   "location": {
                     "page": "ReactiveElement",
@@ -16891,7 +16906,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 63,
+                "id": 2673,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -16905,7 +16920,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 64,
+                    "id": 2674,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -16916,7 +16931,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 65,
+                        "id": 2675,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -16936,7 +16951,7 @@
                         }
                       },
                       {
-                        "id": 66,
+                        "id": 2676,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -16974,7 +16989,7 @@
         }
       },
       {
-        "id": 87,
+        "id": 2697,
         "name": "query",
         "kind": 64,
         "kindString": "Function",
@@ -16994,7 +17009,7 @@
         ],
         "signatures": [
           {
-            "id": 88,
+            "id": 2698,
             "name": "query",
             "kind": 4096,
             "kindString": "Call signature",
@@ -17004,7 +17019,7 @@
             },
             "parameters": [
               {
-                "id": 89,
+                "id": 2699,
                 "name": "selector",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17018,7 +17033,7 @@
                 }
               },
               {
-                "id": 90,
+                "id": 2700,
                 "name": "cache",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17037,7 +17052,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 91,
+                "id": 2701,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -17051,7 +17066,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 92,
+                    "id": 2702,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -17061,7 +17076,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 93,
+                        "id": 2703,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17071,7 +17086,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 1650,
+                              "id": 4260,
                               "name": "ReactiveElement",
                               "location": {
                                 "page": "ReactiveElement",
@@ -17086,7 +17101,7 @@
                         }
                       },
                       {
-                        "id": 94,
+                        "id": 2704,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17124,7 +17139,7 @@
         }
       },
       {
-        "id": 95,
+        "id": 2705,
         "name": "queryAll",
         "kind": 64,
         "kindString": "Function",
@@ -17144,7 +17159,7 @@
         ],
         "signatures": [
           {
-            "id": 96,
+            "id": 2706,
             "name": "queryAll",
             "kind": 4096,
             "kindString": "Call signature",
@@ -17154,7 +17169,7 @@
             },
             "parameters": [
               {
-                "id": 97,
+                "id": 2707,
                 "name": "selector",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17171,7 +17186,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 98,
+                "id": 2708,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -17185,7 +17200,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 99,
+                    "id": 2709,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -17195,7 +17210,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 100,
+                        "id": 2710,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17205,7 +17220,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 1650,
+                              "id": 4260,
                               "name": "ReactiveElement",
                               "location": {
                                 "page": "ReactiveElement",
@@ -17220,7 +17235,7 @@
                         }
                       },
                       {
-                        "id": 101,
+                        "id": 2711,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17258,7 +17273,7 @@
         }
       },
       {
-        "id": 109,
+        "id": 2719,
         "name": "queryAssignedNodes",
         "kind": 64,
         "kindString": "Function",
@@ -17278,7 +17293,7 @@
         ],
         "signatures": [
           {
-            "id": 110,
+            "id": 2720,
             "name": "queryAssignedNodes",
             "kind": 4096,
             "kindString": "Call signature",
@@ -17288,7 +17303,7 @@
             },
             "parameters": [
               {
-                "id": 111,
+                "id": 2721,
                 "name": "slotName",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17304,7 +17319,7 @@
                 }
               },
               {
-                "id": 112,
+                "id": 2722,
                 "name": "flatten",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17320,7 +17335,7 @@
                 }
               },
               {
-                "id": 113,
+                "id": 2723,
                 "name": "selector",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17339,7 +17354,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 114,
+                "id": 2724,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -17353,7 +17368,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 115,
+                    "id": 2725,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -17363,7 +17378,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 116,
+                        "id": 2726,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17373,7 +17388,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 1650,
+                              "id": 4260,
                               "name": "ReactiveElement",
                               "location": {
                                 "page": "ReactiveElement",
@@ -17388,7 +17403,7 @@
                         }
                       },
                       {
-                        "id": 117,
+                        "id": 2727,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17426,7 +17441,7 @@
         }
       },
       {
-        "id": 102,
+        "id": 2712,
         "name": "queryAsync",
         "kind": 64,
         "kindString": "Function",
@@ -17446,7 +17461,7 @@
         ],
         "signatures": [
           {
-            "id": 103,
+            "id": 2713,
             "name": "queryAsync",
             "kind": 4096,
             "kindString": "Call signature",
@@ -17456,7 +17471,7 @@
             },
             "parameters": [
               {
-                "id": 104,
+                "id": 2714,
                 "name": "selector",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17473,7 +17488,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 105,
+                "id": 2715,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -17487,7 +17502,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 106,
+                    "id": 2716,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -17497,7 +17512,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 107,
+                        "id": 2717,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17507,7 +17522,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 1650,
+                              "id": 4260,
                               "name": "ReactiveElement",
                               "location": {
                                 "page": "ReactiveElement",
@@ -17522,7 +17537,7 @@
                         }
                       },
                       {
-                        "id": 108,
+                        "id": 2718,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17560,7 +17575,7 @@
         }
       },
       {
-        "id": 67,
+        "id": 2677,
         "name": "state",
         "kind": 64,
         "kindString": "Function",
@@ -17581,7 +17596,7 @@
         ],
         "signatures": [
           {
-            "id": 68,
+            "id": 2678,
             "name": "state",
             "kind": 4096,
             "kindString": "Call signature",
@@ -17592,7 +17607,7 @@
             },
             "parameters": [
               {
-                "id": 69,
+                "id": 2679,
                 "name": "options",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17601,7 +17616,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 74,
+                  "id": 2684,
                   "name": "InternalPropertyDeclaration",
                   "location": {
                     "page": "decorators",
@@ -17613,7 +17628,7 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 70,
+                "id": 2680,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -17627,7 +17642,7 @@
                 ],
                 "signatures": [
                   {
-                    "id": 71,
+                    "id": 2681,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
@@ -17638,7 +17653,7 @@
                     },
                     "parameters": [
                       {
-                        "id": 72,
+                        "id": 2682,
                         "name": "protoOrDescriptor",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17658,7 +17673,7 @@
                         }
                       },
                       {
-                        "id": 73,
+                        "id": 2683,
                         "name": "name",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -17696,7 +17711,7 @@
         }
       },
       {
-        "id": 74,
+        "id": 2684,
         "name": "InternalPropertyDeclaration",
         "kind": 256,
         "kindString": "Interface",
@@ -17711,7 +17726,7 @@
         },
         "children": [
           {
-            "id": 75,
+            "id": 2685,
             "name": "hasChanged",
             "kind": 2048,
             "kindString": "Method",
@@ -17724,7 +17739,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 76,
+                "id": 2686,
                 "name": "hasChanged",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -17734,7 +17749,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 77,
+                    "id": 2687,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -17745,7 +17760,7 @@
                     }
                   },
                   {
-                    "id": 78,
+                    "id": 2688,
                     "name": "oldValue",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -17782,7 +17797,7 @@
             "title": "Methods",
             "kind": 2048,
             "children": [
-              75
+              2685
             ]
           }
         ],
@@ -17797,7 +17812,7 @@
         ],
         "typeParameter": [
           {
-            "id": 79,
+            "id": 2689,
             "name": "Type",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -17827,9 +17842,12 @@
   {
     "slug": "directives",
     "title": "Directives",
+    "versionLinks": {
+      "v1": "api/lit-html/directives/"
+    },
     "items": [
       {
-        "id": 118,
+        "id": 2728,
         "name": "asyncAppend",
         "kind": 64,
         "kindString": "Function",
@@ -17852,7 +17870,7 @@
         ],
         "signatures": [
           {
-            "id": 119,
+            "id": 2729,
             "name": "asyncAppend",
             "kind": 4096,
             "kindString": "Call signature",
@@ -17863,7 +17881,7 @@
             },
             "parameters": [
               {
-                "id": 120,
+                "id": 2730,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17883,7 +17901,7 @@
                 }
               },
               {
-                "id": 121,
+                "id": 2731,
                 "name": "_mapper",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -17893,21 +17911,21 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 122,
+                    "id": 2732,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 123,
+                        "id": 2733,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
                         "flags": {},
                         "parameters": [
                           {
-                            "id": 124,
+                            "id": 2734,
                             "name": "v",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -17918,7 +17936,7 @@
                             }
                           },
                           {
-                            "id": 125,
+                            "id": 2735,
                             "name": "index",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -17943,13 +17961,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 126,
+                    "id": 2736,
                     "name": "AsyncAppendDirective",
                     "location": {
                       "page": "directives",
@@ -17981,7 +17999,7 @@
         }
       },
       {
-        "id": 126,
+        "id": 2736,
         "name": "AsyncAppendDirective",
         "kind": 128,
         "kindString": "Class",
@@ -17991,7 +18009,7 @@
         },
         "children": [
           {
-            "id": 127,
+            "id": 2737,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -18006,21 +18024,21 @@
             ],
             "signatures": [
               {
-                "id": 128,
+                "id": 2738,
                 "name": "new AsyncAppendDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 129,
+                    "id": 2739,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -18031,7 +18049,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 126,
+                  "id": 2736,
                   "name": "AsyncAppendDirective",
                   "location": {
                     "page": "directives",
@@ -18040,14 +18058,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 161,
+                  "id": 2771,
                   "name": "AsyncReplaceDirective.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 160,
+              "id": 2770,
               "name": "AsyncReplaceDirective.constructor",
               "location": {
                 "page": "directives",
@@ -18069,7 +18087,7 @@
             }
           },
           {
-            "id": 148,
+            "id": 2758,
             "name": "isConnected",
             "kind": 1024,
             "kindString": "Property",
@@ -18093,7 +18111,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 183,
+              "id": 2793,
               "name": "AsyncReplaceDirective.isConnected",
               "location": {
                 "page": "directives",
@@ -18115,7 +18133,7 @@
             }
           },
           {
-            "id": 135,
+            "id": 2745,
             "name": "commitValue",
             "kind": 2048,
             "kindString": "Method",
@@ -18134,14 +18152,14 @@
             ],
             "signatures": [
               {
-                "id": 136,
+                "id": 2746,
                 "name": "commitValue",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 137,
+                    "id": 2747,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -18152,7 +18170,7 @@
                     }
                   },
                   {
-                    "id": 138,
+                    "id": 2748,
                     "name": "index",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -18169,14 +18187,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 176,
+                  "id": 2786,
                   "name": "AsyncReplaceDirective.commitValue"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 175,
+              "id": 2785,
               "name": "AsyncReplaceDirective.commitValue",
               "location": {
                 "page": "directives",
@@ -18198,7 +18216,7 @@
             }
           },
           {
-            "id": 144,
+            "id": 2754,
             "name": "disconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -18218,7 +18236,7 @@
             ],
             "signatures": [
               {
-                "id": 145,
+                "id": 2755,
                 "name": "disconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -18232,14 +18250,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 180,
+                  "id": 2790,
                   "name": "AsyncReplaceDirective.disconnected"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 179,
+              "id": 2789,
               "name": "AsyncReplaceDirective.disconnected",
               "location": {
                 "page": "directives",
@@ -18261,7 +18279,7 @@
             }
           },
           {
-            "id": 146,
+            "id": 2756,
             "name": "reconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -18278,7 +18296,7 @@
             ],
             "signatures": [
               {
-                "id": 147,
+                "id": 2757,
                 "name": "reconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -18289,14 +18307,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 182,
+                  "id": 2792,
                   "name": "AsyncReplaceDirective.reconnected"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 181,
+              "id": 2791,
               "name": "AsyncReplaceDirective.reconnected",
               "location": {
                 "page": "directives",
@@ -18318,7 +18336,7 @@
             }
           },
           {
-            "id": 139,
+            "id": 2749,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -18335,14 +18353,14 @@
             ],
             "signatures": [
               {
-                "id": 140,
+                "id": 2750,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "typeParameter": [
                   {
-                    "id": 141,
+                    "id": 2751,
                     "name": "T",
                     "kind": 131072,
                     "kindString": "Type parameter",
@@ -18351,7 +18369,7 @@
                 ],
                 "parameters": [
                   {
-                    "id": 142,
+                    "id": 2752,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -18368,7 +18386,7 @@
                     }
                   },
                   {
-                    "id": 143,
+                    "id": 2753,
                     "name": "_mapper",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -18393,14 +18411,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 167,
+                  "id": 2777,
                   "name": "AsyncReplaceDirective.render"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 166,
+              "id": 2776,
               "name": "AsyncReplaceDirective.render",
               "location": {
                 "page": "directives",
@@ -18422,7 +18440,7 @@
             }
           },
           {
-            "id": 154,
+            "id": 2764,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -18443,7 +18461,7 @@
             ],
             "signatures": [
               {
-                "id": 155,
+                "id": 2765,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -18454,7 +18472,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 156,
+                    "id": 2766,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -18474,14 +18492,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 190,
+                  "id": 2800,
                   "name": "AsyncReplaceDirective.setValue"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 189,
+              "id": 2799,
               "name": "AsyncReplaceDirective.setValue",
               "location": {
                 "page": "directives",
@@ -18503,7 +18521,7 @@
             }
           },
           {
-            "id": 131,
+            "id": 2741,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -18520,21 +18538,21 @@
             ],
             "signatures": [
               {
-                "id": 132,
+                "id": 2742,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 133,
+                    "id": 2743,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 539,
+                      "id": 3149,
                       "name": "ChildPart",
                       "location": {
                         "page": "custom-directives",
@@ -18543,7 +18561,7 @@
                     }
                   },
                   {
-                    "id": 134,
+                    "id": 2744,
                     "name": "params",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -18596,7 +18614,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -18608,14 +18626,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 172,
+                  "id": 2782,
                   "name": "AsyncReplaceDirective.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 171,
+              "id": 2781,
               "name": "AsyncReplaceDirective.update",
               "location": {
                 "page": "directives",
@@ -18642,35 +18660,35 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              127
+              2737
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              130,
-              148
+              2740,
+              2758
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              157
+              2767
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              149,
-              135,
-              144,
-              146,
-              139,
-              154,
-              131
+              2759,
+              2745,
+              2754,
+              2756,
+              2749,
+              2764,
+              2741
             ]
           }
         ],
@@ -18686,7 +18704,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 159,
+            "id": 2769,
             "name": "AsyncReplaceDirective",
             "location": {
               "page": "directives",
@@ -18706,7 +18724,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 159,
+            "id": 2769,
             "name": "AsyncReplaceDirective",
             "location": {
               "page": "directives",
@@ -18715,7 +18733,7 @@
           },
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -18724,7 +18742,7 @@
           },
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -18734,7 +18752,7 @@
         ]
       },
       {
-        "id": 194,
+        "id": 2804,
         "name": "asyncReplace",
         "kind": 64,
         "kindString": "Function",
@@ -18757,7 +18775,7 @@
         ],
         "signatures": [
           {
-            "id": 195,
+            "id": 2805,
             "name": "asyncReplace",
             "kind": 4096,
             "kindString": "Call signature",
@@ -18768,7 +18786,7 @@
             },
             "parameters": [
               {
-                "id": 196,
+                "id": 2806,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -18788,7 +18806,7 @@
                 }
               },
               {
-                "id": 197,
+                "id": 2807,
                 "name": "_mapper",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -18809,13 +18827,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 159,
+                    "id": 2769,
                     "name": "AsyncReplaceDirective",
                     "location": {
                       "page": "directives",
@@ -18847,14 +18865,14 @@
         }
       },
       {
-        "id": 159,
+        "id": 2769,
         "name": "AsyncReplaceDirective",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 160,
+            "id": 2770,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -18862,21 +18880,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 161,
+                "id": 2771,
                 "name": "new AsyncReplaceDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 162,
+                    "id": 2772,
                     "name": "_partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -18887,7 +18905,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 159,
+                  "id": 2769,
                   "name": "AsyncReplaceDirective",
                   "location": {
                     "page": "directives",
@@ -18896,14 +18914,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 30,
+                  "id": 2640,
                   "name": "AsyncDirective.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 29,
+              "id": 2639,
               "name": "AsyncDirective.constructor",
               "location": {
                 "page": "custom-directives",
@@ -18925,7 +18943,7 @@
             }
           },
           {
-            "id": 183,
+            "id": 2793,
             "name": "isConnected",
             "kind": 1024,
             "kindString": "Property",
@@ -18949,7 +18967,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 32,
+              "id": 2642,
               "name": "AsyncDirective.isConnected",
               "location": {
                 "page": "custom-directives",
@@ -18971,7 +18989,7 @@
             }
           },
           {
-            "id": 175,
+            "id": 2785,
             "name": "commitValue",
             "kind": 2048,
             "kindString": "Method",
@@ -18990,14 +19008,14 @@
             ],
             "signatures": [
               {
-                "id": 176,
+                "id": 2786,
                 "name": "commitValue",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 177,
+                    "id": 2787,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19008,7 +19026,7 @@
                     }
                   },
                   {
-                    "id": 178,
+                    "id": 2788,
                     "name": "_index",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19040,7 +19058,7 @@
             }
           },
           {
-            "id": 179,
+            "id": 2789,
             "name": "disconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -19060,7 +19078,7 @@
             ],
             "signatures": [
               {
-                "id": 180,
+                "id": 2790,
                 "name": "disconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -19074,14 +19092,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 42,
+                  "id": 2652,
                   "name": "AsyncDirective.disconnected"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 41,
+              "id": 2651,
               "name": "AsyncDirective.disconnected",
               "location": {
                 "page": "custom-directives",
@@ -19103,7 +19121,7 @@
             }
           },
           {
-            "id": 181,
+            "id": 2791,
             "name": "reconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -19120,7 +19138,7 @@
             ],
             "signatures": [
               {
-                "id": 182,
+                "id": 2792,
                 "name": "reconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -19131,14 +19149,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 44,
+                  "id": 2654,
                   "name": "AsyncDirective.reconnected"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 43,
+              "id": 2653,
               "name": "AsyncDirective.reconnected",
               "location": {
                 "page": "custom-directives",
@@ -19160,7 +19178,7 @@
             }
           },
           {
-            "id": 166,
+            "id": 2776,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -19177,14 +19195,14 @@
             ],
             "signatures": [
               {
-                "id": 167,
+                "id": 2777,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "typeParameter": [
                   {
-                    "id": 168,
+                    "id": 2778,
                     "name": "T",
                     "kind": 131072,
                     "kindString": "Type parameter",
@@ -19193,7 +19211,7 @@
                 ],
                 "parameters": [
                   {
-                    "id": 169,
+                    "id": 2779,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19210,7 +19228,7 @@
                     }
                   },
                   {
-                    "id": 170,
+                    "id": 2780,
                     "name": "_mapper",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19235,14 +19253,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 48,
+                  "id": 2658,
                   "name": "AsyncDirective.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 47,
+              "id": 2657,
               "name": "AsyncDirective.render",
               "location": {
                 "page": "custom-directives",
@@ -19264,7 +19282,7 @@
             }
           },
           {
-            "id": 189,
+            "id": 2799,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -19285,7 +19303,7 @@
             ],
             "signatures": [
               {
-                "id": 190,
+                "id": 2800,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -19296,7 +19314,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 191,
+                    "id": 2801,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19316,14 +19334,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 39,
+                  "id": 2649,
                   "name": "AsyncDirective.setValue"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 38,
+              "id": 2648,
               "name": "AsyncDirective.setValue",
               "location": {
                 "page": "custom-directives",
@@ -19345,7 +19363,7 @@
             }
           },
           {
-            "id": 171,
+            "id": 2781,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -19362,21 +19380,21 @@
             ],
             "signatures": [
               {
-                "id": 172,
+                "id": 2782,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 173,
+                    "id": 2783,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 539,
+                      "id": 3149,
                       "name": "ChildPart",
                       "location": {
                         "page": "custom-directives",
@@ -19385,7 +19403,7 @@
                     }
                   },
                   {
-                    "id": 174,
+                    "id": 2784,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19438,7 +19456,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -19450,14 +19468,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 51,
+                  "id": 2661,
                   "name": "AsyncDirective.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 50,
+              "id": 2660,
               "name": "AsyncDirective.update",
               "location": {
                 "page": "custom-directives",
@@ -19484,37 +19502,37 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              160
+              2770
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              165,
-              163,
-              164,
-              183
+              2775,
+              2773,
+              2774,
+              2793
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              192
+              2802
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              184,
-              175,
-              179,
-              181,
-              166,
-              189,
-              171
+              2794,
+              2785,
+              2789,
+              2791,
+              2776,
+              2799,
+              2781
             ]
           }
         ],
@@ -19530,7 +19548,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -19541,7 +19559,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 126,
+            "id": 2736,
             "name": "AsyncAppendDirective",
             "location": {
               "page": "directives",
@@ -19561,7 +19579,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -19570,7 +19588,7 @@
           },
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -19580,7 +19598,7 @@
         ]
       },
       {
-        "id": 198,
+        "id": 2808,
         "name": "cache",
         "kind": 64,
         "kindString": "Function",
@@ -19603,7 +19621,7 @@
         ],
         "signatures": [
           {
-            "id": 199,
+            "id": 2809,
             "name": "cache",
             "kind": 4096,
             "kindString": "Call signature",
@@ -19614,7 +19632,7 @@
             },
             "parameters": [
               {
-                "id": 200,
+                "id": 2810,
                 "name": "v",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -19627,13 +19645,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 201,
+                    "id": 2811,
                     "name": "CacheDirective",
                     "location": {
                       "page": "directives",
@@ -19665,7 +19683,7 @@
         }
       },
       {
-        "id": 201,
+        "id": 2811,
         "name": "CacheDirective",
         "kind": 128,
         "kindString": "Class",
@@ -19675,7 +19693,7 @@
         },
         "children": [
           {
-            "id": 202,
+            "id": 2812,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -19690,21 +19708,21 @@
             ],
             "signatures": [
               {
-                "id": 203,
+                "id": 2813,
                 "name": "new CacheDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 204,
+                    "id": 2814,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -19715,7 +19733,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 201,
+                  "id": 2811,
                   "name": "CacheDirective",
                   "location": {
                     "page": "directives",
@@ -19724,14 +19742,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -19753,7 +19771,7 @@
             }
           },
           {
-            "id": 207,
+            "id": 2817,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -19770,14 +19788,14 @@
             ],
             "signatures": [
               {
-                "id": 208,
+                "id": 2818,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 209,
+                    "id": 2819,
                     "name": "v",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19797,14 +19815,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -19826,7 +19844,7 @@
             }
           },
           {
-            "id": 210,
+            "id": 2820,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -19843,21 +19861,21 @@
             ],
             "signatures": [
               {
-                "id": 211,
+                "id": 2821,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 212,
+                    "id": 2822,
                     "name": "containerPart",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 539,
+                      "id": 3149,
                       "name": "ChildPart",
                       "location": {
                         "page": "custom-directives",
@@ -19866,7 +19884,7 @@
                     }
                   },
                   {
-                    "id": 213,
+                    "id": 2823,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -19896,14 +19914,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -19930,30 +19948,30 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              202
+              2812
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              205,
-              206
+              2815,
+              2816
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              214
+              2824
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              207,
-              210
+              2817,
+              2820
             ]
           }
         ],
@@ -19969,7 +19987,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -19989,7 +20007,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -19999,7 +20017,7 @@
         ]
       },
       {
-        "id": 219,
+        "id": 2829,
         "name": "classMap",
         "kind": 64,
         "kindString": "Function",
@@ -20022,7 +20040,7 @@
         ],
         "signatures": [
           {
-            "id": 220,
+            "id": 2830,
             "name": "classMap",
             "kind": 4096,
             "kindString": "Call signature",
@@ -20033,7 +20051,7 @@
             },
             "parameters": [
               {
-                "id": 221,
+                "id": 2831,
                 "name": "classInfo",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -20043,7 +20061,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 216,
+                  "id": 2826,
                   "name": "ClassInfo",
                   "location": {
                     "page": "directives",
@@ -20054,13 +20072,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 222,
+                    "id": 2832,
                     "name": "ClassMapDirective",
                     "location": {
                       "page": "directives",
@@ -20092,7 +20110,7 @@
         }
       },
       {
-        "id": 222,
+        "id": 2832,
         "name": "ClassMapDirective",
         "kind": 128,
         "kindString": "Class",
@@ -20102,7 +20120,7 @@
         },
         "children": [
           {
-            "id": 223,
+            "id": 2833,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -20117,21 +20135,21 @@
             ],
             "signatures": [
               {
-                "id": 224,
+                "id": 2834,
                 "name": "new ClassMapDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 225,
+                    "id": 2835,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -20142,7 +20160,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 222,
+                  "id": 2832,
                   "name": "ClassMapDirective",
                   "location": {
                     "page": "directives",
@@ -20151,14 +20169,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -20180,7 +20198,7 @@
             }
           },
           {
-            "id": 228,
+            "id": 2838,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -20197,21 +20215,21 @@
             ],
             "signatures": [
               {
-                "id": 229,
+                "id": 2839,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 230,
+                    "id": 2840,
                     "name": "classInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 216,
+                      "id": 2826,
                       "name": "ClassInfo",
                       "location": {
                         "page": "directives",
@@ -20226,14 +20244,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -20255,7 +20273,7 @@
             }
           },
           {
-            "id": 231,
+            "id": 2841,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -20272,21 +20290,21 @@
             ],
             "signatures": [
               {
-                "id": 232,
+                "id": 2842,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 233,
+                    "id": 2843,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 503,
+                      "id": 3113,
                       "name": "AttributePart",
                       "location": {
                         "page": "custom-directives",
@@ -20295,7 +20313,7 @@
                     }
                   },
                   {
-                    "id": 234,
+                    "id": 2844,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -20309,7 +20327,7 @@
                           "isOptional": false,
                           "element": {
                             "type": "reference",
-                            "id": 216,
+                            "id": 2826,
                             "name": "ClassInfo",
                             "location": {
                               "page": "directives",
@@ -20332,7 +20350,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -20344,14 +20362,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -20378,30 +20396,30 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              223
+              2833
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              226,
-              227
+              2836,
+              2837
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              235
+              2845
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              228,
-              231
+              2838,
+              2841
             ]
           }
         ],
@@ -20417,7 +20435,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -20437,7 +20455,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -20447,7 +20465,7 @@
         ]
       },
       {
-        "id": 216,
+        "id": 2826,
         "name": "ClassInfo",
         "kind": 256,
         "kindString": "Interface",
@@ -20466,14 +20484,14 @@
           }
         ],
         "indexSignature": {
-          "id": 217,
+          "id": 2827,
           "name": "__index",
           "kind": 8192,
           "kindString": "Index signature",
           "flags": {},
           "parameters": [
             {
-              "id": 218,
+              "id": 2828,
               "name": "name",
               "kind": 32768,
               "flags": {},
@@ -20512,7 +20530,7 @@
         ]
       },
       {
-        "id": 237,
+        "id": 2847,
         "name": "guard",
         "kind": 64,
         "kindString": "Function",
@@ -20535,7 +20553,7 @@
         ],
         "signatures": [
           {
-            "id": 238,
+            "id": 2848,
             "name": "guard",
             "kind": 4096,
             "kindString": "Call signature",
@@ -20546,7 +20564,7 @@
             },
             "parameters": [
               {
-                "id": 239,
+                "id": 2849,
                 "name": "_value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -20557,7 +20575,7 @@
                 }
               },
               {
-                "id": 240,
+                "id": 2850,
                 "name": "f",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -20568,14 +20586,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 241,
+                    "id": 2851,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 242,
+                        "id": 2852,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
@@ -20592,13 +20610,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 243,
+                    "id": 2853,
                     "name": "GuardDirective",
                     "location": {
                       "page": "directives",
@@ -20630,7 +20648,7 @@
         }
       },
       {
-        "id": 243,
+        "id": 2853,
         "name": "GuardDirective",
         "kind": 128,
         "kindString": "Class",
@@ -20640,7 +20658,7 @@
         },
         "children": [
           {
-            "id": 244,
+            "id": 2854,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -20648,21 +20666,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 245,
+                "id": 2855,
                 "name": "new GuardDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 246,
+                    "id": 2856,
                     "name": "_partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -20673,7 +20691,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 243,
+                  "id": 2853,
                   "name": "GuardDirective",
                   "location": {
                     "page": "directives",
@@ -20682,14 +20700,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -20711,7 +20729,7 @@
             }
           },
           {
-            "id": 248,
+            "id": 2858,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -20728,14 +20746,14 @@
             ],
             "signatures": [
               {
-                "id": 249,
+                "id": 2859,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 250,
+                    "id": 2860,
                     "name": "_value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -20746,7 +20764,7 @@
                     }
                   },
                   {
-                    "id": 251,
+                    "id": 2861,
                     "name": "f",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -20754,14 +20772,14 @@
                     "type": {
                       "type": "reflection",
                       "declaration": {
-                        "id": 252,
+                        "id": 2862,
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 253,
+                            "id": 2863,
                             "name": "__type",
                             "kind": 4096,
                             "kindString": "Call signature",
@@ -20782,14 +20800,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -20811,7 +20829,7 @@
             }
           },
           {
-            "id": 254,
+            "id": 2864,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -20828,21 +20846,21 @@
             ],
             "signatures": [
               {
-                "id": 255,
+                "id": 2865,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 256,
+                    "id": 2866,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -20851,7 +20869,7 @@
                     }
                   },
                   {
-                    "id": 257,
+                    "id": 2867,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -20875,14 +20893,14 @@
                           "element": {
                             "type": "reflection",
                             "declaration": {
-                              "id": 258,
+                              "id": 2868,
                               "name": "__type",
                               "kind": 65536,
                               "kindString": "Type literal",
                               "flags": {},
                               "signatures": [
                                 {
-                                  "id": 259,
+                                  "id": 2869,
                                   "name": "__type",
                                   "kind": 4096,
                                   "kindString": "Call signature",
@@ -20906,14 +20924,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -20940,29 +20958,29 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              244
+              2854
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              247
+              2857
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              260
+              2870
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              248,
-              254
+              2858,
+              2864
             ]
           }
         ],
@@ -20978,7 +20996,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -20998,7 +21016,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -21008,7 +21026,7 @@
         ]
       },
       {
-        "id": 262,
+        "id": 2872,
         "name": "ifDefined",
         "kind": 64,
         "kindString": "Function",
@@ -21031,7 +21049,7 @@
         ],
         "signatures": [
           {
-            "id": 263,
+            "id": 2873,
             "name": "ifDefined",
             "kind": 4096,
             "kindString": "Call signature",
@@ -21042,7 +21060,7 @@
             },
             "typeParameter": [
               {
-                "id": 264,
+                "id": 2874,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -21051,7 +21069,7 @@
             ],
             "parameters": [
               {
-                "id": 265,
+                "id": 2875,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -21069,7 +21087,7 @@
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 2585,
+                    "id": 5195,
                     "name": "nothing",
                     "location": {
                       "page": "templates",
@@ -21106,7 +21124,7 @@
         }
       },
       {
-        "id": 266,
+        "id": 2876,
         "name": "live",
         "kind": 64,
         "kindString": "Function",
@@ -21129,7 +21147,7 @@
         ],
         "signatures": [
           {
-            "id": 267,
+            "id": 2877,
             "name": "live",
             "kind": 4096,
             "kindString": "Call signature",
@@ -21140,7 +21158,7 @@
             },
             "parameters": [
               {
-                "id": 268,
+                "id": 2878,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -21153,13 +21171,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 269,
+                    "id": 2879,
                     "name": "LiveDirective",
                     "location": {
                       "page": "directives",
@@ -21191,7 +21209,7 @@
         }
       },
       {
-        "id": 269,
+        "id": 2879,
         "name": "LiveDirective",
         "kind": 128,
         "kindString": "Class",
@@ -21201,7 +21219,7 @@
         },
         "children": [
           {
-            "id": 270,
+            "id": 2880,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -21216,21 +21234,21 @@
             ],
             "signatures": [
               {
-                "id": 271,
+                "id": 2881,
                 "name": "new LiveDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 272,
+                    "id": 2882,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -21241,7 +21259,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 269,
+                  "id": 2879,
                   "name": "LiveDirective",
                   "location": {
                     "page": "directives",
@@ -21250,14 +21268,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -21279,7 +21297,7 @@
             }
           },
           {
-            "id": 273,
+            "id": 2883,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -21296,14 +21314,14 @@
             ],
             "signatures": [
               {
-                "id": 274,
+                "id": 2884,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 275,
+                    "id": 2885,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -21320,14 +21338,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -21349,7 +21367,7 @@
             }
           },
           {
-            "id": 276,
+            "id": 2886,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -21366,21 +21384,21 @@
             ],
             "signatures": [
               {
-                "id": 277,
+                "id": 2887,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 278,
+                    "id": 2888,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 503,
+                      "id": 3113,
                       "name": "AttributePart",
                       "location": {
                         "page": "custom-directives",
@@ -21389,7 +21407,7 @@
                     }
                   },
                   {
-                    "id": 279,
+                    "id": 2889,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -21416,14 +21434,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -21450,22 +21468,22 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              270
+              2880
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              280
+              2890
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              273,
-              276
+              2883,
+              2886
             ]
           }
         ],
@@ -21481,7 +21499,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -21501,7 +21519,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -21511,7 +21529,7 @@
         ]
       },
       {
-        "id": 282,
+        "id": 2892,
         "name": "createRef",
         "kind": 64,
         "kindString": "Function",
@@ -21533,7 +21551,7 @@
         ],
         "signatures": [
           {
-            "id": 283,
+            "id": 2893,
             "name": "createRef",
             "kind": 4096,
             "kindString": "Call signature",
@@ -21543,7 +21561,7 @@
             },
             "typeParameter": [
               {
-                "id": 284,
+                "id": 2894,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -21559,7 +21577,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 285,
+              "id": 2895,
               "typeArguments": [
                 {
                   "type": "reference",
@@ -21589,7 +21607,7 @@
         }
       },
       {
-        "id": 295,
+        "id": 2905,
         "name": "ref",
         "kind": 64,
         "kindString": "Function",
@@ -21612,7 +21630,7 @@
         ],
         "signatures": [
           {
-            "id": 296,
+            "id": 2906,
             "name": "ref",
             "kind": 4096,
             "kindString": "Call signature",
@@ -21623,14 +21641,14 @@
             },
             "parameters": [
               {
-                "id": 297,
+                "id": 2907,
                 "name": "_ref",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 291,
+                  "id": 2901,
                   "name": "RefOrCallback",
                   "location": {
                     "page": "directives",
@@ -21641,13 +21659,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 298,
+                    "id": 2908,
                     "name": "RefDirective",
                     "location": {
                       "page": "directives",
@@ -21679,7 +21697,7 @@
         }
       },
       {
-        "id": 285,
+        "id": 2895,
         "name": "Ref",
         "kind": 128,
         "kindString": "Class",
@@ -21689,7 +21707,7 @@
         },
         "children": [
           {
-            "id": 286,
+            "id": 2896,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -21697,14 +21715,14 @@
             "children": [],
             "signatures": [
               {
-                "id": 287,
+                "id": 2897,
                 "name": "new Ref",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "typeParameter": [
                   {
-                    "id": 288,
+                    "id": 2898,
                     "name": "T",
                     "kind": 131072,
                     "kindString": "Type parameter",
@@ -21720,7 +21738,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 285,
+                  "id": 2895,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -21750,7 +21768,7 @@
             }
           },
           {
-            "id": 289,
+            "id": 2899,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -21795,14 +21813,14 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              286
+              2896
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              289
+              2899
             ]
           }
         ],
@@ -21817,7 +21835,7 @@
         ],
         "typeParameter": [
           {
-            "id": 290,
+            "id": 2900,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -21842,7 +21860,7 @@
         ]
       },
       {
-        "id": 298,
+        "id": 2908,
         "name": "RefDirective",
         "kind": 128,
         "kindString": "Class",
@@ -21852,7 +21870,7 @@
         },
         "children": [
           {
-            "id": 299,
+            "id": 2909,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -21860,21 +21878,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 300,
+                "id": 2910,
                 "name": "new RefDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 301,
+                    "id": 2911,
                     "name": "_partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -21885,7 +21903,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 298,
+                  "id": 2908,
                   "name": "RefDirective",
                   "location": {
                     "page": "directives",
@@ -21894,14 +21912,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 30,
+                  "id": 2640,
                   "name": "AsyncDirective.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 29,
+              "id": 2639,
               "name": "AsyncDirective.constructor",
               "location": {
                 "page": "custom-directives",
@@ -21923,7 +21941,7 @@
             }
           },
           {
-            "id": 319,
+            "id": 2929,
             "name": "isConnected",
             "kind": 1024,
             "kindString": "Property",
@@ -21947,7 +21965,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 32,
+              "id": 2642,
               "name": "AsyncDirective.isConnected",
               "location": {
                 "page": "custom-directives",
@@ -21969,7 +21987,7 @@
             }
           },
           {
-            "id": 315,
+            "id": 2925,
             "name": "disconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -21989,7 +22007,7 @@
             ],
             "signatures": [
               {
-                "id": 316,
+                "id": 2926,
                 "name": "disconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -22003,14 +22021,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 42,
+                  "id": 2652,
                   "name": "AsyncDirective.disconnected"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 41,
+              "id": 2651,
               "name": "AsyncDirective.disconnected",
               "location": {
                 "page": "custom-directives",
@@ -22032,7 +22050,7 @@
             }
           },
           {
-            "id": 317,
+            "id": 2927,
             "name": "reconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -22049,7 +22067,7 @@
             ],
             "signatures": [
               {
-                "id": 318,
+                "id": 2928,
                 "name": "reconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -22060,14 +22078,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 44,
+                  "id": 2654,
                   "name": "AsyncDirective.reconnected"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 43,
+              "id": 2653,
               "name": "AsyncDirective.reconnected",
               "location": {
                 "page": "custom-directives",
@@ -22089,7 +22107,7 @@
             }
           },
           {
-            "id": 305,
+            "id": 2915,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -22106,21 +22124,21 @@
             ],
             "signatures": [
               {
-                "id": 306,
+                "id": 2916,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 307,
+                    "id": 2917,
                     "name": "_ref",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 291,
+                      "id": 2901,
                       "name": "RefOrCallback",
                       "location": {
                         "page": "directives",
@@ -22135,14 +22153,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 48,
+                  "id": 2658,
                   "name": "AsyncDirective.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 47,
+              "id": 2657,
               "name": "AsyncDirective.render",
               "location": {
                 "page": "custom-directives",
@@ -22164,7 +22182,7 @@
             }
           },
           {
-            "id": 325,
+            "id": 2935,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -22185,7 +22203,7 @@
             ],
             "signatures": [
               {
-                "id": 326,
+                "id": 2936,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -22196,7 +22214,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 327,
+                    "id": 2937,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -22216,14 +22234,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 39,
+                  "id": 2649,
                   "name": "AsyncDirective.setValue"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 38,
+              "id": 2648,
               "name": "AsyncDirective.setValue",
               "location": {
                 "page": "custom-directives",
@@ -22245,7 +22263,7 @@
             }
           },
           {
-            "id": 308,
+            "id": 2918,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -22262,21 +22280,21 @@
             ],
             "signatures": [
               {
-                "id": 309,
+                "id": 2919,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 310,
+                    "id": 2920,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 567,
+                      "id": 3177,
                       "name": "ElementPart",
                       "location": {
                         "page": "custom-directives",
@@ -22285,7 +22303,7 @@
                     }
                   },
                   {
-                    "id": 311,
+                    "id": 2921,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -22299,7 +22317,7 @@
                           "isOptional": false,
                           "element": {
                             "type": "reference",
-                            "id": 291,
+                            "id": 2901,
                             "name": "RefOrCallback",
                             "location": {
                               "page": "directives",
@@ -22317,14 +22335,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 51,
+                  "id": 2661,
                   "name": "AsyncDirective.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 50,
+              "id": 2660,
               "name": "AsyncDirective.update",
               "location": {
                 "page": "custom-directives",
@@ -22351,38 +22369,38 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              299
+              2909
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              304,
-              302,
-              303,
-              312,
-              319
+              2914,
+              2912,
+              2913,
+              2922,
+              2929
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              328,
-              313
+              2938,
+              2923
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              320,
-              315,
-              317,
-              305,
-              325,
-              308
+              2930,
+              2925,
+              2927,
+              2915,
+              2935,
+              2918
             ]
           }
         ],
@@ -22398,7 +22416,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -22418,7 +22436,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -22427,7 +22445,7 @@
           },
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -22437,7 +22455,7 @@
         ]
       },
       {
-        "id": 291,
+        "id": 2901,
         "name": "RefOrCallback",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -22457,7 +22475,7 @@
           "types": [
             {
               "type": "reference",
-              "id": 285,
+              "id": 2895,
               "name": "Ref",
               "location": {
                 "page": "directives",
@@ -22467,7 +22485,7 @@
             {
               "type": "reflection",
               "declaration": {
-                "id": 292,
+                "id": 2902,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
@@ -22481,14 +22499,14 @@
                 ],
                 "signatures": [
                   {
-                    "id": 293,
+                    "id": 2903,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 294,
+                        "id": 2904,
                         "name": "el",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -22532,7 +22550,7 @@
         ]
       },
       {
-        "id": 357,
+        "id": 2967,
         "name": "repeat",
         "kind": 64,
         "kindString": "Function",
@@ -22555,7 +22573,7 @@
         ],
         "signatures": [
           {
-            "id": 358,
+            "id": 2968,
             "name": "repeat",
             "kind": 4096,
             "kindString": "Call signature",
@@ -22566,7 +22584,7 @@
             },
             "typeParameter": [
               {
-                "id": 359,
+                "id": 2969,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -22575,7 +22593,7 @@
             ],
             "parameters": [
               {
-                "id": 360,
+                "id": 2970,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -22592,7 +22610,7 @@
                 }
               },
               {
-                "id": 361,
+                "id": 2971,
                 "name": "keyFnOrTemplate",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -22602,7 +22620,7 @@
                   "types": [
                     {
                       "type": "reference",
-                      "id": 330,
+                      "id": 2940,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -22617,7 +22635,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 336,
+                      "id": 2946,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -22634,7 +22652,7 @@
                 }
               },
               {
-                "id": 362,
+                "id": 2972,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -22643,7 +22661,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 336,
+                  "id": 2946,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -22664,7 +22682,7 @@
             }
           },
           {
-            "id": 363,
+            "id": 2973,
             "name": "repeat",
             "kind": 4096,
             "kindString": "Call signature",
@@ -22675,7 +22693,7 @@
             },
             "typeParameter": [
               {
-                "id": 364,
+                "id": 2974,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -22684,7 +22702,7 @@
             ],
             "parameters": [
               {
-                "id": 365,
+                "id": 2975,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -22701,14 +22719,14 @@
                 }
               },
               {
-                "id": 366,
+                "id": 2976,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 336,
+                  "id": 2946,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -22729,7 +22747,7 @@
             }
           },
           {
-            "id": 367,
+            "id": 2977,
             "name": "repeat",
             "kind": 4096,
             "kindString": "Call signature",
@@ -22740,7 +22758,7 @@
             },
             "typeParameter": [
               {
-                "id": 368,
+                "id": 2978,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -22749,7 +22767,7 @@
             ],
             "parameters": [
               {
-                "id": 369,
+                "id": 2979,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -22766,7 +22784,7 @@
                 }
               },
               {
-                "id": 370,
+                "id": 2980,
                 "name": "keyFn",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -22776,7 +22794,7 @@
                   "types": [
                     {
                       "type": "reference",
-                      "id": 330,
+                      "id": 2940,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -22791,7 +22809,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 336,
+                      "id": 2946,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -22808,14 +22826,14 @@
                 }
               },
               {
-                "id": 371,
+                "id": 2981,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 336,
+                  "id": 2946,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -22851,7 +22869,7 @@
         }
       },
       {
-        "id": 372,
+        "id": 2982,
         "name": "RepeatDirective",
         "kind": 128,
         "kindString": "Class",
@@ -22861,7 +22879,7 @@
         },
         "children": [
           {
-            "id": 373,
+            "id": 2983,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -22876,21 +22894,21 @@
             ],
             "signatures": [
               {
-                "id": 374,
+                "id": 2984,
                 "name": "new RepeatDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 375,
+                    "id": 2985,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -22901,7 +22919,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 372,
+                  "id": 2982,
                   "name": "RepeatDirective",
                   "location": {
                     "page": "directives",
@@ -22910,14 +22928,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -22939,7 +22957,7 @@
             }
           },
           {
-            "id": 378,
+            "id": 2988,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -22956,14 +22974,14 @@
             ],
             "signatures": [
               {
-                "id": 379,
+                "id": 2989,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "typeParameter": [
                   {
-                    "id": 380,
+                    "id": 2990,
                     "name": "T",
                     "kind": 131072,
                     "kindString": "Type parameter",
@@ -22972,7 +22990,7 @@
                 ],
                 "parameters": [
                   {
-                    "id": 381,
+                    "id": 2991,
                     "name": "items",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -22989,14 +23007,14 @@
                     }
                   },
                   {
-                    "id": 382,
+                    "id": 2992,
                     "name": "template",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 336,
+                      "id": 2946,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -23020,19 +23038,19 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               },
               {
-                "id": 383,
+                "id": 2993,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "typeParameter": [
                   {
-                    "id": 384,
+                    "id": 2994,
                     "name": "T",
                     "kind": 131072,
                     "kindString": "Type parameter",
@@ -23041,7 +23059,7 @@
                 ],
                 "parameters": [
                   {
-                    "id": 385,
+                    "id": 2995,
                     "name": "items",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23058,7 +23076,7 @@
                     }
                   },
                   {
-                    "id": 386,
+                    "id": 2996,
                     "name": "keyFn",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23068,7 +23086,7 @@
                       "types": [
                         {
                           "type": "reference",
-                          "id": 330,
+                          "id": 2940,
                           "typeArguments": [
                             {
                               "type": "reference",
@@ -23083,7 +23101,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 336,
+                          "id": 2946,
                           "typeArguments": [
                             {
                               "type": "reference",
@@ -23100,14 +23118,14 @@
                     }
                   },
                   {
-                    "id": 387,
+                    "id": 2997,
                     "name": "template",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 336,
+                      "id": 2946,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -23137,7 +23155,7 @@
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -23159,7 +23177,7 @@
             }
           },
           {
-            "id": 388,
+            "id": 2998,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -23176,14 +23194,14 @@
             ],
             "signatures": [
               {
-                "id": 389,
+                "id": 2999,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "typeParameter": [
                   {
-                    "id": 390,
+                    "id": 3000,
                     "name": "T",
                     "kind": 131072,
                     "kindString": "Type parameter",
@@ -23192,14 +23210,14 @@
                 ],
                 "parameters": [
                   {
-                    "id": 391,
+                    "id": 3001,
                     "name": "containerPart",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 539,
+                      "id": 3149,
                       "name": "ChildPart",
                       "location": {
                         "page": "custom-directives",
@@ -23208,7 +23226,7 @@
                     }
                   },
                   {
-                    "id": 392,
+                    "id": 3002,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23231,7 +23249,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 330,
+                              "id": 2940,
                               "typeArguments": [
                                 {
                                   "type": "reference",
@@ -23246,7 +23264,7 @@
                             },
                             {
                               "type": "reference",
-                              "id": 336,
+                              "id": 2946,
                               "typeArguments": [
                                 {
                                   "type": "reference",
@@ -23263,7 +23281,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 336,
+                          "id": 2946,
                           "typeArguments": [
                             {
                               "type": "reference",
@@ -23294,7 +23312,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -23306,14 +23324,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -23340,30 +23358,30 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              373
+              2983
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              377,
-              376
+              2987,
+              2986
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              393
+              3003
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              378,
-              388
+              2988,
+              2998
             ]
           }
         ],
@@ -23379,7 +23397,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -23399,7 +23417,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -23409,7 +23427,7 @@
         ]
       },
       {
-        "id": 336,
+        "id": 2946,
         "name": "ItemTemplate",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -23426,7 +23444,7 @@
         ],
         "typeParameter": [
           {
-            "id": 341,
+            "id": 2951,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -23436,7 +23454,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 337,
+            "id": 2947,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -23450,14 +23468,14 @@
             ],
             "signatures": [
               {
-                "id": 338,
+                "id": 2948,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 339,
+                    "id": 2949,
                     "name": "item",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23468,7 +23486,7 @@
                     }
                   },
                   {
-                    "id": 340,
+                    "id": 2950,
                     "name": "index",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23498,7 +23516,7 @@
         ]
       },
       {
-        "id": 330,
+        "id": 2940,
         "name": "KeyFn",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -23515,7 +23533,7 @@
         ],
         "typeParameter": [
           {
-            "id": 335,
+            "id": 2945,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -23525,7 +23543,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 331,
+            "id": 2941,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -23539,14 +23557,14 @@
             ],
             "signatures": [
               {
-                "id": 332,
+                "id": 2942,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 333,
+                    "id": 2943,
                     "name": "item",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23557,7 +23575,7 @@
                     }
                   },
                   {
-                    "id": 334,
+                    "id": 2944,
                     "name": "index",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -23587,7 +23605,7 @@
         ]
       },
       {
-        "id": 342,
+        "id": 2952,
         "name": "RepeatDirectiveFn",
         "kind": 256,
         "kindString": "Interface",
@@ -23604,14 +23622,14 @@
         ],
         "signatures": [
           {
-            "id": 343,
+            "id": 2953,
             "name": "RepeatDirectiveFn",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "typeParameter": [
               {
-                "id": 344,
+                "id": 2954,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -23620,7 +23638,7 @@
             ],
             "parameters": [
               {
-                "id": 345,
+                "id": 2955,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23637,7 +23655,7 @@
                 }
               },
               {
-                "id": 346,
+                "id": 2956,
                 "name": "keyFnOrTemplate",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23647,7 +23665,7 @@
                   "types": [
                     {
                       "type": "reference",
-                      "id": 330,
+                      "id": 2940,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -23662,7 +23680,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 336,
+                      "id": 2946,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -23679,7 +23697,7 @@
                 }
               },
               {
-                "id": 347,
+                "id": 2957,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23688,7 +23706,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 336,
+                  "id": 2946,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -23709,14 +23727,14 @@
             }
           },
           {
-            "id": 348,
+            "id": 2958,
             "name": "RepeatDirectiveFn",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "typeParameter": [
               {
-                "id": 349,
+                "id": 2959,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -23725,7 +23743,7 @@
             ],
             "parameters": [
               {
-                "id": 350,
+                "id": 2960,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23742,14 +23760,14 @@
                 }
               },
               {
-                "id": 351,
+                "id": 2961,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 336,
+                  "id": 2946,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -23770,14 +23788,14 @@
             }
           },
           {
-            "id": 352,
+            "id": 2962,
             "name": "RepeatDirectiveFn",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "typeParameter": [
               {
-                "id": 353,
+                "id": 2963,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -23786,7 +23804,7 @@
             ],
             "parameters": [
               {
-                "id": 354,
+                "id": 2964,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23803,7 +23821,7 @@
                 }
               },
               {
-                "id": 355,
+                "id": 2965,
                 "name": "keyFn",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23813,7 +23831,7 @@
                   "types": [
                     {
                       "type": "reference",
-                      "id": 330,
+                      "id": 2940,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -23828,7 +23846,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 336,
+                      "id": 2946,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -23845,14 +23863,14 @@
                 }
               },
               {
-                "id": 356,
+                "id": 2966,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 336,
+                  "id": 2946,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -23884,7 +23902,7 @@
         ]
       },
       {
-        "id": 398,
+        "id": 3008,
         "name": "styleMap",
         "kind": 64,
         "kindString": "Function",
@@ -23907,7 +23925,7 @@
         ],
         "signatures": [
           {
-            "id": 399,
+            "id": 3009,
             "name": "styleMap",
             "kind": 4096,
             "kindString": "Call signature",
@@ -23918,7 +23936,7 @@
             },
             "parameters": [
               {
-                "id": 400,
+                "id": 3010,
                 "name": "styleInfo",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -23928,7 +23946,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 395,
+                  "id": 3005,
                   "name": "StyleInfo",
                   "location": {
                     "page": "directives",
@@ -23939,13 +23957,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 401,
+                    "id": 3011,
                     "name": "StyleMapDirective",
                     "location": {
                       "page": "directives",
@@ -23977,7 +23995,7 @@
         }
       },
       {
-        "id": 401,
+        "id": 3011,
         "name": "StyleMapDirective",
         "kind": 128,
         "kindString": "Class",
@@ -23987,7 +24005,7 @@
         },
         "children": [
           {
-            "id": 402,
+            "id": 3012,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -24002,21 +24020,21 @@
             ],
             "signatures": [
               {
-                "id": 403,
+                "id": 3013,
                 "name": "new StyleMapDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 404,
+                    "id": 3014,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -24027,7 +24045,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 401,
+                  "id": 3011,
                   "name": "StyleMapDirective",
                   "location": {
                     "page": "directives",
@@ -24036,14 +24054,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -24065,7 +24083,7 @@
             }
           },
           {
-            "id": 406,
+            "id": 3016,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -24082,21 +24100,21 @@
             ],
             "signatures": [
               {
-                "id": 407,
+                "id": 3017,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 408,
+                    "id": 3018,
                     "name": "styleInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 395,
+                      "id": 3005,
                       "name": "StyleInfo",
                       "location": {
                         "page": "directives",
@@ -24111,14 +24129,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -24140,7 +24158,7 @@
             }
           },
           {
-            "id": 409,
+            "id": 3019,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -24157,21 +24175,21 @@
             ],
             "signatures": [
               {
-                "id": 410,
+                "id": 3020,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 411,
+                    "id": 3021,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 503,
+                      "id": 3113,
                       "name": "AttributePart",
                       "location": {
                         "page": "custom-directives",
@@ -24180,7 +24198,7 @@
                     }
                   },
                   {
-                    "id": 412,
+                    "id": 3022,
                     "name": "__namedParameters",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -24194,7 +24212,7 @@
                           "isOptional": false,
                           "element": {
                             "type": "reference",
-                            "id": 395,
+                            "id": 3005,
                             "name": "StyleInfo",
                             "location": {
                               "page": "directives",
@@ -24217,7 +24235,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -24229,14 +24247,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -24263,29 +24281,29 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              402
+              3012
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              405
+              3015
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              413
+              3023
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              406,
-              409
+              3016,
+              3019
             ]
           }
         ],
@@ -24301,7 +24319,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -24321,7 +24339,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -24331,7 +24349,7 @@
         ]
       },
       {
-        "id": 395,
+        "id": 3005,
         "name": "StyleInfo",
         "kind": 256,
         "kindString": "Interface",
@@ -24351,14 +24369,14 @@
           }
         ],
         "indexSignature": {
-          "id": 396,
+          "id": 3006,
           "name": "__index",
           "kind": 8192,
           "kindString": "Index signature",
           "flags": {},
           "parameters": [
             {
-              "id": 397,
+              "id": 3007,
               "name": "name",
               "kind": 32768,
               "flags": {},
@@ -24397,7 +24415,7 @@
         ]
       },
       {
-        "id": 415,
+        "id": 3025,
         "name": "templateContent",
         "kind": 64,
         "kindString": "Function",
@@ -24420,7 +24438,7 @@
         ],
         "signatures": [
           {
-            "id": 416,
+            "id": 3026,
             "name": "templateContent",
             "kind": 4096,
             "kindString": "Call signature",
@@ -24431,7 +24449,7 @@
             },
             "parameters": [
               {
-                "id": 417,
+                "id": 3027,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -24447,13 +24465,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 418,
+                    "id": 3028,
                     "name": "TemplateContentDirective",
                     "location": {
                       "page": "directives",
@@ -24485,7 +24503,7 @@
         }
       },
       {
-        "id": 418,
+        "id": 3028,
         "name": "TemplateContentDirective",
         "kind": 128,
         "kindString": "Class",
@@ -24495,7 +24513,7 @@
         },
         "children": [
           {
-            "id": 419,
+            "id": 3029,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -24510,21 +24528,21 @@
             ],
             "signatures": [
               {
-                "id": 420,
+                "id": 3030,
                 "name": "new TemplateContentDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 421,
+                    "id": 3031,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -24535,7 +24553,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 418,
+                  "id": 3028,
                   "name": "TemplateContentDirective",
                   "location": {
                     "page": "directives",
@@ -24544,14 +24562,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -24573,7 +24591,7 @@
             }
           },
           {
-            "id": 423,
+            "id": 3033,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -24590,14 +24608,14 @@
             ],
             "signatures": [
               {
-                "id": 424,
+                "id": 3034,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 425,
+                    "id": 3035,
                     "name": "template",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -24618,7 +24636,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -24637,14 +24655,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -24666,7 +24684,7 @@
             }
           },
           {
-            "id": 428,
+            "id": 3038,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -24683,21 +24701,21 @@
             ],
             "signatures": [
               {
-                "id": 429,
+                "id": 3039,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 430,
+                    "id": 3040,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -24706,7 +24724,7 @@
                     }
                   },
                   {
-                    "id": 431,
+                    "id": 3041,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -24726,14 +24744,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -24760,29 +24778,29 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              419
+              3029
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              422
+              3032
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              426
+              3036
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              423,
-              428
+              3033,
+              3038
             ]
           }
         ],
@@ -24798,7 +24816,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -24818,7 +24836,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -24828,7 +24846,7 @@
         ]
       },
       {
-        "id": 449,
+        "id": 3059,
         "name": "unsafeHTML",
         "kind": 64,
         "kindString": "Function",
@@ -24851,7 +24869,7 @@
         ],
         "signatures": [
           {
-            "id": 450,
+            "id": 3060,
             "name": "unsafeHTML",
             "kind": 4096,
             "kindString": "Call signature",
@@ -24862,7 +24880,7 @@
             },
             "parameters": [
               {
-                "id": 451,
+                "id": 3061,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -24886,7 +24904,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -24898,7 +24916,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2585,
+                        "id": 5195,
                         "name": "nothing",
                         "location": {
                           "page": "templates",
@@ -24912,13 +24930,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 432,
+                    "id": 3042,
                     "name": "UnsafeHTMLDirective",
                     "location": {
                       "page": "directives",
@@ -24950,14 +24968,14 @@
         }
       },
       {
-        "id": 432,
+        "id": 3042,
         "name": "UnsafeHTMLDirective",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 435,
+            "id": 3045,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -24972,21 +24990,21 @@
             ],
             "signatures": [
               {
-                "id": 436,
+                "id": 3046,
                 "name": "new UnsafeHTMLDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 437,
+                    "id": 3047,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -24997,7 +25015,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 432,
+                  "id": 3042,
                   "name": "UnsafeHTMLDirective",
                   "location": {
                     "page": "directives",
@@ -25006,14 +25024,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -25035,7 +25053,7 @@
             }
           },
           {
-            "id": 433,
+            "id": 3043,
             "name": "directiveName",
             "kind": 1024,
             "kindString": "Property",
@@ -25071,7 +25089,7 @@
             }
           },
           {
-            "id": 434,
+            "id": 3044,
             "name": "resultType",
             "kind": 1024,
             "kindString": "Property",
@@ -25107,7 +25125,7 @@
             }
           },
           {
-            "id": 440,
+            "id": 3050,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -25124,14 +25142,14 @@
             ],
             "signatures": [
               {
-                "id": 441,
+                "id": 3051,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 442,
+                    "id": 3052,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -25155,7 +25173,7 @@
                           "type": "query",
                           "queryType": {
                             "type": "reference",
-                            "id": 2584,
+                            "id": 5194,
                             "name": "noChange",
                             "location": {
                               "page": "custom-directives",
@@ -25167,7 +25185,7 @@
                           "type": "query",
                           "queryType": {
                             "type": "reference",
-                            "id": 2585,
+                            "id": 5195,
                             "name": "nothing",
                             "location": {
                               "page": "templates",
@@ -25194,7 +25212,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -25206,7 +25224,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2585,
+                        "id": 5195,
                         "name": "nothing",
                         "location": {
                           "page": "templates",
@@ -25216,7 +25234,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 2562,
+                      "id": 5172,
                       "typeArguments": [
                         {
                           "type": "union",
@@ -25242,14 +25260,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -25271,7 +25289,7 @@
             }
           },
           {
-            "id": 445,
+            "id": 3055,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -25288,21 +25306,21 @@
             ],
             "signatures": [
               {
-                "id": 446,
+                "id": 3056,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 447,
+                    "id": 3057,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -25311,7 +25329,7 @@
                     }
                   },
                   {
-                    "id": 448,
+                    "id": 3058,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -25331,14 +25349,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -25365,32 +25383,32 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              435
+              3045
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              439,
-              438,
-              433,
-              434
+              3049,
+              3048,
+              3043,
+              3044
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              443
+              3053
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              440,
-              445
+              3050,
+              3055
             ]
           }
         ],
@@ -25406,7 +25424,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -25417,7 +25435,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 455,
+            "id": 3065,
             "name": "UnsafeSVGDirective",
             "location": {
               "page": "directives",
@@ -25437,7 +25455,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -25447,7 +25465,7 @@
         ]
       },
       {
-        "id": 452,
+        "id": 3062,
         "name": "unsafeSVG",
         "kind": 64,
         "kindString": "Function",
@@ -25470,7 +25488,7 @@
         ],
         "signatures": [
           {
-            "id": 453,
+            "id": 3063,
             "name": "unsafeSVG",
             "kind": 4096,
             "kindString": "Call signature",
@@ -25481,7 +25499,7 @@
             },
             "parameters": [
               {
-                "id": 454,
+                "id": 3064,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -25505,7 +25523,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -25517,7 +25535,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2585,
+                        "id": 5195,
                         "name": "nothing",
                         "location": {
                           "page": "templates",
@@ -25531,13 +25549,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 455,
+                    "id": 3065,
                     "name": "UnsafeSVGDirective",
                     "location": {
                       "page": "directives",
@@ -25569,7 +25587,7 @@
         }
       },
       {
-        "id": 455,
+        "id": 3065,
         "name": "UnsafeSVGDirective",
         "kind": 128,
         "kindString": "Class",
@@ -25579,7 +25597,7 @@
         },
         "children": [
           {
-            "id": 458,
+            "id": 3068,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -25587,21 +25605,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 459,
+                "id": 3069,
                 "name": "new UnsafeSVGDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 460,
+                    "id": 3070,
                     "name": "partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -25612,7 +25630,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 455,
+                  "id": 3065,
                   "name": "UnsafeSVGDirective",
                   "location": {
                     "page": "directives",
@@ -25621,14 +25639,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 436,
+                  "id": 3046,
                   "name": "UnsafeHTMLDirective.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 435,
+              "id": 3045,
               "name": "UnsafeHTMLDirective.constructor",
               "location": {
                 "page": "directives",
@@ -25650,7 +25668,7 @@
             }
           },
           {
-            "id": 456,
+            "id": 3066,
             "name": "directiveName",
             "kind": 1024,
             "kindString": "Property",
@@ -25673,7 +25691,7 @@
             },
             "overwrites": {
               "type": "reference",
-              "id": 433,
+              "id": 3043,
               "name": "UnsafeHTMLDirective.directiveName",
               "location": {
                 "page": "directives",
@@ -25695,7 +25713,7 @@
             }
           },
           {
-            "id": 457,
+            "id": 3067,
             "name": "resultType",
             "kind": 1024,
             "kindString": "Property",
@@ -25718,7 +25736,7 @@
             },
             "overwrites": {
               "type": "reference",
-              "id": 434,
+              "id": 3044,
               "name": "UnsafeHTMLDirective.resultType",
               "location": {
                 "page": "directives",
@@ -25740,7 +25758,7 @@
             }
           },
           {
-            "id": 461,
+            "id": 3071,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -25757,14 +25775,14 @@
             ],
             "signatures": [
               {
-                "id": 462,
+                "id": 3072,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 463,
+                    "id": 3073,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -25788,7 +25806,7 @@
                           "type": "query",
                           "queryType": {
                             "type": "reference",
-                            "id": 2584,
+                            "id": 5194,
                             "name": "noChange",
                             "location": {
                               "page": "custom-directives",
@@ -25800,7 +25818,7 @@
                           "type": "query",
                           "queryType": {
                             "type": "reference",
-                            "id": 2585,
+                            "id": 5195,
                             "name": "nothing",
                             "location": {
                               "page": "templates",
@@ -25827,7 +25845,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2584,
+                        "id": 5194,
                         "name": "noChange",
                         "location": {
                           "page": "custom-directives",
@@ -25839,7 +25857,7 @@
                       "type": "query",
                       "queryType": {
                         "type": "reference",
-                        "id": 2585,
+                        "id": 5195,
                         "name": "nothing",
                         "location": {
                           "page": "templates",
@@ -25849,7 +25867,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 2562,
+                      "id": 5172,
                       "typeArguments": [
                         {
                           "type": "union",
@@ -25875,14 +25893,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 441,
+                  "id": 3051,
                   "name": "UnsafeHTMLDirective.render"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 440,
+              "id": 3050,
               "name": "UnsafeHTMLDirective.render",
               "location": {
                 "page": "directives",
@@ -25904,7 +25922,7 @@
             }
           },
           {
-            "id": 466,
+            "id": 3076,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -25921,21 +25939,21 @@
             ],
             "signatures": [
               {
-                "id": 467,
+                "id": 3077,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 468,
+                    "id": 3078,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -25944,7 +25962,7 @@
                     }
                   },
                   {
-                    "id": 469,
+                    "id": 3079,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -25964,14 +25982,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 446,
+                  "id": 3056,
                   "name": "UnsafeHTMLDirective.update"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 445,
+              "id": 3055,
               "name": "UnsafeHTMLDirective.update",
               "location": {
                 "page": "directives",
@@ -25998,30 +26016,30 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              458
+              3068
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              456,
-              457
+              3066,
+              3067
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              464
+              3074
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              461,
-              466
+              3071,
+              3076
             ]
           }
         ],
@@ -26037,7 +26055,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 432,
+            "id": 3042,
             "name": "UnsafeHTMLDirective",
             "location": {
               "page": "directives",
@@ -26057,7 +26075,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 432,
+            "id": 3042,
             "name": "UnsafeHTMLDirective",
             "location": {
               "page": "directives",
@@ -26066,7 +26084,7 @@
           },
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -26076,7 +26094,7 @@
         ]
       },
       {
-        "id": 500,
+        "id": 3110,
         "name": "until",
         "kind": 64,
         "kindString": "Function",
@@ -26099,7 +26117,7 @@
         ],
         "signatures": [
           {
-            "id": 501,
+            "id": 3111,
             "name": "until",
             "kind": 4096,
             "kindString": "Call signature",
@@ -26110,7 +26128,7 @@
             },
             "parameters": [
               {
-                "id": 502,
+                "id": 3112,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -26128,13 +26146,13 @@
             ],
             "type": {
               "type": "reference",
-              "id": 628,
+              "id": 3238,
               "typeArguments": [
                 {
                   "type": "query",
                   "queryType": {
                     "type": "reference",
-                    "id": 470,
+                    "id": 3080,
                     "name": "UntilDirective",
                     "location": {
                       "page": "directives",
@@ -26166,14 +26184,14 @@
         }
       },
       {
-        "id": 470,
+        "id": 3080,
         "name": "UntilDirective",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 471,
+            "id": 3081,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -26181,21 +26199,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 472,
+                "id": 3082,
                 "name": "new UntilDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 473,
+                    "id": 3083,
                     "name": "_partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -26206,7 +26224,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 470,
+                  "id": 3080,
                   "name": "UntilDirective",
                   "location": {
                     "page": "directives",
@@ -26215,14 +26233,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 30,
+                  "id": 2640,
                   "name": "AsyncDirective.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 29,
+              "id": 2639,
               "name": "AsyncDirective.constructor",
               "location": {
                 "page": "custom-directives",
@@ -26244,7 +26262,7 @@
             }
           },
           {
-            "id": 489,
+            "id": 3099,
             "name": "isConnected",
             "kind": 1024,
             "kindString": "Property",
@@ -26268,7 +26286,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 32,
+              "id": 2642,
               "name": "AsyncDirective.isConnected",
               "location": {
                 "page": "custom-directives",
@@ -26290,7 +26308,7 @@
             }
           },
           {
-            "id": 485,
+            "id": 3095,
             "name": "disconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -26310,7 +26328,7 @@
             ],
             "signatures": [
               {
-                "id": 486,
+                "id": 3096,
                 "name": "disconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -26324,14 +26342,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 42,
+                  "id": 2652,
                   "name": "AsyncDirective.disconnected"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 41,
+              "id": 2651,
               "name": "AsyncDirective.disconnected",
               "location": {
                 "page": "custom-directives",
@@ -26353,7 +26371,7 @@
             }
           },
           {
-            "id": 487,
+            "id": 3097,
             "name": "reconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -26370,7 +26388,7 @@
             ],
             "signatures": [
               {
-                "id": 488,
+                "id": 3098,
                 "name": "reconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -26381,14 +26399,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 44,
+                  "id": 2654,
                   "name": "AsyncDirective.reconnected"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 43,
+              "id": 2653,
               "name": "AsyncDirective.reconnected",
               "location": {
                 "page": "custom-directives",
@@ -26410,7 +26428,7 @@
             }
           },
           {
-            "id": 478,
+            "id": 3088,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -26427,14 +26445,14 @@
             ],
             "signatures": [
               {
-                "id": 479,
+                "id": 3089,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 480,
+                    "id": 3090,
                     "name": "args",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -26456,14 +26474,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 48,
+                  "id": 2658,
                   "name": "AsyncDirective.render"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 47,
+              "id": 2657,
               "name": "AsyncDirective.render",
               "location": {
                 "page": "custom-directives",
@@ -26485,7 +26503,7 @@
             }
           },
           {
-            "id": 495,
+            "id": 3105,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -26506,7 +26524,7 @@
             ],
             "signatures": [
               {
-                "id": 496,
+                "id": 3106,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -26517,7 +26535,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 497,
+                    "id": 3107,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -26537,14 +26555,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 39,
+                  "id": 2649,
                   "name": "AsyncDirective.setValue"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 38,
+              "id": 2648,
               "name": "AsyncDirective.setValue",
               "location": {
                 "page": "custom-directives",
@@ -26566,7 +26584,7 @@
             }
           },
           {
-            "id": 481,
+            "id": 3091,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -26583,21 +26601,21 @@
             ],
             "signatures": [
               {
-                "id": 482,
+                "id": 3092,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 483,
+                    "id": 3093,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -26606,7 +26624,7 @@
                     }
                   },
                   {
-                    "id": 484,
+                    "id": 3094,
                     "name": "args",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -26626,14 +26644,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 51,
+                  "id": 2661,
                   "name": "AsyncDirective.update"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 50,
+              "id": 2660,
               "name": "AsyncDirective.update",
               "location": {
                 "page": "custom-directives",
@@ -26660,37 +26678,37 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              471
+              3081
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              474,
-              477,
-              475,
-              476,
-              489
+              3084,
+              3087,
+              3085,
+              3086,
+              3099
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              498
+              3108
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              490,
-              485,
-              487,
-              478,
-              495,
-              481
+              3100,
+              3095,
+              3097,
+              3088,
+              3105,
+              3091
             ]
           }
         ],
@@ -26706,7 +26724,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -26726,7 +26744,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -26735,7 +26753,7 @@
           },
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -26749,9 +26767,12 @@
   {
     "slug": "custom-directives",
     "title": "Custom directives",
+    "versionLinks": {
+      "v1": "api/lit-html/custom-directives/"
+    },
     "items": [
       {
-        "id": 28,
+        "id": 2638,
         "name": "AsyncDirective",
         "kind": 128,
         "kindString": "Class",
@@ -26764,7 +26785,7 @@
         },
         "children": [
           {
-            "id": 29,
+            "id": 2639,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -26772,21 +26793,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 30,
+                "id": 2640,
                 "name": "new AsyncDirective",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 31,
+                    "id": 2641,
                     "name": "_partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -26797,7 +26818,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 28,
+                  "id": 2638,
                   "name": "AsyncDirective",
                   "location": {
                     "page": "custom-directives",
@@ -26806,14 +26827,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 652,
+                  "id": 3262,
                   "name": "Directive.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 651,
+              "id": 3261,
               "name": "Directive.constructor",
               "location": {
                 "page": "custom-directives",
@@ -26835,7 +26856,7 @@
             }
           },
           {
-            "id": 32,
+            "id": 2642,
             "name": "isConnected",
             "kind": 1024,
             "kindString": "Property",
@@ -26872,7 +26893,7 @@
             }
           },
           {
-            "id": 41,
+            "id": 2651,
             "name": "disconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -26894,7 +26915,7 @@
             ],
             "signatures": [
               {
-                "id": 42,
+                "id": 2652,
                 "name": "disconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -26923,7 +26944,7 @@
             }
           },
           {
-            "id": 43,
+            "id": 2653,
             "name": "reconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -26942,7 +26963,7 @@
             ],
             "signatures": [
               {
-                "id": 44,
+                "id": 2654,
                 "name": "reconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -26968,7 +26989,7 @@
             }
           },
           {
-            "id": 47,
+            "id": 2657,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -26987,14 +27008,14 @@
             ],
             "signatures": [
               {
-                "id": 48,
+                "id": 2658,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 49,
+                    "id": 2659,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -27016,14 +27037,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 657,
+                  "id": 3267,
                   "name": "Directive.render"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 656,
+              "id": 3266,
               "name": "Directive.render",
               "location": {
                 "page": "custom-directives",
@@ -27045,7 +27066,7 @@
             }
           },
           {
-            "id": 38,
+            "id": 2648,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -27066,7 +27087,7 @@
             ],
             "signatures": [
               {
-                "id": 39,
+                "id": 2649,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -27077,7 +27098,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 40,
+                    "id": 2650,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -27112,7 +27133,7 @@
             }
           },
           {
-            "id": 50,
+            "id": 2660,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -27129,21 +27150,21 @@
             ],
             "signatures": [
               {
-                "id": 51,
+                "id": 2661,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 52,
+                    "id": 2662,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -27152,7 +27173,7 @@
                     }
                   },
                   {
-                    "id": 53,
+                    "id": 2663,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -27172,14 +27193,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 660,
+                  "id": 3270,
                   "name": "Directive.update"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 659,
+              "id": 3269,
               "name": "Directive.update",
               "location": {
                 "page": "custom-directives",
@@ -27206,33 +27227,33 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              29
+              2639
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              32
+              2642
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              45
+              2655
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              33,
-              41,
-              43,
-              47,
-              38,
-              50
+              2643,
+              2651,
+              2653,
+              2657,
+              2648,
+              2660
             ]
           }
         ],
@@ -27248,7 +27269,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -27259,7 +27280,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 159,
+            "id": 2769,
             "name": "AsyncReplaceDirective",
             "location": {
               "page": "directives",
@@ -27268,7 +27289,7 @@
           },
           {
             "type": "reference",
-            "id": 298,
+            "id": 2908,
             "name": "RefDirective",
             "location": {
               "page": "directives",
@@ -27277,7 +27298,7 @@
           },
           {
             "type": "reference",
-            "id": 470,
+            "id": 3080,
             "name": "UntilDirective",
             "location": {
               "page": "directives",
@@ -27301,7 +27322,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -27311,7 +27332,7 @@
         ]
       },
       {
-        "id": 21,
+        "id": 2631,
         "name": "directive",
         "kind": 64,
         "kindString": "Function",
@@ -27333,7 +27354,7 @@
         ],
         "signatures": [
           {
-            "id": 22,
+            "id": 2632,
             "name": "directive",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27343,14 +27364,14 @@
             },
             "typeParameter": [
               {
-                "id": 23,
+                "id": 2633,
                 "name": "C",
                 "kind": 131072,
                 "kindString": "Type parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 622,
+                  "id": 3232,
                   "name": "DirectiveClass",
                   "location": {
                     "page": "custom-directives",
@@ -27361,7 +27382,7 @@
             ],
             "parameters": [
               {
-                "id": 24,
+                "id": 2634,
                 "name": "c",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27375,21 +27396,21 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 25,
+                "id": 2635,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 26,
+                    "id": 2636,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 27,
+                        "id": 2637,
                         "name": "values",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -27423,7 +27444,7 @@
                     ],
                     "type": {
                       "type": "reference",
-                      "id": 628,
+                      "id": 3238,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -27457,7 +27478,7 @@
         }
       },
       {
-        "id": 705,
+        "id": 3315,
         "name": "clearPart",
         "kind": 64,
         "kindString": "Function",
@@ -27476,21 +27497,21 @@
         ],
         "signatures": [
           {
-            "id": 706,
+            "id": 3316,
             "name": "clearPart",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 707,
+                "id": 3317,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -27520,7 +27541,7 @@
         }
       },
       {
-        "id": 699,
+        "id": 3309,
         "name": "getCommittedValue",
         "kind": 64,
         "kindString": "Function",
@@ -27543,7 +27564,7 @@
         ],
         "signatures": [
           {
-            "id": 700,
+            "id": 3310,
             "name": "getCommittedValue",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27554,7 +27575,7 @@
             },
             "parameters": [
               {
-                "id": 701,
+                "id": 3311,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27564,7 +27585,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -27594,7 +27615,7 @@
         }
       },
       {
-        "id": 678,
+        "id": 3288,
         "name": "getDirectiveClass",
         "kind": 64,
         "kindString": "Function",
@@ -27616,7 +27637,7 @@
         ],
         "signatures": [
           {
-            "id": 679,
+            "id": 3289,
             "name": "getDirectiveClass",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27626,7 +27647,7 @@
             },
             "parameters": [
               {
-                "id": 680,
+                "id": 3290,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27646,7 +27667,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 622,
+                  "id": 3232,
                   "name": "DirectiveClass",
                   "location": {
                     "page": "custom-directives",
@@ -27672,7 +27693,7 @@
         }
       },
       {
-        "id": 684,
+        "id": 3294,
         "name": "insertPart",
         "kind": 64,
         "kindString": "Function",
@@ -27695,7 +27716,7 @@
         ],
         "signatures": [
           {
-            "id": 685,
+            "id": 3295,
             "name": "insertPart",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27706,7 +27727,7 @@
             },
             "parameters": [
               {
-                "id": 686,
+                "id": 3296,
                 "name": "containerPart",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27716,7 +27737,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -27725,7 +27746,7 @@
                 }
               },
               {
-                "id": 687,
+                "id": 3297,
                 "name": "refPart",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27737,7 +27758,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -27746,7 +27767,7 @@
                 }
               },
               {
-                "id": 688,
+                "id": 3298,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27758,7 +27779,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -27769,7 +27790,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 539,
+              "id": 3149,
               "name": "ChildPart",
               "location": {
                 "page": "custom-directives",
@@ -27793,7 +27814,7 @@
         }
       },
       {
-        "id": 675,
+        "id": 3285,
         "name": "isDirectiveResult",
         "kind": 64,
         "kindString": "Function",
@@ -27815,7 +27836,7 @@
         ],
         "signatures": [
           {
-            "id": 676,
+            "id": 3286,
             "name": "isDirectiveResult",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27825,7 +27846,7 @@
             },
             "parameters": [
               {
-                "id": 677,
+                "id": 3287,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27842,11 +27863,11 @@
               "asserts": false,
               "targetType": {
                 "type": "reference",
-                "id": 628,
+                "id": 3238,
                 "typeArguments": [
                   {
                     "type": "reference",
-                    "id": 622,
+                    "id": 3232,
                     "name": "DirectiveClass",
                     "location": {
                       "page": "custom-directives",
@@ -27878,7 +27899,7 @@
         }
       },
       {
-        "id": 663,
+        "id": 3273,
         "name": "isPrimitive",
         "kind": 64,
         "kindString": "Function",
@@ -27901,7 +27922,7 @@
         ],
         "signatures": [
           {
-            "id": 664,
+            "id": 3274,
             "name": "isPrimitive",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27912,7 +27933,7 @@
             },
             "parameters": [
               {
-                "id": 665,
+                "id": 3275,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -27949,7 +27970,7 @@
         }
       },
       {
-        "id": 681,
+        "id": 3291,
         "name": "isSingleExpression",
         "kind": 64,
         "kindString": "Function",
@@ -27972,7 +27993,7 @@
         ],
         "signatures": [
           {
-            "id": 682,
+            "id": 3292,
             "name": "isSingleExpression",
             "kind": 4096,
             "kindString": "Call signature",
@@ -27983,14 +28004,14 @@
             },
             "parameters": [
               {
-                "id": 683,
+                "id": 3293,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 648,
+                  "id": 3258,
                   "name": "PartInfo",
                   "location": {
                     "page": "custom-directives",
@@ -28020,7 +28041,7 @@
         }
       },
       {
-        "id": 671,
+        "id": 3281,
         "name": "isTemplateResult",
         "kind": 64,
         "kindString": "Function",
@@ -28042,7 +28063,7 @@
         ],
         "signatures": [
           {
-            "id": 672,
+            "id": 3282,
             "name": "isTemplateResult",
             "kind": 4096,
             "kindString": "Call signature",
@@ -28052,7 +28073,7 @@
             },
             "parameters": [
               {
-                "id": 673,
+                "id": 3283,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28063,7 +28084,7 @@
                 }
               },
               {
-                "id": 674,
+                "id": 3284,
                 "name": "type",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28072,7 +28093,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 666,
+                  "id": 3276,
                   "name": "TemplateResultType",
                   "location": {
                     "page": "custom-directives",
@@ -28087,7 +28108,7 @@
               "asserts": false,
               "targetType": {
                 "type": "reference",
-                "id": 2562,
+                "id": 5172,
                 "typeArguments": [
                   {
                     "type": "union",
@@ -28127,7 +28148,7 @@
         }
       },
       {
-        "id": 702,
+        "id": 3312,
         "name": "removePart",
         "kind": 64,
         "kindString": "Function",
@@ -28149,7 +28170,7 @@
         ],
         "signatures": [
           {
-            "id": 703,
+            "id": 3313,
             "name": "removePart",
             "kind": 4096,
             "kindString": "Call signature",
@@ -28159,7 +28180,7 @@
             },
             "parameters": [
               {
-                "id": 704,
+                "id": 3314,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28169,7 +28190,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -28199,7 +28220,7 @@
         }
       },
       {
-        "id": 689,
+        "id": 3299,
         "name": "setChildPartValue",
         "kind": 64,
         "kindString": "Function",
@@ -28222,7 +28243,7 @@
         ],
         "signatures": [
           {
-            "id": 690,
+            "id": 3300,
             "name": "setChildPartValue",
             "kind": 4096,
             "kindString": "Call signature",
@@ -28233,14 +28254,14 @@
             },
             "typeParameter": [
               {
-                "id": 691,
+                "id": 3301,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -28257,7 +28278,7 @@
             ],
             "parameters": [
               {
-                "id": 692,
+                "id": 3302,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28271,7 +28292,7 @@
                 }
               },
               {
-                "id": 693,
+                "id": 3303,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28285,7 +28306,7 @@
                 }
               },
               {
-                "id": 694,
+                "id": 3304,
                 "name": "directiveParent",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28297,7 +28318,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 2608,
+                  "id": 5218,
                   "name": "DirectiveParent",
                   "location": {
                     "page": "misc",
@@ -28327,7 +28348,7 @@
         }
       },
       {
-        "id": 695,
+        "id": 3305,
         "name": "setCommittedValue",
         "kind": 64,
         "kindString": "Function",
@@ -28350,7 +28371,7 @@
         ],
         "signatures": [
           {
-            "id": 696,
+            "id": 3306,
             "name": "setCommittedValue",
             "kind": 4096,
             "kindString": "Call signature",
@@ -28361,7 +28382,7 @@
             },
             "parameters": [
               {
-                "id": 697,
+                "id": 3307,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28369,7 +28390,7 @@
                 "comment": {},
                 "type": {
                   "type": "reference",
-                  "id": 603,
+                  "id": 3213,
                   "name": "Part",
                   "location": {
                     "page": "custom-directives",
@@ -28378,7 +28399,7 @@
                 }
               },
               {
-                "id": 698,
+                "id": 3308,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -28415,7 +28436,7 @@
         }
       },
       {
-        "id": 666,
+        "id": 3276,
         "name": "TemplateResultType",
         "kind": 32,
         "kindString": "Variable",
@@ -28435,14 +28456,14 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 667,
+            "id": 3277,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
             "flags": {},
             "children": [
               {
-                "id": 668,
+                "id": 3278,
                 "name": "HTML",
                 "kind": 1024,
                 "kindString": "Property",
@@ -28462,7 +28483,7 @@
                 }
               },
               {
-                "id": 669,
+                "id": 3279,
                 "name": "SVG",
                 "kind": 1024,
                 "kindString": "Property",
@@ -28487,8 +28508,8 @@
                 "title": "Properties",
                 "kind": 1024,
                 "children": [
-                  668,
-                  669
+                  3278,
+                  3279
                 ]
               }
             ],
@@ -28516,14 +28537,14 @@
         }
       },
       {
-        "id": 503,
+        "id": 3113,
         "name": "AttributePart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 504,
+            "id": 3114,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -28538,14 +28559,14 @@
             ],
             "signatures": [
               {
-                "id": 505,
+                "id": 3115,
                 "name": "new AttributePart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 506,
+                    "id": 3116,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -28559,7 +28580,7 @@
                     }
                   },
                   {
-                    "id": 507,
+                    "id": 3117,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -28570,7 +28591,7 @@
                     }
                   },
                   {
-                    "id": 508,
+                    "id": 3118,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -28588,14 +28609,14 @@
                     }
                   },
                   {
-                    "id": 509,
+                    "id": 3119,
                     "name": "parent",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 2613,
+                      "id": 5223,
                       "name": "Disconnectable",
                       "location": {
                         "page": "misc",
@@ -28604,7 +28625,7 @@
                     }
                   },
                   {
-                    "id": 510,
+                    "id": 3120,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -28618,7 +28639,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 2586,
+                          "id": 5196,
                           "name": "RenderOptions",
                           "location": {
                             "page": "LitElement",
@@ -28631,7 +28652,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 503,
+                  "id": 3113,
                   "name": "AttributePart",
                   "location": {
                     "page": "custom-directives",
@@ -28655,7 +28676,7 @@
             }
           },
           {
-            "id": 512,
+            "id": 3122,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -28694,7 +28715,7 @@
             }
           },
           {
-            "id": 513,
+            "id": 3123,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -28730,7 +28751,7 @@
             }
           },
           {
-            "id": 514,
+            "id": 3124,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -28756,7 +28777,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -28780,7 +28801,7 @@
             }
           },
           {
-            "id": 515,
+            "id": 3125,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -28827,7 +28848,7 @@
             }
           },
           {
-            "id": 511,
+            "id": 3121,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -28880,7 +28901,7 @@
             }
           },
           {
-            "id": 517,
+            "id": 3127,
             "name": "tagName",
             "kind": 262144,
             "kindString": "Accessor",
@@ -28901,7 +28922,7 @@
             },
             "getSignature": [
               {
-                "id": 518,
+                "id": 3128,
                 "name": "tagName",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -28932,27 +28953,27 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              504
+              3114
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              516,
-              512,
-              513,
-              514,
-              515,
-              511
+              3126,
+              3122,
+              3123,
+              3124,
+              3125,
+              3121
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              519,
-              517
+              3129,
+              3127
             ]
           }
         ],
@@ -28968,7 +28989,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 521,
+            "id": 3131,
             "name": "BooleanAttributePart",
             "location": {
               "page": "custom-directives",
@@ -28977,7 +28998,7 @@
           },
           {
             "type": "reference",
-            "id": 582,
+            "id": 3192,
             "name": "EventPart",
             "location": {
               "page": "custom-directives",
@@ -28986,7 +29007,7 @@
           },
           {
             "type": "reference",
-            "id": 604,
+            "id": 3214,
             "name": "PropertyPart",
             "location": {
               "page": "custom-directives",
@@ -28997,7 +29018,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 2613,
+            "id": 5223,
             "name": "Disconnectable",
             "location": {
               "page": "misc",
@@ -29020,14 +29041,14 @@
         }
       },
       {
-        "id": 521,
+        "id": 3131,
         "name": "BooleanAttributePart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 522,
+            "id": 3132,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -29035,14 +29056,14 @@
             "children": [],
             "signatures": [
               {
-                "id": 523,
+                "id": 3133,
                 "name": "new BooleanAttributePart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 524,
+                    "id": 3134,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29056,7 +29077,7 @@
                     }
                   },
                   {
-                    "id": 525,
+                    "id": 3135,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29067,7 +29088,7 @@
                     }
                   },
                   {
-                    "id": 526,
+                    "id": 3136,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29085,14 +29106,14 @@
                     }
                   },
                   {
-                    "id": 527,
+                    "id": 3137,
                     "name": "parent",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 2613,
+                      "id": 5223,
                       "name": "Disconnectable",
                       "location": {
                         "page": "misc",
@@ -29101,7 +29122,7 @@
                     }
                   },
                   {
-                    "id": 528,
+                    "id": 3138,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29115,7 +29136,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 2586,
+                          "id": 5196,
                           "name": "RenderOptions",
                           "location": {
                             "page": "LitElement",
@@ -29128,7 +29149,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 521,
+                  "id": 3131,
                   "name": "BooleanAttributePart",
                   "location": {
                     "page": "custom-directives",
@@ -29137,14 +29158,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 505,
+                  "id": 3115,
                   "name": "AttributePart.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 504,
+              "id": 3114,
               "name": "AttributePart.constructor",
               "location": {
                 "page": "custom-directives",
@@ -29166,7 +29187,7 @@
             }
           },
           {
-            "id": 530,
+            "id": 3140,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -29192,7 +29213,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 512,
+              "id": 3122,
               "name": "AttributePart.element",
               "location": {
                 "page": "custom-directives",
@@ -29214,7 +29235,7 @@
             }
           },
           {
-            "id": 531,
+            "id": 3141,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -29237,7 +29258,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 513,
+              "id": 3123,
               "name": "AttributePart.name",
               "location": {
                 "page": "custom-directives",
@@ -29259,7 +29280,7 @@
             }
           },
           {
-            "id": 532,
+            "id": 3142,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -29285,7 +29306,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -29296,7 +29317,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 514,
+              "id": 3124,
               "name": "AttributePart.options",
               "location": {
                 "page": "custom-directives",
@@ -29318,7 +29339,7 @@
             }
           },
           {
-            "id": 533,
+            "id": 3143,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -29352,7 +29373,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 515,
+              "id": 3125,
               "name": "AttributePart.strings",
               "location": {
                 "page": "custom-directives",
@@ -29374,7 +29395,7 @@
             }
           },
           {
-            "id": 529,
+            "id": 3139,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -29398,7 +29419,7 @@
             "defaultValue": "4",
             "overwrites": {
               "type": "reference",
-              "id": 511,
+              "id": 3121,
               "name": "AttributePart.type",
               "location": {
                 "page": "custom-directives",
@@ -29420,7 +29441,7 @@
             }
           },
           {
-            "id": 535,
+            "id": 3145,
             "name": "tagName",
             "kind": 262144,
             "kindString": "Accessor",
@@ -29441,7 +29462,7 @@
             },
             "getSignature": [
               {
-                "id": 536,
+                "id": 3146,
                 "name": "tagName",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -29454,7 +29475,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 517,
+              "id": 3127,
               "name": "AttributePart.tagName",
               "location": {
                 "page": "custom-directives",
@@ -29481,27 +29502,27 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              522
+              3132
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              534,
-              530,
-              531,
-              532,
-              533,
-              529
+              3144,
+              3140,
+              3141,
+              3142,
+              3143,
+              3139
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              537,
-              535
+              3147,
+              3145
             ]
           }
         ],
@@ -29517,7 +29538,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -29541,7 +29562,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -29551,14 +29572,14 @@
         ]
       },
       {
-        "id": 539,
+        "id": 3149,
         "name": "ChildPart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 540,
+            "id": 3150,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -29573,14 +29594,14 @@
             ],
             "signatures": [
               {
-                "id": 541,
+                "id": 3151,
                 "name": "new ChildPart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 542,
+                    "id": 3152,
                     "name": "startNode",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29591,7 +29612,7 @@
                     }
                   },
                   {
-                    "id": 543,
+                    "id": 3153,
                     "name": "endNode",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29611,7 +29632,7 @@
                     }
                   },
                   {
-                    "id": 544,
+                    "id": 3154,
                     "name": "parent",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29625,7 +29646,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 539,
+                          "id": 3149,
                           "name": "ChildPart",
                           "location": {
                             "page": "custom-directives",
@@ -29640,7 +29661,7 @@
                     }
                   },
                   {
-                    "id": 545,
+                    "id": 3155,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -29654,7 +29675,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 2586,
+                          "id": 5196,
                           "name": "RenderOptions",
                           "location": {
                             "page": "LitElement",
@@ -29667,7 +29688,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 539,
+                  "id": 3149,
                   "name": "ChildPart",
                   "location": {
                     "page": "custom-directives",
@@ -29691,7 +29712,7 @@
             }
           },
           {
-            "id": 547,
+            "id": 3157,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -29717,7 +29738,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -29741,7 +29762,7 @@
             }
           },
           {
-            "id": 546,
+            "id": 3156,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -29778,7 +29799,7 @@
             }
           },
           {
-            "id": 556,
+            "id": 3166,
             "name": "endNode",
             "kind": 262144,
             "kindString": "Accessor",
@@ -29811,7 +29832,7 @@
             },
             "getSignature": [
               {
-                "id": 557,
+                "id": 3167,
                 "name": "endNode",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -29849,7 +29870,7 @@
             }
           },
           {
-            "id": 552,
+            "id": 3162,
             "name": "parentNode",
             "kind": 262144,
             "kindString": "Accessor",
@@ -29874,7 +29895,7 @@
             },
             "getSignature": [
               {
-                "id": 553,
+                "id": 3163,
                 "name": "parentNode",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -29904,7 +29925,7 @@
             }
           },
           {
-            "id": 554,
+            "id": 3164,
             "name": "startNode",
             "kind": 262144,
             "kindString": "Accessor",
@@ -29937,7 +29958,7 @@
             },
             "getSignature": [
               {
-                "id": 555,
+                "id": 3165,
                 "name": "startNode",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -29980,39 +30001,39 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              540
+              3150
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              548,
-              566,
-              563,
-              565,
-              564,
-              562,
-              549,
-              547,
-              546
+              3158,
+              3176,
+              3173,
+              3175,
+              3174,
+              3172,
+              3159,
+              3157,
+              3156
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              550,
-              556,
-              552,
-              554
+              3160,
+              3166,
+              3162,
+              3164
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              558
+              3168
             ]
           }
         ],
@@ -30028,7 +30049,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 2619,
+            "id": 5229,
             "name": "RootPart",
             "location": {
               "page": "misc",
@@ -30039,7 +30060,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 2613,
+            "id": 5223,
             "name": "Disconnectable",
             "location": {
               "page": "misc",
@@ -30062,7 +30083,7 @@
         }
       },
       {
-        "id": 650,
+        "id": 3260,
         "name": "Directive",
         "kind": 128,
         "kindString": "Class",
@@ -30074,7 +30095,7 @@
         },
         "children": [
           {
-            "id": 651,
+            "id": 3261,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -30089,21 +30110,21 @@
             ],
             "signatures": [
               {
-                "id": 652,
+                "id": 3262,
                 "name": "new Directive",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 653,
+                    "id": 3263,
                     "name": "_partInfo",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -30114,7 +30135,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 650,
+                  "id": 3260,
                   "name": "Directive",
                   "location": {
                     "page": "custom-directives",
@@ -30138,7 +30159,7 @@
             }
           },
           {
-            "id": 656,
+            "id": 3266,
             "name": "render",
             "kind": 2048,
             "kindString": "Method",
@@ -30157,14 +30178,14 @@
             ],
             "signatures": [
               {
-                "id": 657,
+                "id": 3267,
                 "name": "render",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 658,
+                    "id": 3268,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30201,7 +30222,7 @@
             }
           },
           {
-            "id": 659,
+            "id": 3269,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -30218,21 +30239,21 @@
             ],
             "signatures": [
               {
-                "id": 660,
+                "id": 3270,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 661,
+                    "id": 3271,
                     "name": "_part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 603,
+                      "id": 3213,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -30241,7 +30262,7 @@
                     }
                   },
                   {
-                    "id": 662,
+                    "id": 3272,
                     "name": "props",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30281,22 +30302,22 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              651
+              3261
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              654
+              3264
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              656,
-              659
+              3266,
+              3269
             ]
           }
         ],
@@ -30312,7 +30333,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 28,
+            "id": 2638,
             "name": "AsyncDirective",
             "location": {
               "page": "custom-directives",
@@ -30321,7 +30342,7 @@
           },
           {
             "type": "reference",
-            "id": 201,
+            "id": 2811,
             "name": "CacheDirective",
             "location": {
               "page": "directives",
@@ -30330,7 +30351,7 @@
           },
           {
             "type": "reference",
-            "id": 222,
+            "id": 2832,
             "name": "ClassMapDirective",
             "location": {
               "page": "directives",
@@ -30339,7 +30360,7 @@
           },
           {
             "type": "reference",
-            "id": 243,
+            "id": 2853,
             "name": "GuardDirective",
             "location": {
               "page": "directives",
@@ -30348,7 +30369,7 @@
           },
           {
             "type": "reference",
-            "id": 269,
+            "id": 2879,
             "name": "LiveDirective",
             "location": {
               "page": "directives",
@@ -30357,7 +30378,7 @@
           },
           {
             "type": "reference",
-            "id": 372,
+            "id": 2982,
             "name": "RepeatDirective",
             "location": {
               "page": "directives",
@@ -30366,7 +30387,7 @@
           },
           {
             "type": "reference",
-            "id": 401,
+            "id": 3011,
             "name": "StyleMapDirective",
             "location": {
               "page": "directives",
@@ -30375,7 +30396,7 @@
           },
           {
             "type": "reference",
-            "id": 418,
+            "id": 3028,
             "name": "TemplateContentDirective",
             "location": {
               "page": "directives",
@@ -30384,7 +30405,7 @@
           },
           {
             "type": "reference",
-            "id": 432,
+            "id": 3042,
             "name": "UnsafeHTMLDirective",
             "location": {
               "page": "directives",
@@ -30395,7 +30416,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 2613,
+            "id": 5223,
             "name": "Disconnectable",
             "location": {
               "page": "misc",
@@ -30418,14 +30439,14 @@
         }
       },
       {
-        "id": 567,
+        "id": 3177,
         "name": "ElementPart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 568,
+            "id": 3178,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -30440,14 +30461,14 @@
             ],
             "signatures": [
               {
-                "id": 569,
+                "id": 3179,
                 "name": "new ElementPart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 570,
+                    "id": 3180,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30461,14 +30482,14 @@
                     }
                   },
                   {
-                    "id": 571,
+                    "id": 3181,
                     "name": "parent",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 2613,
+                      "id": 5223,
                       "name": "Disconnectable",
                       "location": {
                         "page": "misc",
@@ -30477,7 +30498,7 @@
                     }
                   },
                   {
-                    "id": 572,
+                    "id": 3182,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30491,7 +30512,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 2586,
+                          "id": 5196,
                           "name": "RenderOptions",
                           "location": {
                             "page": "LitElement",
@@ -30504,7 +30525,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 567,
+                  "id": 3177,
                   "name": "ElementPart",
                   "location": {
                     "page": "custom-directives",
@@ -30528,7 +30549,7 @@
             }
           },
           {
-            "id": 573,
+            "id": 3183,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -30565,7 +30586,7 @@
             }
           },
           {
-            "id": 576,
+            "id": 3186,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -30589,7 +30610,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -30613,7 +30634,7 @@
             }
           },
           {
-            "id": 574,
+            "id": 3184,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -30655,31 +30676,31 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              568
+              3178
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              575,
-              573,
-              576,
-              574
+              3185,
+              3183,
+              3186,
+              3184
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              577
+              3187
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              579
+              3189
             ]
           }
         ],
@@ -30695,7 +30716,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 2613,
+            "id": 5223,
             "name": "Disconnectable",
             "location": {
               "page": "misc",
@@ -30718,14 +30739,14 @@
         }
       },
       {
-        "id": 582,
+        "id": 3192,
         "name": "EventPart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 583,
+            "id": 3193,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -30740,14 +30761,14 @@
             ],
             "signatures": [
               {
-                "id": 584,
+                "id": 3194,
                 "name": "new EventPart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 585,
+                    "id": 3195,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30761,7 +30782,7 @@
                     }
                   },
                   {
-                    "id": 586,
+                    "id": 3196,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30772,7 +30793,7 @@
                     }
                   },
                   {
-                    "id": 587,
+                    "id": 3197,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30790,14 +30811,14 @@
                     }
                   },
                   {
-                    "id": 588,
+                    "id": 3198,
                     "name": "parent",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 2613,
+                      "id": 5223,
                       "name": "Disconnectable",
                       "location": {
                         "page": "misc",
@@ -30806,7 +30827,7 @@
                     }
                   },
                   {
-                    "id": 589,
+                    "id": 3199,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -30820,7 +30841,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 2586,
+                          "id": 5196,
                           "name": "RenderOptions",
                           "location": {
                             "page": "LitElement",
@@ -30833,7 +30854,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 582,
+                  "id": 3192,
                   "name": "EventPart",
                   "location": {
                     "page": "custom-directives",
@@ -30842,14 +30863,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 505,
+                  "id": 3115,
                   "name": "AttributePart.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 504,
+              "id": 3114,
               "name": "AttributePart.constructor",
               "location": {
                 "page": "custom-directives",
@@ -30871,7 +30892,7 @@
             }
           },
           {
-            "id": 594,
+            "id": 3204,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -30897,7 +30918,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 512,
+              "id": 3122,
               "name": "AttributePart.element",
               "location": {
                 "page": "custom-directives",
@@ -30919,7 +30940,7 @@
             }
           },
           {
-            "id": 595,
+            "id": 3205,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -30942,7 +30963,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 513,
+              "id": 3123,
               "name": "AttributePart.name",
               "location": {
                 "page": "custom-directives",
@@ -30964,7 +30985,7 @@
             }
           },
           {
-            "id": 596,
+            "id": 3206,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -30990,7 +31011,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -31001,7 +31022,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 514,
+              "id": 3124,
               "name": "AttributePart.options",
               "location": {
                 "page": "custom-directives",
@@ -31023,7 +31044,7 @@
             }
           },
           {
-            "id": 597,
+            "id": 3207,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -31057,7 +31078,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 515,
+              "id": 3125,
               "name": "AttributePart.strings",
               "location": {
                 "page": "custom-directives",
@@ -31079,7 +31100,7 @@
             }
           },
           {
-            "id": 590,
+            "id": 3200,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -31103,7 +31124,7 @@
             "defaultValue": "5",
             "overwrites": {
               "type": "reference",
-              "id": 511,
+              "id": 3121,
               "name": "AttributePart.type",
               "location": {
                 "page": "custom-directives",
@@ -31125,7 +31146,7 @@
             }
           },
           {
-            "id": 599,
+            "id": 3209,
             "name": "tagName",
             "kind": 262144,
             "kindString": "Accessor",
@@ -31146,7 +31167,7 @@
             },
             "getSignature": [
               {
-                "id": 600,
+                "id": 3210,
                 "name": "tagName",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -31159,7 +31180,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 517,
+              "id": 3127,
               "name": "AttributePart.tagName",
               "location": {
                 "page": "custom-directives",
@@ -31181,7 +31202,7 @@
             }
           },
           {
-            "id": 591,
+            "id": 3201,
             "name": "handleEvent",
             "kind": 2048,
             "kindString": "Method",
@@ -31198,14 +31219,14 @@
             ],
             "signatures": [
               {
-                "id": 592,
+                "id": 3202,
                 "name": "handleEvent",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 593,
+                    "id": 3203,
                     "name": "event",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -31242,34 +31263,34 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              583
+              3193
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              598,
-              594,
-              595,
-              596,
-              597,
-              590
+              3208,
+              3204,
+              3205,
+              3206,
+              3207,
+              3200
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              601,
-              599
+              3211,
+              3209
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              591
+              3201
             ]
           }
         ],
@@ -31285,7 +31306,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -31309,7 +31330,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -31319,7 +31340,7 @@
         ]
       },
       {
-        "id": 630,
+        "id": 3240,
         "name": "PartType",
         "kind": 32,
         "kindString": "Variable",
@@ -31339,14 +31360,14 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 631,
+            "id": 3241,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
             "flags": {},
             "children": [
               {
-                "id": 632,
+                "id": 3242,
                 "name": "ATTRIBUTE",
                 "kind": 1024,
                 "kindString": "Property",
@@ -31366,7 +31387,7 @@
                 }
               },
               {
-                "id": 635,
+                "id": 3245,
                 "name": "BOOLEAN_ATTRIBUTE",
                 "kind": 1024,
                 "kindString": "Property",
@@ -31386,7 +31407,7 @@
                 }
               },
               {
-                "id": 633,
+                "id": 3243,
                 "name": "CHILD",
                 "kind": 1024,
                 "kindString": "Property",
@@ -31406,7 +31427,7 @@
                 }
               },
               {
-                "id": 637,
+                "id": 3247,
                 "name": "ELEMENT",
                 "kind": 1024,
                 "kindString": "Property",
@@ -31426,7 +31447,7 @@
                 }
               },
               {
-                "id": 636,
+                "id": 3246,
                 "name": "EVENT",
                 "kind": 1024,
                 "kindString": "Property",
@@ -31446,7 +31467,7 @@
                 }
               },
               {
-                "id": 634,
+                "id": 3244,
                 "name": "PROPERTY",
                 "kind": 1024,
                 "kindString": "Property",
@@ -31471,12 +31492,12 @@
                 "title": "Properties",
                 "kind": 1024,
                 "children": [
-                  632,
-                  635,
-                  633,
-                  637,
-                  636,
-                  634
+                  3242,
+                  3245,
+                  3243,
+                  3247,
+                  3246,
+                  3244
                 ]
               }
             ],
@@ -31504,14 +31525,14 @@
         }
       },
       {
-        "id": 604,
+        "id": 3214,
         "name": "PropertyPart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 605,
+            "id": 3215,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -31519,14 +31540,14 @@
             "children": [],
             "signatures": [
               {
-                "id": 606,
+                "id": 3216,
                 "name": "new PropertyPart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 607,
+                    "id": 3217,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -31540,7 +31561,7 @@
                     }
                   },
                   {
-                    "id": 608,
+                    "id": 3218,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -31551,7 +31572,7 @@
                     }
                   },
                   {
-                    "id": 609,
+                    "id": 3219,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -31569,14 +31590,14 @@
                     }
                   },
                   {
-                    "id": 610,
+                    "id": 3220,
                     "name": "parent",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 2613,
+                      "id": 5223,
                       "name": "Disconnectable",
                       "location": {
                         "page": "misc",
@@ -31585,7 +31606,7 @@
                     }
                   },
                   {
-                    "id": 611,
+                    "id": 3221,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -31599,7 +31620,7 @@
                         },
                         {
                           "type": "reference",
-                          "id": 2586,
+                          "id": 5196,
                           "name": "RenderOptions",
                           "location": {
                             "page": "LitElement",
@@ -31612,7 +31633,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 604,
+                  "id": 3214,
                   "name": "PropertyPart",
                   "location": {
                     "page": "custom-directives",
@@ -31621,14 +31642,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 505,
+                  "id": 3115,
                   "name": "AttributePart.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 504,
+              "id": 3114,
               "name": "AttributePart.constructor",
               "location": {
                 "page": "custom-directives",
@@ -31650,7 +31671,7 @@
             }
           },
           {
-            "id": 613,
+            "id": 3223,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -31676,7 +31697,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 512,
+              "id": 3122,
               "name": "AttributePart.element",
               "location": {
                 "page": "custom-directives",
@@ -31698,7 +31719,7 @@
             }
           },
           {
-            "id": 614,
+            "id": 3224,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -31721,7 +31742,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 513,
+              "id": 3123,
               "name": "AttributePart.name",
               "location": {
                 "page": "custom-directives",
@@ -31743,7 +31764,7 @@
             }
           },
           {
-            "id": 615,
+            "id": 3225,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -31769,7 +31790,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -31780,7 +31801,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 514,
+              "id": 3124,
               "name": "AttributePart.options",
               "location": {
                 "page": "custom-directives",
@@ -31802,7 +31823,7 @@
             }
           },
           {
-            "id": 616,
+            "id": 3226,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -31836,7 +31857,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 515,
+              "id": 3125,
               "name": "AttributePart.strings",
               "location": {
                 "page": "custom-directives",
@@ -31858,7 +31879,7 @@
             }
           },
           {
-            "id": 612,
+            "id": 3222,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -31882,7 +31903,7 @@
             "defaultValue": "3",
             "overwrites": {
               "type": "reference",
-              "id": 511,
+              "id": 3121,
               "name": "AttributePart.type",
               "location": {
                 "page": "custom-directives",
@@ -31904,7 +31925,7 @@
             }
           },
           {
-            "id": 618,
+            "id": 3228,
             "name": "tagName",
             "kind": 262144,
             "kindString": "Accessor",
@@ -31925,7 +31946,7 @@
             },
             "getSignature": [
               {
-                "id": 619,
+                "id": 3229,
                 "name": "tagName",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -31938,7 +31959,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 517,
+              "id": 3127,
               "name": "AttributePart.tagName",
               "location": {
                 "page": "custom-directives",
@@ -31965,27 +31986,27 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              605
+              3215
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              617,
-              613,
-              614,
-              615,
-              616,
-              612
+              3227,
+              3223,
+              3224,
+              3225,
+              3226,
+              3222
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              620,
-              618
+              3230,
+              3228
             ]
           }
         ],
@@ -32001,7 +32022,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -32025,7 +32046,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -32035,14 +32056,14 @@
         ]
       },
       {
-        "id": 641,
+        "id": 3251,
         "name": "AttributePartInfo",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 644,
+            "id": 3254,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -32078,7 +32099,7 @@
             }
           },
           {
-            "id": 643,
+            "id": 3253,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -32122,7 +32143,7 @@
             }
           },
           {
-            "id": 645,
+            "id": 3255,
             "name": "tagName",
             "kind": 1024,
             "kindString": "Property",
@@ -32158,7 +32179,7 @@
             }
           },
           {
-            "id": 642,
+            "id": 3252,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -32216,10 +32237,10 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              644,
-              643,
-              645,
-              642
+              3254,
+              3253,
+              3255,
+              3252
             ]
           }
         ],
@@ -32247,14 +32268,14 @@
         }
       },
       {
-        "id": 639,
+        "id": 3249,
         "name": "ChildPartInfo",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 640,
+            "id": 3250,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -32295,7 +32316,7 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              640
+              3250
             ]
           }
         ],
@@ -32323,14 +32344,14 @@
         }
       },
       {
-        "id": 622,
+        "id": 3232,
         "name": "DirectiveClass",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 623,
+            "id": 3233,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -32338,21 +32359,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 624,
+                "id": 3234,
                 "name": "new DirectiveClass",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 625,
+                    "id": 3235,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 648,
+                      "id": 3258,
                       "name": "PartInfo",
                       "location": {
                         "page": "custom-directives",
@@ -32363,7 +32384,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 650,
+                  "id": 3260,
                   "name": "Directive",
                   "location": {
                     "page": "custom-directives",
@@ -32392,7 +32413,7 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              623
+              3233
             ]
           }
         ],
@@ -32420,7 +32441,7 @@
         }
       },
       {
-        "id": 626,
+        "id": 3236,
         "name": "DirectiveParameters",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -32440,14 +32461,14 @@
         ],
         "typeParameter": [
           {
-            "id": 627,
+            "id": 3237,
             "name": "C",
             "kind": 131072,
             "kindString": "Type parameter",
             "flags": {},
             "type": {
               "type": "reference",
-              "id": 650,
+              "id": 3260,
               "name": "Directive",
               "location": {
                 "page": "custom-directives",
@@ -32488,7 +32509,7 @@
         }
       },
       {
-        "id": 628,
+        "id": 3238,
         "name": "DirectiveResult",
         "kind": 256,
         "kindString": "Interface",
@@ -32508,14 +32529,14 @@
         ],
         "typeParameter": [
           {
-            "id": 629,
+            "id": 3239,
             "name": "C",
             "kind": 131072,
             "kindString": "Type parameter",
             "flags": {},
             "type": {
               "type": "reference",
-              "id": 622,
+              "id": 3232,
               "name": "DirectiveClass",
               "location": {
                 "page": "custom-directives",
@@ -32524,7 +32545,7 @@
             },
             "default": {
               "type": "reference",
-              "id": 622,
+              "id": 3232,
               "name": "DirectiveClass",
               "location": {
                 "page": "custom-directives",
@@ -32548,14 +32569,14 @@
         }
       },
       {
-        "id": 646,
+        "id": 3256,
         "name": "ElementPartInfo",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 647,
+            "id": 3257,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -32596,7 +32617,7 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              647
+              3257
             ]
           }
         ],
@@ -32624,7 +32645,7 @@
         }
       },
       {
-        "id": 603,
+        "id": 3213,
         "name": "Part",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -32644,7 +32665,7 @@
           "types": [
             {
               "type": "reference",
-              "id": 539,
+              "id": 3149,
               "name": "ChildPart",
               "location": {
                 "page": "custom-directives",
@@ -32653,7 +32674,7 @@
             },
             {
               "type": "reference",
-              "id": 503,
+              "id": 3113,
               "name": "AttributePart",
               "location": {
                 "page": "custom-directives",
@@ -32662,7 +32683,7 @@
             },
             {
               "type": "reference",
-              "id": 604,
+              "id": 3214,
               "name": "PropertyPart",
               "location": {
                 "page": "custom-directives",
@@ -32671,7 +32692,7 @@
             },
             {
               "type": "reference",
-              "id": 521,
+              "id": 3131,
               "name": "BooleanAttributePart",
               "location": {
                 "page": "custom-directives",
@@ -32680,7 +32701,7 @@
             },
             {
               "type": "reference",
-              "id": 567,
+              "id": 3177,
               "name": "ElementPart",
               "location": {
                 "page": "custom-directives",
@@ -32689,7 +32710,7 @@
             },
             {
               "type": "reference",
-              "id": 582,
+              "id": 3192,
               "name": "EventPart",
               "location": {
                 "page": "custom-directives",
@@ -32713,7 +32734,7 @@
         }
       },
       {
-        "id": 648,
+        "id": 3258,
         "name": "PartInfo",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -32737,7 +32758,7 @@
           "types": [
             {
               "type": "reference",
-              "id": 639,
+              "id": 3249,
               "name": "ChildPartInfo",
               "location": {
                 "page": "custom-directives",
@@ -32746,7 +32767,7 @@
             },
             {
               "type": "reference",
-              "id": 641,
+              "id": 3251,
               "name": "AttributePartInfo",
               "location": {
                 "page": "custom-directives",
@@ -32755,7 +32776,7 @@
             },
             {
               "type": "reference",
-              "id": 646,
+              "id": 3256,
               "name": "ElementPartInfo",
               "location": {
                 "page": "custom-directives",
@@ -32779,7 +32800,7 @@
         }
       },
       {
-        "id": 2584,
+        "id": 5194,
         "name": "noChange",
         "kind": 32,
         "kindString": "Variable",
@@ -32826,9 +32847,12 @@
   {
     "slug": "static-html",
     "title": "Static HTML",
+    "versionLinks": {
+      "v1": "api/lit-html/templates/"
+    },
     "items": [
       {
-        "id": 2690,
+        "id": 5300,
         "name": "html",
         "kind": 64,
         "kindString": "Function",
@@ -32851,7 +32875,7 @@
         ],
         "signatures": [
           {
-            "id": 2691,
+            "id": 5301,
             "name": "html",
             "kind": 4096,
             "kindString": "Call signature",
@@ -32862,7 +32886,7 @@
             },
             "parameters": [
               {
-                "id": 2692,
+                "id": 5302,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -32873,7 +32897,7 @@
                 }
               },
               {
-                "id": 2693,
+                "id": 5303,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -32891,7 +32915,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2562,
+              "id": 5172,
               "typeArguments": [
                 {
                   "type": "reference",
@@ -32921,7 +32945,7 @@
         }
       },
       {
-        "id": 2669,
+        "id": 5279,
         "name": "literal",
         "kind": 64,
         "kindString": "Function",
@@ -32944,7 +32968,7 @@
         ],
         "signatures": [
           {
-            "id": 2670,
+            "id": 5280,
             "name": "literal",
             "kind": 4096,
             "kindString": "Call signature",
@@ -32955,7 +32979,7 @@
             },
             "parameters": [
               {
-                "id": 2671,
+                "id": 5281,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -32966,7 +32990,7 @@
                 }
               },
               {
-                "id": 2672,
+                "id": 5282,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -32985,14 +33009,14 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 2673,
+                "id": 5283,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "children": [
                   {
-                    "id": 2674,
+                    "id": 5284,
                     "name": "_$litStatic$",
                     "kind": 1024,
                     "kindString": "Property",
@@ -33015,7 +33039,7 @@
                     "title": "Properties",
                     "kind": 1024,
                     "children": [
-                      2674
+                      5284
                     ]
                   }
                 ]
@@ -33038,7 +33062,7 @@
         }
       },
       {
-        "id": 2694,
+        "id": 5304,
         "name": "svg",
         "kind": 64,
         "kindString": "Function",
@@ -33061,7 +33085,7 @@
         ],
         "signatures": [
           {
-            "id": 2695,
+            "id": 5305,
             "name": "svg",
             "kind": 4096,
             "kindString": "Call signature",
@@ -33072,7 +33096,7 @@
             },
             "parameters": [
               {
-                "id": 2696,
+                "id": 5306,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -33083,7 +33107,7 @@
                 }
               },
               {
-                "id": 2697,
+                "id": 5307,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -33101,7 +33125,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 2562,
+              "id": 5172,
               "typeArguments": [
                 {
                   "type": "reference",
@@ -33131,7 +33155,7 @@
         }
       },
       {
-        "id": 2664,
+        "id": 5274,
         "name": "unsafeStatic",
         "kind": 64,
         "kindString": "Function",
@@ -33154,7 +33178,7 @@
         ],
         "signatures": [
           {
-            "id": 2665,
+            "id": 5275,
             "name": "unsafeStatic",
             "kind": 4096,
             "kindString": "Call signature",
@@ -33165,7 +33189,7 @@
             },
             "parameters": [
               {
-                "id": 2666,
+                "id": 5276,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -33179,14 +33203,14 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 2667,
+                "id": 5277,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "children": [
                   {
-                    "id": 2668,
+                    "id": 5278,
                     "name": "_$litStatic$",
                     "kind": 1024,
                     "kindString": "Property",
@@ -33209,7 +33233,7 @@
                     "title": "Properties",
                     "kind": 1024,
                     "children": [
-                      2668
+                      5278
                     ]
                   }
                 ]
@@ -33232,7 +33256,7 @@
         }
       },
       {
-        "id": 2675,
+        "id": 5285,
         "name": "withStatic",
         "kind": 64,
         "kindString": "Function",
@@ -33254,7 +33278,7 @@
         ],
         "signatures": [
           {
-            "id": 2676,
+            "id": 5286,
             "name": "withStatic",
             "kind": 4096,
             "kindString": "Call signature",
@@ -33264,7 +33288,7 @@
             },
             "parameters": [
               {
-                "id": 2677,
+                "id": 5287,
                 "name": "coreTag",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -33275,21 +33299,21 @@
                     {
                       "type": "reflection",
                       "declaration": {
-                        "id": 2678,
+                        "id": 5288,
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 2679,
+                            "id": 5289,
                             "name": "__type",
                             "kind": 4096,
                             "kindString": "Call signature",
                             "flags": {},
                             "parameters": [
                               {
-                                "id": 2680,
+                                "id": 5290,
                                 "name": "strings",
                                 "kind": 32768,
                                 "kindString": "Parameter",
@@ -33300,7 +33324,7 @@
                                 }
                               },
                               {
-                                "id": 2681,
+                                "id": 5291,
                                 "name": "values",
                                 "kind": 32768,
                                 "kindString": "Parameter",
@@ -33318,7 +33342,7 @@
                             ],
                             "type": {
                               "type": "reference",
-                              "id": 2562,
+                              "id": 5172,
                               "typeArguments": [
                                 {
                                   "type": "literal",
@@ -33338,21 +33362,21 @@
                     {
                       "type": "reflection",
                       "declaration": {
-                        "id": 2682,
+                        "id": 5292,
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
                         "flags": {},
                         "signatures": [
                           {
-                            "id": 2683,
+                            "id": 5293,
                             "name": "__type",
                             "kind": 4096,
                             "kindString": "Call signature",
                             "flags": {},
                             "parameters": [
                               {
-                                "id": 2684,
+                                "id": 5294,
                                 "name": "strings",
                                 "kind": 32768,
                                 "kindString": "Parameter",
@@ -33363,7 +33387,7 @@
                                 }
                               },
                               {
-                                "id": 2685,
+                                "id": 5295,
                                 "name": "values",
                                 "kind": 32768,
                                 "kindString": "Parameter",
@@ -33381,7 +33405,7 @@
                             ],
                             "type": {
                               "type": "reference",
-                              "id": 2562,
+                              "id": 5172,
                               "typeArguments": [
                                 {
                                   "type": "literal",
@@ -33405,21 +33429,21 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 2686,
+                "id": 5296,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 2687,
+                    "id": 5297,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 2688,
+                        "id": 5298,
                         "name": "strings",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -33430,7 +33454,7 @@
                         }
                       },
                       {
-                        "id": 2689,
+                        "id": 5299,
                         "name": "values",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -33448,7 +33472,7 @@
                     ],
                     "type": {
                       "type": "reference",
-                      "id": 2562,
+                      "id": 5172,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -33486,9 +33510,12 @@
   {
     "slug": "controllers",
     "title": "Controllers",
+    "versionLinks": {
+      "v1": "api/lit-element/LitElement/"
+    },
     "items": [
       {
-        "id": 1588,
+        "id": 4198,
         "name": "ReactiveController",
         "kind": 256,
         "kindString": "Interface",
@@ -33499,7 +33526,7 @@
         },
         "children": [
           {
-            "id": 1589,
+            "id": 4199,
             "name": "hostConnected",
             "kind": 2048,
             "kindString": "Method",
@@ -33512,7 +33539,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1590,
+                "id": 4200,
                 "name": "hostConnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33541,7 +33568,7 @@
             }
           },
           {
-            "id": 1591,
+            "id": 4201,
             "name": "hostDisconnected",
             "kind": 2048,
             "kindString": "Method",
@@ -33554,7 +33581,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1592,
+                "id": 4202,
                 "name": "hostDisconnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33583,7 +33610,7 @@
             }
           },
           {
-            "id": 1593,
+            "id": 4203,
             "name": "hostUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -33597,7 +33624,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1594,
+                "id": 4204,
                 "name": "hostUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33627,7 +33654,7 @@
             }
           },
           {
-            "id": 1595,
+            "id": 4205,
             "name": "hostUpdated",
             "kind": 2048,
             "kindString": "Method",
@@ -33640,7 +33667,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1596,
+                "id": 4206,
                 "name": "hostUpdated",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33674,10 +33701,10 @@
             "title": "Methods",
             "kind": 2048,
             "children": [
-              1589,
-              1591,
-              1593,
-              1595
+              4199,
+              4201,
+              4203,
+              4205
             ]
           }
         ],
@@ -33705,7 +33732,7 @@
         }
       },
       {
-        "id": 1597,
+        "id": 4207,
         "name": "ReactiveControllerHost",
         "kind": 256,
         "kindString": "Interface",
@@ -33715,7 +33742,7 @@
         },
         "children": [
           {
-            "id": 1606,
+            "id": 4216,
             "name": "updateComplete",
             "kind": 1024,
             "kindString": "Property",
@@ -33766,7 +33793,7 @@
             }
           },
           {
-            "id": 1598,
+            "id": 4208,
             "name": "addController",
             "kind": 2048,
             "kindString": "Method",
@@ -33777,7 +33804,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1599,
+                "id": 4209,
                 "name": "addController",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33787,14 +33814,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 1600,
+                    "id": 4210,
                     "name": "controller",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1588,
+                      "id": 4198,
                       "name": "ReactiveController",
                       "location": {
                         "page": "controllers",
@@ -33824,7 +33851,7 @@
             }
           },
           {
-            "id": 1601,
+            "id": 4211,
             "name": "removeController",
             "kind": 2048,
             "kindString": "Method",
@@ -33835,7 +33862,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1602,
+                "id": 4212,
                 "name": "removeController",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33845,14 +33872,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 1603,
+                    "id": 4213,
                     "name": "controller",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1588,
+                      "id": 4198,
                       "name": "ReactiveController",
                       "location": {
                         "page": "controllers",
@@ -33882,7 +33909,7 @@
             }
           },
           {
-            "id": 1604,
+            "id": 4214,
             "name": "requestUpdate",
             "kind": 2048,
             "kindString": "Method",
@@ -33893,7 +33920,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 1605,
+                "id": 4215,
                 "name": "requestUpdate",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -33927,16 +33954,16 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              1606
+              4216
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              1598,
-              1601,
-              1604
+              4208,
+              4211,
+              4214
             ]
           }
         ],
@@ -33952,7 +33979,7 @@
         "implementedBy": [
           {
             "type": "reference",
-            "id": 1650,
+            "id": 4260,
             "name": "ReactiveElement",
             "location": {
               "page": "ReactiveElement",
@@ -33979,9 +34006,12 @@
   {
     "slug": "misc",
     "title": "Misc",
+    "versionLinks": {
+      "v1": "api/lit-element/LitElement/"
+    },
     "items": [
       {
-        "id": 1636,
+        "id": 4246,
         "name": "defaultConverter",
         "kind": 32,
         "kindString": "Variable",
@@ -34000,7 +34030,7 @@
         ],
         "type": {
           "type": "reference",
-          "id": 1607,
+          "id": 4217,
           "name": "ComplexAttributeConverter",
           "location": {
             "page": "ReactiveElement",
@@ -34022,7 +34052,7 @@
         }
       },
       {
-        "id": 1641,
+        "id": 4251,
         "name": "notEqual",
         "kind": 64,
         "kindString": "Function",
@@ -34044,7 +34074,7 @@
         ],
         "signatures": [
           {
-            "id": 1642,
+            "id": 4252,
             "name": "notEqual",
             "kind": 4096,
             "kindString": "Call signature",
@@ -34054,7 +34084,7 @@
             },
             "parameters": [
               {
-                "id": 1643,
+                "id": 4253,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -34065,7 +34095,7 @@
                 }
               },
               {
-                "id": 1644,
+                "id": 4254,
                 "name": "old",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -34097,14 +34127,14 @@
         }
       },
       {
-        "id": 2573,
+        "id": 5183,
         "name": "CompiledTemplate",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 2574,
+            "id": 5184,
             "name": "el",
             "kind": 1024,
             "kindString": "Property",
@@ -34143,7 +34173,7 @@
             }
           },
           {
-            "id": 2575,
+            "id": 5185,
             "name": "h",
             "kind": 1024,
             "kindString": "Property",
@@ -34182,8 +34212,8 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2574,
-              2575
+              5184,
+              5185
             ]
           }
         ],
@@ -34243,14 +34273,14 @@
         ]
       },
       {
-        "id": 2570,
+        "id": 5180,
         "name": "CompiledTemplateResult",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 2572,
+            "id": 5182,
             "name": "values",
             "kind": 1024,
             "kindString": "Property",
@@ -34292,8 +34322,8 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2571,
-              2572
+              5181,
+              5182
             ]
           }
         ],
@@ -34321,7 +34351,7 @@
         }
       },
       {
-        "id": 2608,
+        "id": 5218,
         "name": "DirectiveParent",
         "kind": 256,
         "kindString": "Interface",
@@ -34332,10 +34362,10 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2610,
-              2609,
-              2611,
-              2612
+              5220,
+              5219,
+              5221,
+              5222
             ]
           }
         ],
@@ -34363,7 +34393,7 @@
         }
       },
       {
-        "id": 2613,
+        "id": 5223,
         "name": "Disconnectable",
         "kind": 256,
         "kindString": "Interface",
@@ -34374,9 +34404,9 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2615,
-              2616,
-              2614
+              5225,
+              5226,
+              5224
             ]
           }
         ],
@@ -34392,7 +34422,7 @@
         "implementedBy": [
           {
             "type": "reference",
-            "id": 503,
+            "id": 3113,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -34401,7 +34431,7 @@
           },
           {
             "type": "reference",
-            "id": 539,
+            "id": 3149,
             "name": "ChildPart",
             "location": {
               "page": "custom-directives",
@@ -34410,7 +34440,7 @@
           },
           {
             "type": "reference",
-            "id": 650,
+            "id": 3260,
             "name": "Directive",
             "location": {
               "page": "custom-directives",
@@ -34419,7 +34449,7 @@
           },
           {
             "type": "reference",
-            "id": 567,
+            "id": 3177,
             "name": "ElementPart",
             "location": {
               "page": "custom-directives",
@@ -34442,7 +34472,7 @@
         }
       },
       {
-        "id": 1637,
+        "id": 4247,
         "name": "HasChanged",
         "kind": 256,
         "kindString": "Interface",
@@ -34459,14 +34489,14 @@
         ],
         "signatures": [
           {
-            "id": 1638,
+            "id": 4248,
             "name": "HasChanged",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 1639,
+                "id": 4249,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -34477,7 +34507,7 @@
                 }
               },
               {
-                "id": 1640,
+                "id": 4250,
                 "name": "old",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -34509,7 +34539,7 @@
         }
       },
       {
-        "id": 2568,
+        "id": 5178,
         "name": "HTMLTemplateResult",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -34526,7 +34556,7 @@
         ],
         "type": {
           "type": "reference",
-          "id": 2562,
+          "id": 5172,
           "typeArguments": [
             {
               "type": "query",
@@ -34557,7 +34587,7 @@
         }
       },
       {
-        "id": 1646,
+        "id": 4256,
         "name": "Initializer",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -34575,7 +34605,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 1647,
+            "id": 4257,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -34589,21 +34619,21 @@
             ],
             "signatures": [
               {
-                "id": 1648,
+                "id": 4258,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 1649,
+                    "id": 4259,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 1650,
+                      "id": 4260,
                       "name": "ReactiveElement",
                       "location": {
                         "page": "ReactiveElement",
@@ -34635,7 +34665,7 @@
         }
       },
       {
-        "id": 2619,
+        "id": 5229,
         "name": "RootPart",
         "kind": 256,
         "kindString": "Interface",
@@ -34645,7 +34675,7 @@
         },
         "children": [
           {
-            "id": 2624,
+            "id": 5234,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -34671,7 +34701,7 @@
                 },
                 {
                   "type": "reference",
-                  "id": 2586,
+                  "id": 5196,
                   "name": "RenderOptions",
                   "location": {
                     "page": "LitElement",
@@ -34682,7 +34712,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 547,
+              "id": 3157,
               "name": "ChildPart.options",
               "location": {
                 "page": "custom-directives",
@@ -34704,7 +34734,7 @@
             }
           },
           {
-            "id": 2623,
+            "id": 5233,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -34728,7 +34758,7 @@
             "defaultValue": "2",
             "inheritedFrom": {
               "type": "reference",
-              "id": 546,
+              "id": 3156,
               "name": "ChildPart.type",
               "location": {
                 "page": "custom-directives",
@@ -34750,7 +34780,7 @@
             }
           },
           {
-            "id": 2632,
+            "id": 5242,
             "name": "endNode",
             "kind": 262144,
             "kindString": "Accessor",
@@ -34783,7 +34813,7 @@
             },
             "getSignature": [
               {
-                "id": 2633,
+                "id": 5243,
                 "name": "endNode",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -34808,7 +34838,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 556,
+              "id": 3166,
               "name": "ChildPart.endNode",
               "location": {
                 "page": "custom-directives",
@@ -34830,7 +34860,7 @@
             }
           },
           {
-            "id": 2628,
+            "id": 5238,
             "name": "parentNode",
             "kind": 262144,
             "kindString": "Accessor",
@@ -34855,7 +34885,7 @@
             },
             "getSignature": [
               {
-                "id": 2629,
+                "id": 5239,
                 "name": "parentNode",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -34872,7 +34902,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 552,
+              "id": 3162,
               "name": "ChildPart.parentNode",
               "location": {
                 "page": "custom-directives",
@@ -34894,7 +34924,7 @@
             }
           },
           {
-            "id": 2630,
+            "id": 5240,
             "name": "startNode",
             "kind": 262144,
             "kindString": "Accessor",
@@ -34927,7 +34957,7 @@
             },
             "getSignature": [
               {
-                "id": 2631,
+                "id": 5241,
                 "name": "startNode",
                 "kind": 524288,
                 "kindString": "Get signature",
@@ -34952,7 +34982,7 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 554,
+              "id": 3164,
               "name": "ChildPart.startNode",
               "location": {
                 "page": "custom-directives",
@@ -34974,7 +35004,7 @@
             }
           },
           {
-            "id": 2620,
+            "id": 5230,
             "name": "setConnected",
             "kind": 2048,
             "kindString": "Method",
@@ -34986,7 +35016,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 2621,
+                "id": 5231,
                 "name": "setConnected",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -34997,7 +35027,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 2622,
+                    "id": 5232,
                     "name": "isConnected",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -35037,27 +35067,27 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              2625,
-              2624,
-              2623
+              5235,
+              5234,
+              5233
             ]
           },
           {
             "title": "Accessors",
             "kind": 262144,
             "children": [
-              2626,
-              2632,
-              2628,
-              2630
+              5236,
+              5242,
+              5238,
+              5240
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              2634,
-              2620
+              5244,
+              5230
             ]
           }
         ],
@@ -35073,7 +35103,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 539,
+            "id": 3149,
             "name": "ChildPart",
             "location": {
               "page": "custom-directives",
@@ -35097,7 +35127,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 539,
+            "id": 3149,
             "name": "ChildPart",
             "location": {
               "page": "custom-directives",
@@ -35107,7 +35137,7 @@
         ]
       },
       {
-        "id": 2558,
+        "id": 5168,
         "name": "ValueSanitizer",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -35125,7 +35155,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 2559,
+            "id": 5169,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -35144,7 +35174,7 @@
             ],
             "signatures": [
               {
-                "id": 2560,
+                "id": 5170,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -35156,7 +35186,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 2561,
+                    "id": 5171,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -35193,7 +35223,7 @@
         }
       },
       {
-        "id": 1645,
+        "id": 4255,
         "name": "WarningKind",
         "kind": 4194304,
         "kindString": "Type alias",

--- a/packages/lit-dev-api/api-data/lit-element-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-element-2/pages.json
@@ -2,6 +2,9 @@
   {
     "slug": "LitElement",
     "title": "LitElement",
+    "versionLinks": {
+      "v2": "api/LitElement/"
+    },
     "items": [
       {
         "id": 252,
@@ -3038,6 +3041,9 @@
   {
     "slug": "UpdatingElement",
     "title": "UpdatingElement",
+    "versionLinks": {
+      "v2": "api/ReactiveElement/"
+    },
     "items": [
       {
         "id": 1142,
@@ -6197,6 +6203,9 @@
   {
     "slug": "styles",
     "title": "Styles",
+    "versionLinks": {
+      "v2": "api/styles/"
+    },
     "items": [
       {
         "id": 2169,
@@ -6941,6 +6950,9 @@
   {
     "slug": "decorators",
     "title": "Decorators",
+    "versionLinks": {
+      "v2": "api/decorators/"
+    },
     "items": [
       {
         "id": 2135,

--- a/packages/lit-dev-api/api-data/lit-html-1/pages.json
+++ b/packages/lit-dev-api/api-data/lit-html-1/pages.json
@@ -2,9 +2,12 @@
   {
     "slug": "templates",
     "title": "Templates",
+    "versionLinks": {
+      "v2": "api/templates/"
+    },
     "items": [
       {
-        "id": 2,
+        "id": 4884,
         "name": "html",
         "kind": 64,
         "kindString": "Function",
@@ -26,7 +29,7 @@
         ],
         "signatures": [
           {
-            "id": 3,
+            "id": 4885,
             "name": "html",
             "kind": 4096,
             "kindString": "Call signature",
@@ -36,7 +39,7 @@
             },
             "parameters": [
               {
-                "id": 4,
+                "id": 4886,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -47,7 +50,7 @@
                 }
               },
               {
-                "id": 5,
+                "id": 4887,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -65,7 +68,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 396,
+              "id": 5278,
               "name": "TemplateResult",
               "location": {
                 "page": "templates",
@@ -89,7 +92,7 @@
         }
       },
       {
-        "id": 187,
+        "id": 5069,
         "name": "nothing",
         "kind": 32,
         "kindString": "Variable",
@@ -112,7 +115,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 188,
+            "id": 5070,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -135,7 +138,7 @@
         }
       },
       {
-        "id": 347,
+        "id": 5229,
         "name": "render",
         "kind": 64,
         "kindString": "Function",
@@ -158,7 +161,7 @@
         ],
         "signatures": [
           {
-            "id": 348,
+            "id": 5230,
             "name": "render",
             "kind": 4096,
             "kindString": "Call signature",
@@ -169,7 +172,7 @@
             },
             "parameters": [
               {
-                "id": 349,
+                "id": 5231,
                 "name": "result",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -183,7 +186,7 @@
                 }
               },
               {
-                "id": 350,
+                "id": 5232,
                 "name": "container",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -212,7 +215,7 @@
                 }
               },
               {
-                "id": 351,
+                "id": 5233,
                 "name": "options",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -227,7 +230,7 @@
                   "typeArguments": [
                     {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -260,7 +263,7 @@
         }
       },
       {
-        "id": 6,
+        "id": 4888,
         "name": "svg",
         "kind": 64,
         "kindString": "Function",
@@ -282,7 +285,7 @@
         ],
         "signatures": [
           {
-            "id": 7,
+            "id": 4889,
             "name": "svg",
             "kind": 4096,
             "kindString": "Call signature",
@@ -292,7 +295,7 @@
             },
             "parameters": [
               {
-                "id": 8,
+                "id": 4890,
                 "name": "strings",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -303,7 +306,7 @@
                 }
               },
               {
-                "id": 9,
+                "id": 4891,
                 "name": "values",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -321,7 +324,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 381,
+              "id": 5263,
               "name": "SVGTemplateResult",
               "location": {
                 "page": "templates",
@@ -345,7 +348,7 @@
         }
       },
       {
-        "id": 381,
+        "id": 5263,
         "name": "SVGTemplateResult",
         "kind": 128,
         "kindString": "Class",
@@ -356,7 +359,7 @@
         },
         "children": [
           {
-            "id": 382,
+            "id": 5264,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -364,14 +367,14 @@
             "children": [],
             "signatures": [
               {
-                "id": 383,
+                "id": 5265,
                 "name": "new SVGTemplateResult",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 384,
+                    "id": 5266,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -382,7 +385,7 @@
                     }
                   },
                   {
-                    "id": 385,
+                    "id": 5267,
                     "name": "values",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -400,7 +403,7 @@
                     }
                   },
                   {
-                    "id": 386,
+                    "id": 5268,
                     "name": "type",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -411,14 +414,14 @@
                     }
                   },
                   {
-                    "id": 387,
+                    "id": 5269,
                     "name": "processor",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 371,
+                      "id": 5253,
                       "name": "TemplateProcessor",
                       "location": {
                         "page": "custom-directives",
@@ -429,7 +432,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 381,
+                  "id": 5263,
                   "name": "SVGTemplateResult",
                   "location": {
                     "page": "templates",
@@ -438,14 +441,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 398,
+                  "id": 5280,
                   "name": "TemplateResult.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 397,
+              "id": 5279,
               "name": "TemplateResult.constructor",
               "location": {
                 "page": "templates",
@@ -467,7 +470,7 @@
             }
           },
           {
-            "id": 395,
+            "id": 5277,
             "name": "processor",
             "kind": 1024,
             "kindString": "Property",
@@ -486,7 +489,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 371,
+              "id": 5253,
               "name": "TemplateProcessor",
               "location": {
                 "page": "custom-directives",
@@ -495,7 +498,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 406,
+              "id": 5288,
               "name": "TemplateResult.processor",
               "location": {
                 "page": "templates",
@@ -517,7 +520,7 @@
             }
           },
           {
-            "id": 392,
+            "id": 5274,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -540,7 +543,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 403,
+              "id": 5285,
               "name": "TemplateResult.strings",
               "location": {
                 "page": "templates",
@@ -562,7 +565,7 @@
             }
           },
           {
-            "id": 394,
+            "id": 5276,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -585,7 +588,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 405,
+              "id": 5287,
               "name": "TemplateResult.type",
               "location": {
                 "page": "templates",
@@ -607,7 +610,7 @@
             }
           },
           {
-            "id": 393,
+            "id": 5275,
             "name": "values",
             "kind": 1024,
             "kindString": "Property",
@@ -637,7 +640,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 404,
+              "id": 5286,
               "name": "TemplateResult.values",
               "location": {
                 "page": "templates",
@@ -659,7 +662,7 @@
             }
           },
           {
-            "id": 388,
+            "id": 5270,
             "name": "getHTML",
             "kind": 2048,
             "kindString": "Method",
@@ -679,7 +682,7 @@
             ],
             "signatures": [
               {
-                "id": 389,
+                "id": 5271,
                 "name": "getHTML",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -693,14 +696,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 408,
+                  "id": 5290,
                   "name": "TemplateResult.getHTML"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 407,
+              "id": 5289,
               "name": "TemplateResult.getHTML",
               "location": {
                 "page": "templates",
@@ -722,7 +725,7 @@
             }
           },
           {
-            "id": 390,
+            "id": 5272,
             "name": "getTemplateElement",
             "kind": 2048,
             "kindString": "Method",
@@ -739,7 +742,7 @@
             ],
             "signatures": [
               {
-                "id": 391,
+                "id": 5273,
                 "name": "getTemplateElement",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -753,14 +756,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 410,
+                  "id": 5292,
                   "name": "TemplateResult.getTemplateElement"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 409,
+              "id": 5291,
               "name": "TemplateResult.getTemplateElement",
               "location": {
                 "page": "templates",
@@ -787,25 +790,25 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              382
+              5264
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              395,
-              392,
-              394,
-              393
+              5277,
+              5274,
+              5276,
+              5275
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              388,
-              390
+              5270,
+              5272
             ]
           }
         ],
@@ -821,7 +824,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 396,
+            "id": 5278,
             "name": "TemplateResult",
             "location": {
               "page": "templates",
@@ -845,7 +848,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 396,
+            "id": 5278,
             "name": "TemplateResult",
             "location": {
               "page": "templates",
@@ -855,7 +858,7 @@
         ]
       },
       {
-        "id": 396,
+        "id": 5278,
         "name": "TemplateResult",
         "kind": 128,
         "kindString": "Class",
@@ -865,7 +868,7 @@
         },
         "children": [
           {
-            "id": 397,
+            "id": 5279,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -882,14 +885,14 @@
             ],
             "signatures": [
               {
-                "id": 398,
+                "id": 5280,
                 "name": "new TemplateResult",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 399,
+                    "id": 5281,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -900,7 +903,7 @@
                     }
                   },
                   {
-                    "id": 400,
+                    "id": 5282,
                     "name": "values",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -918,7 +921,7 @@
                     }
                   },
                   {
-                    "id": 401,
+                    "id": 5283,
                     "name": "type",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -929,14 +932,14 @@
                     }
                   },
                   {
-                    "id": 402,
+                    "id": 5284,
                     "name": "processor",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 371,
+                      "id": 5253,
                       "name": "TemplateProcessor",
                       "location": {
                         "page": "custom-directives",
@@ -947,7 +950,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 396,
+                  "id": 5278,
                   "name": "TemplateResult",
                   "location": {
                     "page": "templates",
@@ -971,7 +974,7 @@
             }
           },
           {
-            "id": 406,
+            "id": 5288,
             "name": "processor",
             "kind": 1024,
             "kindString": "Property",
@@ -990,7 +993,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 371,
+              "id": 5253,
               "name": "TemplateProcessor",
               "location": {
                 "page": "custom-directives",
@@ -1012,7 +1015,7 @@
             }
           },
           {
-            "id": 403,
+            "id": 5285,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -1048,7 +1051,7 @@
             }
           },
           {
-            "id": 405,
+            "id": 5287,
             "name": "type",
             "kind": 1024,
             "kindString": "Property",
@@ -1084,7 +1087,7 @@
             }
           },
           {
-            "id": 404,
+            "id": 5286,
             "name": "values",
             "kind": 1024,
             "kindString": "Property",
@@ -1127,7 +1130,7 @@
             }
           },
           {
-            "id": 407,
+            "id": 5289,
             "name": "getHTML",
             "kind": 2048,
             "kindString": "Method",
@@ -1147,7 +1150,7 @@
             ],
             "signatures": [
               {
-                "id": 408,
+                "id": 5290,
                 "name": "getHTML",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1176,7 +1179,7 @@
             }
           },
           {
-            "id": 409,
+            "id": 5291,
             "name": "getTemplateElement",
             "kind": 2048,
             "kindString": "Method",
@@ -1193,7 +1196,7 @@
             ],
             "signatures": [
               {
-                "id": 410,
+                "id": 5292,
                 "name": "getTemplateElement",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -1227,25 +1230,25 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              397
+              5279
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              406,
-              403,
-              405,
-              404
+              5288,
+              5285,
+              5287,
+              5286
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              407,
-              409
+              5289,
+              5291
             ]
           }
         ],
@@ -1261,7 +1264,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 381,
+            "id": 5263,
             "name": "SVGTemplateResult",
             "location": {
               "page": "templates",
@@ -1284,14 +1287,14 @@
         }
       },
       {
-        "id": 343,
+        "id": 5225,
         "name": "RenderOptions",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 345,
+            "id": 5227,
             "name": "eventContext",
             "kind": 1024,
             "kindString": "Property",
@@ -1328,7 +1331,7 @@
             }
           },
           {
-            "id": 344,
+            "id": 5226,
             "name": "templateFactory",
             "kind": 1024,
             "kindString": "Property",
@@ -1369,8 +1372,8 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              345,
-              344
+              5227,
+              5226
             ]
           }
         ],
@@ -1402,9 +1405,12 @@
   {
     "slug": "directives",
     "title": "Directives",
+    "versionLinks": {
+      "v2": "api/directives/"
+    },
     "items": [
       {
-        "id": 27,
+        "id": 4909,
         "name": "asyncAppend",
         "kind": 64,
         "kindString": "Function",
@@ -1427,7 +1433,7 @@
         ],
         "signatures": [
           {
-            "id": 28,
+            "id": 4910,
             "name": "asyncAppend",
             "kind": 4096,
             "kindString": "Call signature",
@@ -1438,7 +1444,7 @@
             },
             "typeParameter": [
               {
-                "id": 29,
+                "id": 4911,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -1447,7 +1453,7 @@
             ],
             "parameters": [
               {
-                "id": 30,
+                "id": 4912,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -1467,7 +1473,7 @@
                 }
               },
               {
-                "id": 31,
+                "id": 4913,
                 "name": "mapper",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -1480,21 +1486,21 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 32,
+                    "id": 4914,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 33,
+                        "id": 4915,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
                         "flags": {},
                         "parameters": [
                           {
-                            "id": 34,
+                            "id": 4916,
                             "name": "v",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -1505,7 +1511,7 @@
                             }
                           },
                           {
-                            "id": 35,
+                            "id": 4917,
                             "name": "index",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -1531,28 +1537,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 36,
+                "id": 4918,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 37,
+                    "id": 4919,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 38,
+                        "id": 4920,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -1592,7 +1598,7 @@
         }
       },
       {
-        "id": 40,
+        "id": 4922,
         "name": "asyncReplace",
         "kind": 64,
         "kindString": "Function",
@@ -1615,7 +1621,7 @@
         ],
         "signatures": [
           {
-            "id": 41,
+            "id": 4923,
             "name": "asyncReplace",
             "kind": 4096,
             "kindString": "Call signature",
@@ -1626,7 +1632,7 @@
             },
             "typeParameter": [
               {
-                "id": 42,
+                "id": 4924,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -1635,7 +1641,7 @@
             ],
             "parameters": [
               {
-                "id": 43,
+                "id": 4925,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -1655,7 +1661,7 @@
                 }
               },
               {
-                "id": 44,
+                "id": 4926,
                 "name": "mapper",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -1668,21 +1674,21 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 45,
+                    "id": 4927,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 46,
+                        "id": 4928,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
                         "flags": {},
                         "parameters": [
                           {
-                            "id": 47,
+                            "id": 4929,
                             "name": "v",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -1693,7 +1699,7 @@
                             }
                           },
                           {
-                            "id": 48,
+                            "id": 4930,
                             "name": "index",
                             "kind": 32768,
                             "kindString": "Parameter",
@@ -1719,28 +1725,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 49,
+                "id": 4931,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 50,
+                    "id": 4932,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 51,
+                        "id": 4933,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -1780,7 +1786,7 @@
         }
       },
       {
-        "id": 53,
+        "id": 4935,
         "name": "cache",
         "kind": 64,
         "kindString": "Function",
@@ -1803,7 +1809,7 @@
         ],
         "signatures": [
           {
-            "id": 54,
+            "id": 4936,
             "name": "cache",
             "kind": 4096,
             "kindString": "Call signature",
@@ -1814,7 +1820,7 @@
             },
             "parameters": [
               {
-                "id": 55,
+                "id": 4937,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -1828,28 +1834,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 56,
+                "id": 4938,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 57,
+                    "id": 4939,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 58,
+                        "id": 4940,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -1883,7 +1889,7 @@
         }
       },
       {
-        "id": 63,
+        "id": 4945,
         "name": "classMap",
         "kind": 64,
         "kindString": "Function",
@@ -1905,7 +1911,7 @@
         ],
         "signatures": [
           {
-            "id": 64,
+            "id": 4946,
             "name": "classMap",
             "kind": 4096,
             "kindString": "Call signature",
@@ -1915,7 +1921,7 @@
             },
             "parameters": [
               {
-                "id": 65,
+                "id": 4947,
                 "name": "classInfo",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -1925,7 +1931,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 60,
+                  "id": 4942,
                   "name": "ClassInfo",
                   "location": {
                     "page": "directives",
@@ -1937,28 +1943,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 66,
+                "id": 4948,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 67,
+                    "id": 4949,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 68,
+                        "id": 4950,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -1992,7 +1998,7 @@
         }
       },
       {
-        "id": 60,
+        "id": 4942,
         "name": "ClassInfo",
         "kind": 256,
         "kindString": "Interface",
@@ -2008,14 +2014,14 @@
           }
         ],
         "indexSignature": {
-          "id": 61,
+          "id": 4943,
           "name": "__index",
           "kind": 8192,
           "kindString": "Index signature",
           "flags": {},
           "parameters": [
             {
-              "id": 62,
+              "id": 4944,
               "name": "name",
               "kind": 32768,
               "flags": {},
@@ -2058,7 +2064,7 @@
         }
       },
       {
-        "id": 70,
+        "id": 4952,
         "name": "guard",
         "kind": 64,
         "kindString": "Function",
@@ -2081,7 +2087,7 @@
         ],
         "signatures": [
           {
-            "id": 71,
+            "id": 4953,
             "name": "guard",
             "kind": 4096,
             "kindString": "Call signature",
@@ -2092,7 +2098,7 @@
             },
             "parameters": [
               {
-                "id": 72,
+                "id": 4954,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2106,7 +2112,7 @@
                 }
               },
               {
-                "id": 73,
+                "id": 4955,
                 "name": "f",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2117,14 +2123,14 @@
                 "type": {
                   "type": "reflection",
                   "declaration": {
-                    "id": 74,
+                    "id": 4956,
                     "name": "__type",
                     "kind": 65536,
                     "kindString": "Type literal",
                     "flags": {},
                     "signatures": [
                       {
-                        "id": 75,
+                        "id": 4957,
                         "name": "__type",
                         "kind": 4096,
                         "kindString": "Call signature",
@@ -2142,28 +2148,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 76,
+                "id": 4958,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 77,
+                    "id": 4959,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 78,
+                        "id": 4960,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -2197,7 +2203,7 @@
         }
       },
       {
-        "id": 80,
+        "id": 4962,
         "name": "ifDefined",
         "kind": 64,
         "kindString": "Function",
@@ -2220,7 +2226,7 @@
         ],
         "signatures": [
           {
-            "id": 81,
+            "id": 4963,
             "name": "ifDefined",
             "kind": 4096,
             "kindString": "Call signature",
@@ -2231,7 +2237,7 @@
             },
             "parameters": [
               {
-                "id": 82,
+                "id": 4964,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2245,28 +2251,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 83,
+                "id": 4965,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 84,
+                    "id": 4966,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 85,
+                        "id": 4967,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -2300,7 +2306,7 @@
         }
       },
       {
-        "id": 87,
+        "id": 4969,
         "name": "live",
         "kind": 64,
         "kindString": "Function",
@@ -2323,7 +2329,7 @@
         ],
         "signatures": [
           {
-            "id": 88,
+            "id": 4970,
             "name": "live",
             "kind": 4096,
             "kindString": "Call signature",
@@ -2334,7 +2340,7 @@
             },
             "parameters": [
               {
-                "id": 89,
+                "id": 4971,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2348,21 +2354,21 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 90,
+                "id": 4972,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 91,
+                    "id": 4973,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 92,
+                        "id": 4974,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
@@ -2372,7 +2378,7 @@
                           "types": [
                             {
                               "type": "reference",
-                              "id": 213,
+                              "id": 5095,
                               "name": "AttributePart",
                               "location": {
                                 "page": "custom-directives",
@@ -2381,7 +2387,7 @@
                             },
                             {
                               "type": "reference",
-                              "id": 332,
+                              "id": 5214,
                               "name": "PropertyPart",
                               "location": {
                                 "page": "custom-directives",
@@ -2390,7 +2396,7 @@
                             },
                             {
                               "type": "reference",
-                              "id": 224,
+                              "id": 5106,
                               "name": "BooleanAttributePart",
                               "location": {
                                 "page": "custom-directives",
@@ -2426,7 +2432,7 @@
         }
       },
       {
-        "id": 106,
+        "id": 4988,
         "name": "repeat",
         "kind": 64,
         "kindString": "Function",
@@ -2449,7 +2455,7 @@
         ],
         "signatures": [
           {
-            "id": 107,
+            "id": 4989,
             "name": "repeat",
             "kind": 4096,
             "kindString": "Call signature",
@@ -2460,7 +2466,7 @@
             },
             "typeParameter": [
               {
-                "id": 108,
+                "id": 4990,
                 "name": "T",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -2469,7 +2475,7 @@
             ],
             "parameters": [
               {
-                "id": 109,
+                "id": 4991,
                 "name": "items",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2486,7 +2492,7 @@
                 }
               },
               {
-                "id": 110,
+                "id": 4992,
                 "name": "keyFnOrTemplate",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2496,7 +2502,7 @@
                   "types": [
                     {
                       "type": "reference",
-                      "id": 94,
+                      "id": 4976,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -2511,7 +2517,7 @@
                     },
                     {
                       "type": "reference",
-                      "id": 100,
+                      "id": 4982,
                       "typeArguments": [
                         {
                           "type": "reference",
@@ -2528,7 +2534,7 @@
                 }
               },
               {
-                "id": 111,
+                "id": 4993,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2537,7 +2543,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 100,
+                  "id": 4982,
                   "typeArguments": [
                     {
                       "type": "reference",
@@ -2554,7 +2560,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 167,
+              "id": 5049,
               "name": "DirectiveFn",
               "location": {
                 "page": "custom-directives",
@@ -2578,7 +2584,7 @@
         }
       },
       {
-        "id": 100,
+        "id": 4982,
         "name": "ItemTemplate",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -2595,7 +2601,7 @@
         ],
         "typeParameter": [
           {
-            "id": 105,
+            "id": 4987,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -2605,7 +2611,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 101,
+            "id": 4983,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -2619,14 +2625,14 @@
             ],
             "signatures": [
               {
-                "id": 102,
+                "id": 4984,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 103,
+                    "id": 4985,
                     "name": "item",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2637,7 +2643,7 @@
                     }
                   },
                   {
-                    "id": 104,
+                    "id": 4986,
                     "name": "index",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2671,7 +2677,7 @@
         }
       },
       {
-        "id": 94,
+        "id": 4976,
         "name": "KeyFn",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -2688,7 +2694,7 @@
         ],
         "typeParameter": [
           {
-            "id": 99,
+            "id": 4981,
             "name": "T",
             "kind": 131072,
             "kindString": "Type parameter",
@@ -2698,7 +2704,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 95,
+            "id": 4977,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -2712,14 +2718,14 @@
             ],
             "signatures": [
               {
-                "id": 96,
+                "id": 4978,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 97,
+                    "id": 4979,
                     "name": "item",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2730,7 +2736,7 @@
                     }
                   },
                   {
-                    "id": 98,
+                    "id": 4980,
                     "name": "index",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -2764,7 +2770,7 @@
         }
       },
       {
-        "id": 116,
+        "id": 4998,
         "name": "styleMap",
         "kind": 64,
         "kindString": "Function",
@@ -2787,7 +2793,7 @@
         ],
         "signatures": [
           {
-            "id": 117,
+            "id": 4999,
             "name": "styleMap",
             "kind": 4096,
             "kindString": "Call signature",
@@ -2798,7 +2804,7 @@
             },
             "parameters": [
               {
-                "id": 118,
+                "id": 5000,
                 "name": "styleInfo",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2808,7 +2814,7 @@
                 },
                 "type": {
                   "type": "reference",
-                  "id": 113,
+                  "id": 4995,
                   "name": "StyleInfo",
                   "location": {
                     "page": "directives",
@@ -2820,28 +2826,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 119,
+                "id": 5001,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 120,
+                    "id": 5002,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 121,
+                        "id": 5003,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -2875,7 +2881,7 @@
         }
       },
       {
-        "id": 113,
+        "id": 4995,
         "name": "StyleInfo",
         "kind": 256,
         "kindString": "Interface",
@@ -2891,14 +2897,14 @@
           }
         ],
         "indexSignature": {
-          "id": 114,
+          "id": 4996,
           "name": "__index",
           "kind": 8192,
           "kindString": "Index signature",
           "flags": {},
           "parameters": [
             {
-              "id": 115,
+              "id": 4997,
               "name": "name",
               "kind": 32768,
               "flags": {},
@@ -2928,7 +2934,7 @@
         }
       },
       {
-        "id": 123,
+        "id": 5005,
         "name": "templateContent",
         "kind": 64,
         "kindString": "Function",
@@ -2951,7 +2957,7 @@
         ],
         "signatures": [
           {
-            "id": 124,
+            "id": 5006,
             "name": "templateContent",
             "kind": 4096,
             "kindString": "Call signature",
@@ -2962,7 +2968,7 @@
             },
             "parameters": [
               {
-                "id": 125,
+                "id": 5007,
                 "name": "template",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -2979,28 +2985,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 126,
+                "id": 5008,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 127,
+                    "id": 5009,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 128,
+                        "id": 5010,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -3034,7 +3040,7 @@
         }
       },
       {
-        "id": 130,
+        "id": 5012,
         "name": "unsafeHTML",
         "kind": 64,
         "kindString": "Function",
@@ -3057,7 +3063,7 @@
         ],
         "signatures": [
           {
-            "id": 131,
+            "id": 5013,
             "name": "unsafeHTML",
             "kind": 4096,
             "kindString": "Call signature",
@@ -3068,7 +3074,7 @@
             },
             "parameters": [
               {
-                "id": 132,
+                "id": 5014,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -3082,28 +3088,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 133,
+                "id": 5015,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 134,
+                    "id": 5016,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 135,
+                        "id": 5017,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -3137,7 +3143,7 @@
         }
       },
       {
-        "id": 137,
+        "id": 5019,
         "name": "unsafeSVG",
         "kind": 64,
         "kindString": "Function",
@@ -3160,7 +3166,7 @@
         ],
         "signatures": [
           {
-            "id": 138,
+            "id": 5020,
             "name": "unsafeSVG",
             "kind": 4096,
             "kindString": "Call signature",
@@ -3171,7 +3177,7 @@
             },
             "parameters": [
               {
-                "id": 139,
+                "id": 5021,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -3185,28 +3191,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 140,
+                "id": 5022,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 141,
+                    "id": 5023,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 142,
+                        "id": 5024,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -3240,7 +3246,7 @@
         }
       },
       {
-        "id": 144,
+        "id": 5026,
         "name": "until",
         "kind": 64,
         "kindString": "Function",
@@ -3263,7 +3269,7 @@
         ],
         "signatures": [
           {
-            "id": 145,
+            "id": 5027,
             "name": "until",
             "kind": 4096,
             "kindString": "Call signature",
@@ -3274,7 +3280,7 @@
             },
             "parameters": [
               {
-                "id": 146,
+                "id": 5028,
                 "name": "args",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -3293,28 +3299,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 147,
+                "id": 5029,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 148,
+                    "id": 5030,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 149,
+                        "id": 5031,
                         "name": "part",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 189,
+                          "id": 5071,
                           "name": "Part",
                           "location": {
                             "page": "custom-directives",
@@ -3352,9 +3358,12 @@
   {
     "slug": "custom-directives",
     "title": "Custom directives",
+    "versionLinks": {
+      "v2": "api/custom-directives/"
+    },
     "items": [
       {
-        "id": 196,
+        "id": 5078,
         "name": "AttributeCommitter",
         "kind": 128,
         "kindString": "Class",
@@ -3364,7 +3373,7 @@
         },
         "children": [
           {
-            "id": 197,
+            "id": 5079,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -3381,14 +3390,14 @@
             ],
             "signatures": [
               {
-                "id": 198,
+                "id": 5080,
                 "name": "new AttributeCommitter",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 199,
+                    "id": 5081,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -3402,7 +3411,7 @@
                     }
                   },
                   {
-                    "id": 200,
+                    "id": 5082,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -3413,7 +3422,7 @@
                     }
                   },
                   {
-                    "id": 201,
+                    "id": 5083,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -3433,7 +3442,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 196,
+                  "id": 5078,
                   "name": "AttributeCommitter",
                   "location": {
                     "page": "custom-directives",
@@ -3457,7 +3466,7 @@
             }
           },
           {
-            "id": 206,
+            "id": 5088,
             "name": "dirty",
             "kind": 1024,
             "kindString": "Property",
@@ -3492,7 +3501,7 @@
             }
           },
           {
-            "id": 202,
+            "id": 5084,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -3531,7 +3540,7 @@
             }
           },
           {
-            "id": 203,
+            "id": 5085,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -3567,7 +3576,7 @@
             }
           },
           {
-            "id": 205,
+            "id": 5087,
             "name": "parts",
             "kind": 1024,
             "kindString": "Property",
@@ -3591,7 +3600,7 @@
                 "type": "array",
                 "elementType": {
                   "type": "reference",
-                  "id": 213,
+                  "id": 5095,
                   "name": "AttributePart",
                   "location": {
                     "page": "custom-directives",
@@ -3615,7 +3624,7 @@
             }
           },
           {
-            "id": 204,
+            "id": 5086,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -3658,7 +3667,7 @@
             }
           },
           {
-            "id": 211,
+            "id": 5093,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -3675,7 +3684,7 @@
             ],
             "signatures": [
               {
-                "id": 212,
+                "id": 5094,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -3706,27 +3715,27 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              197
+              5079
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              206,
-              202,
-              203,
-              205,
-              204
+              5088,
+              5084,
+              5085,
+              5087,
+              5086
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              207,
-              209,
-              211
+              5089,
+              5091,
+              5093
             ]
           }
         ],
@@ -3742,7 +3751,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 314,
+            "id": 5196,
             "name": "PropertyCommitter",
             "location": {
               "page": "custom-directives",
@@ -3765,7 +3774,7 @@
         }
       },
       {
-        "id": 213,
+        "id": 5095,
         "name": "AttributePart",
         "kind": 128,
         "kindString": "Class",
@@ -3775,7 +3784,7 @@
         },
         "children": [
           {
-            "id": 214,
+            "id": 5096,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -3792,21 +3801,21 @@
             ],
             "signatures": [
               {
-                "id": 215,
+                "id": 5097,
                 "name": "new AttributePart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 216,
+                    "id": 5098,
                     "name": "committer",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 196,
+                      "id": 5078,
                       "name": "AttributeCommitter",
                       "location": {
                         "page": "custom-directives",
@@ -3817,7 +3826,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 213,
+                  "id": 5095,
                   "name": "AttributePart",
                   "location": {
                     "page": "custom-directives",
@@ -3841,7 +3850,7 @@
             }
           },
           {
-            "id": 217,
+            "id": 5099,
             "name": "committer",
             "kind": 1024,
             "kindString": "Property",
@@ -3860,7 +3869,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 196,
+              "id": 5078,
               "name": "AttributeCommitter",
               "location": {
                 "page": "custom-directives",
@@ -3882,7 +3891,7 @@
             }
           },
           {
-            "id": 218,
+            "id": 5100,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -3904,7 +3913,7 @@
             "defaultValue": "...",
             "implementationOf": {
               "type": "reference",
-              "id": 190,
+              "id": 5072,
               "name": "Part.value",
               "location": {
                 "page": "custom-directives",
@@ -3926,7 +3935,7 @@
             }
           },
           {
-            "id": 222,
+            "id": 5104,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -3947,7 +3956,7 @@
             ],
             "signatures": [
               {
-                "id": 223,
+                "id": 5105,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -3962,14 +3971,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 195,
+                  "id": 5077,
                   "name": "Part.commit"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 194,
+              "id": 5076,
               "name": "Part.commit",
               "location": {
                 "page": "custom-directives",
@@ -3991,7 +4000,7 @@
             }
           },
           {
-            "id": 219,
+            "id": 5101,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -4011,7 +4020,7 @@
             ],
             "signatures": [
               {
-                "id": 220,
+                "id": 5102,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -4021,7 +4030,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 221,
+                    "id": 5103,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4038,14 +4047,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 192,
+                  "id": 5074,
                   "name": "Part.setValue"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 191,
+              "id": 5073,
               "name": "Part.setValue",
               "location": {
                 "page": "custom-directives",
@@ -4072,23 +4081,23 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              214
+              5096
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              217,
-              218
+              5099,
+              5100
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              222,
-              219
+              5104,
+              5101
             ]
           }
         ],
@@ -4104,7 +4113,7 @@
         "extendedBy": [
           {
             "type": "reference",
-            "id": 332,
+            "id": 5214,
             "name": "PropertyPart",
             "location": {
               "page": "custom-directives",
@@ -4115,7 +4124,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 189,
+            "id": 5071,
             "name": "Part",
             "location": {
               "page": "custom-directives",
@@ -4138,7 +4147,7 @@
         }
       },
       {
-        "id": 224,
+        "id": 5106,
         "name": "BooleanAttributePart",
         "kind": 128,
         "kindString": "Class",
@@ -4149,7 +4158,7 @@
         },
         "children": [
           {
-            "id": 225,
+            "id": 5107,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -4166,14 +4175,14 @@
             ],
             "signatures": [
               {
-                "id": 226,
+                "id": 5108,
                 "name": "new BooleanAttributePart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 227,
+                    "id": 5109,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4187,7 +4196,7 @@
                     }
                   },
                   {
-                    "id": 228,
+                    "id": 5110,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4198,7 +4207,7 @@
                     }
                   },
                   {
-                    "id": 229,
+                    "id": 5111,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4218,7 +4227,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 224,
+                  "id": 5106,
                   "name": "BooleanAttributePart",
                   "location": {
                     "page": "custom-directives",
@@ -4242,7 +4251,7 @@
             }
           },
           {
-            "id": 230,
+            "id": 5112,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -4281,7 +4290,7 @@
             }
           },
           {
-            "id": 231,
+            "id": 5113,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -4317,7 +4326,7 @@
             }
           },
           {
-            "id": 232,
+            "id": 5114,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -4360,7 +4369,7 @@
             }
           },
           {
-            "id": 233,
+            "id": 5115,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -4382,7 +4391,7 @@
             "defaultValue": "...",
             "implementationOf": {
               "type": "reference",
-              "id": 190,
+              "id": 5072,
               "name": "Part.value",
               "location": {
                 "page": "custom-directives",
@@ -4404,7 +4413,7 @@
             }
           },
           {
-            "id": 238,
+            "id": 5120,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -4425,7 +4434,7 @@
             ],
             "signatures": [
               {
-                "id": 239,
+                "id": 5121,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -4440,14 +4449,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 195,
+                  "id": 5077,
                   "name": "Part.commit"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 194,
+              "id": 5076,
               "name": "Part.commit",
               "location": {
                 "page": "custom-directives",
@@ -4469,7 +4478,7 @@
             }
           },
           {
-            "id": 235,
+            "id": 5117,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -4489,7 +4498,7 @@
             ],
             "signatures": [
               {
-                "id": 236,
+                "id": 5118,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -4499,7 +4508,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 237,
+                    "id": 5119,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4516,14 +4525,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 192,
+                  "id": 5074,
                   "name": "Part.setValue"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 191,
+              "id": 5073,
               "name": "Part.setValue",
               "location": {
                 "page": "custom-directives",
@@ -4550,26 +4559,26 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              225
+              5107
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              234,
-              230,
-              231,
-              232,
-              233
+              5116,
+              5112,
+              5113,
+              5114,
+              5115
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              238,
-              235
+              5120,
+              5117
             ]
           }
         ],
@@ -4585,7 +4594,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 189,
+            "id": 5071,
             "name": "Part",
             "location": {
               "page": "custom-directives",
@@ -4608,7 +4617,7 @@
         }
       },
       {
-        "id": 411,
+        "id": 5293,
         "name": "createMarker",
         "kind": 64,
         "kindString": "Function",
@@ -4627,7 +4636,7 @@
         ],
         "signatures": [
           {
-            "id": 412,
+            "id": 5294,
             "name": "createMarker",
             "kind": 4096,
             "kindString": "Call signature",
@@ -4653,7 +4662,7 @@
         }
       },
       {
-        "id": 162,
+        "id": 5044,
         "name": "defaultTemplateProcessor",
         "kind": 32,
         "kindString": "Variable",
@@ -4672,7 +4681,7 @@
         ],
         "type": {
           "type": "reference",
-          "id": 150,
+          "id": 5032,
           "name": "DefaultTemplateProcessor",
           "location": {
             "page": "custom-directives",
@@ -4695,7 +4704,7 @@
         }
       },
       {
-        "id": 150,
+        "id": 5032,
         "name": "DefaultTemplateProcessor",
         "kind": 128,
         "kindString": "Class",
@@ -4705,7 +4714,7 @@
         },
         "children": [
           {
-            "id": 151,
+            "id": 5033,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -4713,14 +4722,14 @@
             "children": [],
             "signatures": [
               {
-                "id": 152,
+                "id": 5034,
                 "name": "new DefaultTemplateProcessor",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 150,
+                  "id": 5032,
                   "name": "DefaultTemplateProcessor",
                   "location": {
                     "page": "custom-directives",
@@ -4744,7 +4753,7 @@
             }
           },
           {
-            "id": 153,
+            "id": 5035,
             "name": "handleAttributeExpressions",
             "kind": 2048,
             "kindString": "Method",
@@ -4764,7 +4773,7 @@
             ],
             "signatures": [
               {
-                "id": 154,
+                "id": 5036,
                 "name": "handleAttributeExpressions",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -4774,7 +4783,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 155,
+                    "id": 5037,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4791,7 +4800,7 @@
                     }
                   },
                   {
-                    "id": 156,
+                    "id": 5038,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4805,7 +4814,7 @@
                     }
                   },
                   {
-                    "id": 157,
+                    "id": 5039,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -4822,14 +4831,14 @@
                     }
                   },
                   {
-                    "id": 158,
+                    "id": 5040,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -4845,7 +4854,7 @@
                     "type": "array",
                     "elementType": {
                       "type": "reference",
-                      "id": 189,
+                      "id": 5071,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -4856,14 +4865,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 373,
+                  "id": 5255,
                   "name": "TemplateProcessor.handleAttributeExpressions"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 372,
+              "id": 5254,
               "name": "TemplateProcessor.handleAttributeExpressions",
               "location": {
                 "page": "custom-directives",
@@ -4885,7 +4894,7 @@
             }
           },
           {
-            "id": 159,
+            "id": 5041,
             "name": "handleTextExpression",
             "kind": 2048,
             "kindString": "Method",
@@ -4905,7 +4914,7 @@
             ],
             "signatures": [
               {
-                "id": 160,
+                "id": 5042,
                 "name": "handleTextExpression",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -4915,14 +4924,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 161,
+                    "id": 5043,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -4933,7 +4942,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 270,
+                  "id": 5152,
                   "name": "NodePart",
                   "location": {
                     "page": "custom-directives",
@@ -4942,14 +4951,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 379,
+                  "id": 5261,
                   "name": "TemplateProcessor.handleTextExpression"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 378,
+              "id": 5260,
               "name": "TemplateProcessor.handleTextExpression",
               "location": {
                 "page": "custom-directives",
@@ -4976,15 +4985,15 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              151
+              5033
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              153,
-              159
+              5035,
+              5041
             ]
           }
         ],
@@ -5000,7 +5009,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 371,
+            "id": 5253,
             "name": "TemplateProcessor",
             "location": {
               "page": "custom-directives",
@@ -5023,7 +5032,7 @@
         }
       },
       {
-        "id": 163,
+        "id": 5045,
         "name": "directive",
         "kind": 64,
         "kindString": "Function",
@@ -5052,7 +5061,7 @@
         ],
         "signatures": [
           {
-            "id": 164,
+            "id": 5046,
             "name": "directive",
             "kind": 4096,
             "kindString": "Call signature",
@@ -5069,7 +5078,7 @@
             },
             "typeParameter": [
               {
-                "id": 165,
+                "id": 5047,
                 "name": "F",
                 "kind": 131072,
                 "kindString": "Type parameter",
@@ -5082,7 +5091,7 @@
             ],
             "parameters": [
               {
-                "id": 166,
+                "id": 5048,
                 "name": "f",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -5117,14 +5126,14 @@
         }
       },
       {
-        "id": 240,
+        "id": 5122,
         "name": "EventPart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 241,
+            "id": 5123,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -5141,14 +5150,14 @@
             ],
             "signatures": [
               {
-                "id": 242,
+                "id": 5124,
                 "name": "new EventPart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 243,
+                    "id": 5125,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -5162,7 +5171,7 @@
                     }
                   },
                   {
-                    "id": 244,
+                    "id": 5126,
                     "name": "eventName",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -5173,7 +5182,7 @@
                     }
                   },
                   {
-                    "id": 245,
+                    "id": 5127,
                     "name": "eventContext",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -5188,7 +5197,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 240,
+                  "id": 5122,
                   "name": "EventPart",
                   "location": {
                     "page": "custom-directives",
@@ -5212,7 +5221,7 @@
             }
           },
           {
-            "id": 246,
+            "id": 5128,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -5251,7 +5260,7 @@
             }
           },
           {
-            "id": 248,
+            "id": 5130,
             "name": "eventContext",
             "kind": 1024,
             "kindString": "Property",
@@ -5288,7 +5297,7 @@
             }
           },
           {
-            "id": 247,
+            "id": 5129,
             "name": "eventName",
             "kind": 1024,
             "kindString": "Property",
@@ -5324,7 +5333,7 @@
             }
           },
           {
-            "id": 249,
+            "id": 5131,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -5355,7 +5364,7 @@
             "defaultValue": "...",
             "implementationOf": {
               "type": "reference",
-              "id": 190,
+              "id": 5072,
               "name": "Part.value",
               "location": {
                 "page": "custom-directives",
@@ -5377,7 +5386,7 @@
             }
           },
           {
-            "id": 259,
+            "id": 5141,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -5398,7 +5407,7 @@
             ],
             "signatures": [
               {
-                "id": 260,
+                "id": 5142,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -5413,14 +5422,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 195,
+                  "id": 5077,
                   "name": "Part.commit"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 194,
+              "id": 5076,
               "name": "Part.commit",
               "location": {
                 "page": "custom-directives",
@@ -5442,7 +5451,7 @@
             }
           },
           {
-            "id": 261,
+            "id": 5143,
             "name": "handleEvent",
             "kind": 2048,
             "kindString": "Method",
@@ -5459,14 +5468,14 @@
             ],
             "signatures": [
               {
-                "id": 262,
+                "id": 5144,
                 "name": "handleEvent",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 263,
+                    "id": 5145,
                     "name": "event",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -5498,7 +5507,7 @@
             }
           },
           {
-            "id": 256,
+            "id": 5138,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -5518,7 +5527,7 @@
             ],
             "signatures": [
               {
-                "id": 257,
+                "id": 5139,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -5528,7 +5537,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 258,
+                    "id": 5140,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -5554,14 +5563,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 192,
+                  "id": 5074,
                   "name": "Part.setValue"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 191,
+              "id": 5073,
               "name": "Part.setValue",
               "location": {
                 "page": "custom-directives",
@@ -5588,29 +5597,29 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              241
+              5123
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              252,
-              250,
-              251,
-              246,
-              248,
-              247,
-              249
+              5134,
+              5132,
+              5133,
+              5128,
+              5130,
+              5129,
+              5131
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              259,
-              261,
-              256
+              5141,
+              5143,
+              5138
             ]
           }
         ],
@@ -5626,7 +5635,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 189,
+            "id": 5071,
             "name": "Part",
             "location": {
               "page": "custom-directives",
@@ -5649,7 +5658,7 @@
         }
       },
       {
-        "id": 171,
+        "id": 5053,
         "name": "isDirective",
         "kind": 64,
         "kindString": "Function",
@@ -5668,14 +5677,14 @@
         ],
         "signatures": [
           {
-            "id": 172,
+            "id": 5054,
             "name": "isDirective",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 173,
+                "id": 5055,
                 "name": "o",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -5692,7 +5701,7 @@
               "asserts": false,
               "targetType": {
                 "type": "reference",
-                "id": 167,
+                "id": 5049,
                 "name": "DirectiveFn",
                 "location": {
                   "page": "custom-directives",
@@ -5717,7 +5726,7 @@
         }
       },
       {
-        "id": 264,
+        "id": 5146,
         "name": "isIterable",
         "kind": 64,
         "kindString": "Function",
@@ -5736,14 +5745,14 @@
         ],
         "signatures": [
           {
-            "id": 265,
+            "id": 5147,
             "name": "isIterable",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 266,
+                "id": 5148,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -5786,7 +5795,7 @@
         }
       },
       {
-        "id": 267,
+        "id": 5149,
         "name": "isPrimitive",
         "kind": 64,
         "kindString": "Function",
@@ -5805,14 +5814,14 @@
         ],
         "signatures": [
           {
-            "id": 268,
+            "id": 5150,
             "name": "isPrimitive",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 269,
+                "id": 5151,
                 "name": "value",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -5849,7 +5858,7 @@
         }
       },
       {
-        "id": 413,
+        "id": 5295,
         "name": "isTemplatePartActive",
         "kind": 64,
         "kindString": "Function",
@@ -5868,14 +5877,14 @@
         ],
         "signatures": [
           {
-            "id": 414,
+            "id": 5296,
             "name": "isTemplatePartActive",
             "kind": 4096,
             "kindString": "Call signature",
             "flags": {},
             "parameters": [
               {
-                "id": 415,
+                "id": 5297,
                 "name": "part",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -5907,7 +5916,7 @@
         }
       },
       {
-        "id": 185,
+        "id": 5067,
         "name": "noChange",
         "kind": 32,
         "kindString": "Variable",
@@ -5930,7 +5939,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 186,
+            "id": 5068,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -5953,7 +5962,7 @@
         }
       },
       {
-        "id": 270,
+        "id": 5152,
         "name": "NodePart",
         "kind": 128,
         "kindString": "Class",
@@ -5964,7 +5973,7 @@
         },
         "children": [
           {
-            "id": 271,
+            "id": 5153,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -5981,21 +5990,21 @@
             ],
             "signatures": [
               {
-                "id": 272,
+                "id": 5154,
                 "name": "new NodePart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 273,
+                    "id": 5155,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -6006,7 +6015,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 270,
+                  "id": 5152,
                   "name": "NodePart",
                   "location": {
                     "page": "custom-directives",
@@ -6030,7 +6039,7 @@
             }
           },
           {
-            "id": 276,
+            "id": 5158,
             "name": "endNode",
             "kind": 1024,
             "kindString": "Property",
@@ -6064,7 +6073,7 @@
             }
           },
           {
-            "id": 274,
+            "id": 5156,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -6083,7 +6092,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 343,
+              "id": 5225,
               "name": "RenderOptions",
               "location": {
                 "page": "templates",
@@ -6105,7 +6114,7 @@
             }
           },
           {
-            "id": 275,
+            "id": 5157,
             "name": "startNode",
             "kind": 1024,
             "kindString": "Property",
@@ -6139,7 +6148,7 @@
             }
           },
           {
-            "id": 277,
+            "id": 5159,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -6161,7 +6170,7 @@
             "defaultValue": "...",
             "implementationOf": {
               "type": "reference",
-              "id": 190,
+              "id": 5072,
               "name": "Part.value",
               "location": {
                 "page": "custom-directives",
@@ -6183,7 +6192,7 @@
             }
           },
           {
-            "id": 279,
+            "id": 5161,
             "name": "appendInto",
             "kind": 2048,
             "kindString": "Method",
@@ -6204,7 +6213,7 @@
             ],
             "signatures": [
               {
-                "id": 280,
+                "id": 5162,
                 "name": "appendInto",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -6215,7 +6224,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 281,
+                    "id": 5163,
                     "name": "container",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6247,7 +6256,7 @@
             }
           },
           {
-            "id": 285,
+            "id": 5167,
             "name": "appendIntoPart",
             "kind": 2048,
             "kindString": "Method",
@@ -6268,7 +6277,7 @@
             ],
             "signatures": [
               {
-                "id": 286,
+                "id": 5168,
                 "name": "appendIntoPart",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -6279,14 +6288,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 287,
+                    "id": 5169,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 270,
+                      "id": 5152,
                       "name": "NodePart",
                       "location": {
                         "page": "custom-directives",
@@ -6316,7 +6325,7 @@
             }
           },
           {
-            "id": 311,
+            "id": 5193,
             "name": "clear",
             "kind": 2048,
             "kindString": "Method",
@@ -6333,14 +6342,14 @@
             ],
             "signatures": [
               {
-                "id": 312,
+                "id": 5194,
                 "name": "clear",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 313,
+                    "id": 5195,
                     "name": "startNode",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6373,7 +6382,7 @@
             }
           },
           {
-            "id": 294,
+            "id": 5176,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -6394,7 +6403,7 @@
             ],
             "signatures": [
               {
-                "id": 295,
+                "id": 5177,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -6409,14 +6418,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 195,
+                  "id": 5077,
                   "name": "Part.commit"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 194,
+              "id": 5076,
               "name": "Part.commit",
               "location": {
                 "page": "custom-directives",
@@ -6438,7 +6447,7 @@
             }
           },
           {
-            "id": 282,
+            "id": 5164,
             "name": "insertAfterNode",
             "kind": 2048,
             "kindString": "Method",
@@ -6459,7 +6468,7 @@
             ],
             "signatures": [
               {
-                "id": 283,
+                "id": 5165,
                 "name": "insertAfterNode",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -6470,7 +6479,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 284,
+                    "id": 5166,
                     "name": "ref",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6502,7 +6511,7 @@
             }
           },
           {
-            "id": 288,
+            "id": 5170,
             "name": "insertAfterPart",
             "kind": 2048,
             "kindString": "Method",
@@ -6523,7 +6532,7 @@
             ],
             "signatures": [
               {
-                "id": 289,
+                "id": 5171,
                 "name": "insertAfterPart",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -6534,14 +6543,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 290,
+                    "id": 5172,
                     "name": "ref",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 270,
+                      "id": 5152,
                       "name": "NodePart",
                       "location": {
                         "page": "custom-directives",
@@ -6571,7 +6580,7 @@
             }
           },
           {
-            "id": 291,
+            "id": 5173,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -6591,7 +6600,7 @@
             ],
             "signatures": [
               {
-                "id": 292,
+                "id": 5174,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -6601,7 +6610,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 293,
+                    "id": 5175,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6618,14 +6627,14 @@
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "id": 192,
+                  "id": 5074,
                   "name": "Part.setValue"
                 }
               }
             ],
             "implementationOf": {
               "type": "reference",
-              "id": 191,
+              "id": 5073,
               "name": "Part.setValue",
               "location": {
                 "page": "custom-directives",
@@ -6652,36 +6661,36 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              271
+              5153
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              278,
-              276,
-              274,
-              275,
-              277
+              5160,
+              5158,
+              5156,
+              5157,
+              5159
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              308,
-              299,
-              305,
-              302,
-              296,
-              279,
-              285,
-              311,
-              294,
-              282,
-              288,
-              291
+              5190,
+              5181,
+              5187,
+              5184,
+              5178,
+              5161,
+              5167,
+              5193,
+              5176,
+              5164,
+              5170,
+              5173
             ]
           }
         ],
@@ -6697,7 +6706,7 @@
         "implementedTypes": [
           {
             "type": "reference",
-            "id": 189,
+            "id": 5071,
             "name": "Part",
             "location": {
               "page": "custom-directives",
@@ -6720,7 +6729,7 @@
         }
       },
       {
-        "id": 346,
+        "id": 5228,
         "name": "parts",
         "kind": 32,
         "kindString": "Variable",
@@ -6746,7 +6755,7 @@
             },
             {
               "type": "reference",
-              "id": 270,
+              "id": 5152,
               "name": "NodePart",
               "location": {
                 "page": "custom-directives",
@@ -6772,7 +6781,7 @@
         }
       },
       {
-        "id": 314,
+        "id": 5196,
         "name": "PropertyCommitter",
         "kind": 128,
         "kindString": "Class",
@@ -6783,7 +6792,7 @@
         },
         "children": [
           {
-            "id": 315,
+            "id": 5197,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -6800,14 +6809,14 @@
             ],
             "signatures": [
               {
-                "id": 316,
+                "id": 5198,
                 "name": "new PropertyCommitter",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 317,
+                    "id": 5199,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6821,7 +6830,7 @@
                     }
                   },
                   {
-                    "id": 318,
+                    "id": 5200,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6832,7 +6841,7 @@
                     }
                   },
                   {
-                    "id": 319,
+                    "id": 5201,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -6852,7 +6861,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 314,
+                  "id": 5196,
                   "name": "PropertyCommitter",
                   "location": {
                     "page": "custom-directives",
@@ -6861,14 +6870,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 198,
+                  "id": 5080,
                   "name": "AttributeCommitter.constructor"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 197,
+              "id": 5079,
               "name": "AttributeCommitter.constructor",
               "location": {
                 "page": "custom-directives",
@@ -6890,7 +6899,7 @@
             }
           },
           {
-            "id": 331,
+            "id": 5213,
             "name": "dirty",
             "kind": 1024,
             "kindString": "Property",
@@ -6912,7 +6921,7 @@
             "defaultValue": "true",
             "inheritedFrom": {
               "type": "reference",
-              "id": 206,
+              "id": 5088,
               "name": "AttributeCommitter.dirty",
               "location": {
                 "page": "custom-directives",
@@ -6934,7 +6943,7 @@
             }
           },
           {
-            "id": 327,
+            "id": 5209,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -6960,7 +6969,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 202,
+              "id": 5084,
               "name": "AttributeCommitter.element",
               "location": {
                 "page": "custom-directives",
@@ -6982,7 +6991,7 @@
             }
           },
           {
-            "id": 328,
+            "id": 5210,
             "name": "name",
             "kind": 1024,
             "kindString": "Property",
@@ -7005,7 +7014,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 203,
+              "id": 5085,
               "name": "AttributeCommitter.name",
               "location": {
                 "page": "custom-directives",
@@ -7027,7 +7036,7 @@
             }
           },
           {
-            "id": 330,
+            "id": 5212,
             "name": "parts",
             "kind": 1024,
             "kindString": "Property",
@@ -7051,7 +7060,7 @@
                 "type": "array",
                 "elementType": {
                   "type": "reference",
-                  "id": 213,
+                  "id": 5095,
                   "name": "AttributePart",
                   "location": {
                     "page": "custom-directives",
@@ -7062,7 +7071,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 205,
+              "id": 5087,
               "name": "AttributeCommitter.parts",
               "location": {
                 "page": "custom-directives",
@@ -7084,7 +7093,7 @@
             }
           },
           {
-            "id": 320,
+            "id": 5202,
             "name": "single",
             "kind": 1024,
             "kindString": "Property",
@@ -7120,7 +7129,7 @@
             }
           },
           {
-            "id": 329,
+            "id": 5211,
             "name": "strings",
             "kind": 1024,
             "kindString": "Property",
@@ -7150,7 +7159,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 204,
+              "id": 5086,
               "name": "AttributeCommitter.strings",
               "location": {
                 "page": "custom-directives",
@@ -7172,7 +7181,7 @@
             }
           },
           {
-            "id": 325,
+            "id": 5207,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -7189,7 +7198,7 @@
             ],
             "signatures": [
               {
-                "id": 326,
+                "id": 5208,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -7200,14 +7209,14 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "id": 212,
+                  "id": 5094,
                   "name": "AttributeCommitter.commit"
                 }
               }
             ],
             "overwrites": {
               "type": "reference",
-              "id": 211,
+              "id": 5093,
               "name": "AttributeCommitter.commit",
               "location": {
                 "page": "custom-directives",
@@ -7234,28 +7243,28 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              315
+              5197
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              331,
-              327,
-              328,
-              330,
-              320,
-              329
+              5213,
+              5209,
+              5210,
+              5212,
+              5202,
+              5211
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              321,
-              323,
-              325
+              5203,
+              5205,
+              5207
             ]
           }
         ],
@@ -7271,7 +7280,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 196,
+            "id": 5078,
             "name": "AttributeCommitter",
             "location": {
               "page": "custom-directives",
@@ -7295,7 +7304,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 196,
+            "id": 5078,
             "name": "AttributeCommitter",
             "location": {
               "page": "custom-directives",
@@ -7305,14 +7314,14 @@
         ]
       },
       {
-        "id": 332,
+        "id": 5214,
         "name": "PropertyPart",
         "kind": 128,
         "kindString": "Class",
         "flags": {},
         "children": [
           {
-            "id": 333,
+            "id": 5215,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -7320,21 +7329,21 @@
             "children": [],
             "signatures": [
               {
-                "id": 334,
+                "id": 5216,
                 "name": "new PropertyPart",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 335,
+                    "id": 5217,
                     "name": "committer",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 196,
+                      "id": 5078,
                       "name": "AttributeCommitter",
                       "location": {
                         "page": "custom-directives",
@@ -7345,7 +7354,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 332,
+                  "id": 5214,
                   "name": "PropertyPart",
                   "location": {
                     "page": "custom-directives",
@@ -7354,14 +7363,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 215,
+                  "id": 5097,
                   "name": "AttributePart.constructor"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 214,
+              "id": 5096,
               "name": "AttributePart.constructor",
               "location": {
                 "page": "custom-directives",
@@ -7383,7 +7392,7 @@
             }
           },
           {
-            "id": 336,
+            "id": 5218,
             "name": "committer",
             "kind": 1024,
             "kindString": "Property",
@@ -7402,7 +7411,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 196,
+              "id": 5078,
               "name": "AttributeCommitter",
               "location": {
                 "page": "custom-directives",
@@ -7411,7 +7420,7 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "id": 217,
+              "id": 5099,
               "name": "AttributePart.committer",
               "location": {
                 "page": "custom-directives",
@@ -7433,7 +7442,7 @@
             }
           },
           {
-            "id": 337,
+            "id": 5219,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -7455,7 +7464,7 @@
             "defaultValue": "...",
             "inheritedFrom": {
               "type": "reference",
-              "id": 218,
+              "id": 5100,
               "name": "AttributePart.value",
               "location": {
                 "page": "custom-directives",
@@ -7477,7 +7486,7 @@
             }
           },
           {
-            "id": 341,
+            "id": 5223,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -7498,7 +7507,7 @@
             ],
             "signatures": [
               {
-                "id": 342,
+                "id": 5224,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -7513,14 +7522,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 223,
+                  "id": 5105,
                   "name": "AttributePart.commit"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 222,
+              "id": 5104,
               "name": "AttributePart.commit",
               "location": {
                 "page": "custom-directives",
@@ -7542,7 +7551,7 @@
             }
           },
           {
-            "id": 338,
+            "id": 5220,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -7562,7 +7571,7 @@
             ],
             "signatures": [
               {
-                "id": 339,
+                "id": 5221,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -7572,7 +7581,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 340,
+                    "id": 5222,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -7589,14 +7598,14 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "id": 220,
+                  "id": 5102,
                   "name": "AttributePart.setValue"
                 }
               }
             ],
             "inheritedFrom": {
               "type": "reference",
-              "id": 219,
+              "id": 5101,
               "name": "AttributePart.setValue",
               "location": {
                 "page": "custom-directives",
@@ -7623,23 +7632,23 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              333
+              5215
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              336,
-              337
+              5218,
+              5219
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              341,
-              338
+              5223,
+              5220
             ]
           }
         ],
@@ -7655,7 +7664,7 @@
         "extendedTypes": [
           {
             "type": "reference",
-            "id": 213,
+            "id": 5095,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -7679,7 +7688,7 @@
         "heritage": [
           {
             "type": "reference",
-            "id": 213,
+            "id": 5095,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -7689,7 +7698,7 @@
         ]
       },
       {
-        "id": 174,
+        "id": 5056,
         "name": "removeNodes",
         "kind": 64,
         "kindString": "Function",
@@ -7711,7 +7720,7 @@
         ],
         "signatures": [
           {
-            "id": 175,
+            "id": 5057,
             "name": "removeNodes",
             "kind": 4096,
             "kindString": "Call signature",
@@ -7721,7 +7730,7 @@
             },
             "parameters": [
               {
-                "id": 176,
+                "id": 5058,
                 "name": "container",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7732,7 +7741,7 @@
                 }
               },
               {
-                "id": 177,
+                "id": 5059,
                 "name": "start",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7752,7 +7761,7 @@
                 }
               },
               {
-                "id": 178,
+                "id": 5060,
                 "name": "end",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7794,7 +7803,7 @@
         }
       },
       {
-        "id": 179,
+        "id": 5061,
         "name": "reparentNodes",
         "kind": 64,
         "kindString": "Function",
@@ -7816,7 +7825,7 @@
         ],
         "signatures": [
           {
-            "id": 180,
+            "id": 5062,
             "name": "reparentNodes",
             "kind": 4096,
             "kindString": "Call signature",
@@ -7826,7 +7835,7 @@
             },
             "parameters": [
               {
-                "id": 181,
+                "id": 5063,
                 "name": "container",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7837,7 +7846,7 @@
                 }
               },
               {
-                "id": 182,
+                "id": 5064,
                 "name": "start",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7857,7 +7866,7 @@
                 }
               },
               {
-                "id": 183,
+                "id": 5065,
                 "name": "end",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7878,7 +7887,7 @@
                 "defaultValue": "null"
               },
               {
-                "id": 184,
+                "id": 5066,
                 "name": "before",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -7920,7 +7929,7 @@
         }
       },
       {
-        "id": 416,
+        "id": 5298,
         "name": "Template",
         "kind": 128,
         "kindString": "Class",
@@ -7930,7 +7939,7 @@
         },
         "children": [
           {
-            "id": 417,
+            "id": 5299,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -7947,21 +7956,21 @@
             ],
             "signatures": [
               {
-                "id": 418,
+                "id": 5300,
                 "name": "new Template",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 419,
+                    "id": 5301,
                     "name": "result",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 396,
+                      "id": 5278,
                       "name": "TemplateResult",
                       "location": {
                         "page": "templates",
@@ -7970,7 +7979,7 @@
                     }
                   },
                   {
-                    "id": 420,
+                    "id": 5302,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -7986,7 +7995,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 416,
+                  "id": 5298,
                   "name": "Template",
                   "location": {
                     "page": "custom-directives",
@@ -8010,7 +8019,7 @@
             }
           },
           {
-            "id": 422,
+            "id": 5304,
             "name": "element",
             "kind": 1024,
             "kindString": "Property",
@@ -8049,7 +8058,7 @@
             }
           },
           {
-            "id": 421,
+            "id": 5303,
             "name": "parts",
             "kind": 1024,
             "kindString": "Property",
@@ -8094,15 +8103,15 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              417
+              5299
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              422,
-              421
+              5304,
+              5303
             ]
           }
         ],
@@ -8130,7 +8139,7 @@
         }
       },
       {
-        "id": 352,
+        "id": 5234,
         "name": "templateCaches",
         "kind": 32,
         "kindString": "Variable",
@@ -8177,7 +8186,7 @@
         }
       },
       {
-        "id": 353,
+        "id": 5235,
         "name": "templateFactory",
         "kind": 64,
         "kindString": "Function",
@@ -8197,7 +8206,7 @@
         ],
         "signatures": [
           {
-            "id": 354,
+            "id": 5236,
             "name": "templateFactory",
             "kind": 4096,
             "kindString": "Call signature",
@@ -8207,14 +8216,14 @@
             },
             "parameters": [
               {
-                "id": 355,
+                "id": 5237,
                 "name": "result",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 396,
+                  "id": 5278,
                   "name": "TemplateResult",
                   "location": {
                     "page": "templates",
@@ -8225,7 +8234,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 416,
+              "id": 5298,
               "name": "Template",
               "location": {
                 "page": "custom-directives",
@@ -8249,7 +8258,7 @@
         }
       },
       {
-        "id": 356,
+        "id": 5238,
         "name": "TemplateInstance",
         "kind": 128,
         "kindString": "Class",
@@ -8259,7 +8268,7 @@
         },
         "children": [
           {
-            "id": 357,
+            "id": 5239,
             "name": "constructor",
             "kind": 512,
             "kindString": "Constructor",
@@ -8276,21 +8285,21 @@
             ],
             "signatures": [
               {
-                "id": 358,
+                "id": 5240,
                 "name": "new TemplateInstance",
                 "kind": 16384,
                 "kindString": "Constructor signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 359,
+                    "id": 5241,
                     "name": "template",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 416,
+                      "id": 5298,
                       "name": "Template",
                       "location": {
                         "page": "custom-directives",
@@ -8299,14 +8308,14 @@
                     }
                   },
                   {
-                    "id": 360,
+                    "id": 5242,
                     "name": "processor",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 371,
+                      "id": 5253,
                       "name": "TemplateProcessor",
                       "location": {
                         "page": "custom-directives",
@@ -8315,14 +8324,14 @@
                     }
                   },
                   {
-                    "id": 361,
+                    "id": 5243,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -8333,7 +8342,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 356,
+                  "id": 5238,
                   "name": "TemplateInstance",
                   "location": {
                     "page": "custom-directives",
@@ -8357,7 +8366,7 @@
             }
           },
           {
-            "id": 364,
+            "id": 5246,
             "name": "options",
             "kind": 1024,
             "kindString": "Property",
@@ -8376,7 +8385,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 343,
+              "id": 5225,
               "name": "RenderOptions",
               "location": {
                 "page": "templates",
@@ -8398,7 +8407,7 @@
             }
           },
           {
-            "id": 363,
+            "id": 5245,
             "name": "processor",
             "kind": 1024,
             "kindString": "Property",
@@ -8417,7 +8426,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 371,
+              "id": 5253,
               "name": "TemplateProcessor",
               "location": {
                 "page": "custom-directives",
@@ -8439,7 +8448,7 @@
             }
           },
           {
-            "id": 365,
+            "id": 5247,
             "name": "template",
             "kind": 1024,
             "kindString": "Property",
@@ -8458,7 +8467,7 @@
             ],
             "type": {
               "type": "reference",
-              "id": 416,
+              "id": 5298,
               "name": "Template",
               "location": {
                 "page": "custom-directives",
@@ -8480,7 +8489,7 @@
             }
           },
           {
-            "id": 366,
+            "id": 5248,
             "name": "update",
             "kind": 2048,
             "kindString": "Method",
@@ -8497,14 +8506,14 @@
             ],
             "signatures": [
               {
-                "id": 367,
+                "id": 5249,
                 "name": "update",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 368,
+                    "id": 5250,
                     "name": "values",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8548,25 +8557,25 @@
             "title": "Constructors",
             "kind": 512,
             "children": [
-              357
+              5239
             ]
           },
           {
             "title": "Properties",
             "kind": 1024,
             "children": [
-              362,
-              364,
-              363,
-              365
+              5244,
+              5246,
+              5245,
+              5247
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              369,
-              366
+              5251,
+              5248
             ]
           }
         ],
@@ -8594,7 +8603,7 @@
         }
       },
       {
-        "id": 167,
+        "id": 5049,
         "name": "DirectiveFn",
         "kind": 4194304,
         "kindString": "Type alias",
@@ -8612,7 +8621,7 @@
         "type": {
           "type": "reflection",
           "declaration": {
-            "id": 168,
+            "id": 5050,
             "name": "__type",
             "kind": 65536,
             "kindString": "Type literal",
@@ -8626,21 +8635,21 @@
             ],
             "signatures": [
               {
-                "id": 169,
+                "id": 5051,
                 "name": "__type",
                 "kind": 4096,
                 "kindString": "Call signature",
                 "flags": {},
                 "parameters": [
                   {
-                    "id": 170,
+                    "id": 5052,
                     "name": "part",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 189,
+                      "id": 5071,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -8672,7 +8681,7 @@
         }
       },
       {
-        "id": 189,
+        "id": 5071,
         "name": "Part",
         "kind": 256,
         "kindString": "Interface",
@@ -8682,7 +8691,7 @@
         },
         "children": [
           {
-            "id": 190,
+            "id": 5072,
             "name": "value",
             "kind": 1024,
             "kindString": "Property",
@@ -8718,7 +8727,7 @@
             }
           },
           {
-            "id": 194,
+            "id": 5076,
             "name": "commit",
             "kind": 2048,
             "kindString": "Method",
@@ -8730,7 +8739,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 195,
+                "id": 5077,
                 "name": "commit",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8760,7 +8769,7 @@
             }
           },
           {
-            "id": 191,
+            "id": 5073,
             "name": "setValue",
             "kind": 2048,
             "kindString": "Method",
@@ -8771,7 +8780,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 192,
+                "id": 5074,
                 "name": "setValue",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8781,7 +8790,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 193,
+                    "id": 5075,
                     "name": "value",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8821,15 +8830,15 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              190
+              5072
             ]
           },
           {
             "title": "Methods",
             "kind": 2048,
             "children": [
-              194,
-              191
+              5076,
+              5073
             ]
           }
         ],
@@ -8845,7 +8854,7 @@
         "implementedBy": [
           {
             "type": "reference",
-            "id": 213,
+            "id": 5095,
             "name": "AttributePart",
             "location": {
               "page": "custom-directives",
@@ -8854,7 +8863,7 @@
           },
           {
             "type": "reference",
-            "id": 224,
+            "id": 5106,
             "name": "BooleanAttributePart",
             "location": {
               "page": "custom-directives",
@@ -8863,7 +8872,7 @@
           },
           {
             "type": "reference",
-            "id": 240,
+            "id": 5122,
             "name": "EventPart",
             "location": {
               "page": "custom-directives",
@@ -8872,7 +8881,7 @@
           },
           {
             "type": "reference",
-            "id": 270,
+            "id": 5152,
             "name": "NodePart",
             "location": {
               "page": "custom-directives",
@@ -8895,14 +8904,14 @@
         }
       },
       {
-        "id": 371,
+        "id": 5253,
         "name": "TemplateProcessor",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 372,
+            "id": 5254,
             "name": "handleAttributeExpressions",
             "kind": 2048,
             "kindString": "Method",
@@ -8913,7 +8922,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 373,
+                "id": 5255,
                 "name": "handleAttributeExpressions",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -8923,7 +8932,7 @@
                 },
                 "parameters": [
                   {
-                    "id": 374,
+                    "id": 5256,
                     "name": "element",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8940,7 +8949,7 @@
                     }
                   },
                   {
-                    "id": 375,
+                    "id": 5257,
                     "name": "name",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8954,7 +8963,7 @@
                     }
                   },
                   {
-                    "id": 376,
+                    "id": 5258,
                     "name": "strings",
                     "kind": 32768,
                     "kindString": "Parameter",
@@ -8975,14 +8984,14 @@
                     }
                   },
                   {
-                    "id": 377,
+                    "id": 5259,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -8998,7 +9007,7 @@
                     "type": "array",
                     "elementType": {
                       "type": "reference",
-                      "id": 189,
+                      "id": 5071,
                       "name": "Part",
                       "location": {
                         "page": "custom-directives",
@@ -9024,7 +9033,7 @@
             }
           },
           {
-            "id": 378,
+            "id": 5260,
             "name": "handleTextExpression",
             "kind": 2048,
             "kindString": "Method",
@@ -9035,7 +9044,7 @@
             "children": [],
             "signatures": [
               {
-                "id": 379,
+                "id": 5261,
                 "name": "handleTextExpression",
                 "kind": 4096,
                 "kindString": "Call signature",
@@ -9045,14 +9054,14 @@
                 },
                 "parameters": [
                   {
-                    "id": 380,
+                    "id": 5262,
                     "name": "options",
                     "kind": 32768,
                     "kindString": "Parameter",
                     "flags": {},
                     "type": {
                       "type": "reference",
-                      "id": 343,
+                      "id": 5225,
                       "name": "RenderOptions",
                       "location": {
                         "page": "templates",
@@ -9063,7 +9072,7 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "id": 270,
+                  "id": 5152,
                   "name": "NodePart",
                   "location": {
                     "page": "custom-directives",
@@ -9092,8 +9101,8 @@
             "title": "Methods",
             "kind": 2048,
             "children": [
-              372,
-              378
+              5254,
+              5260
             ]
           }
         ],
@@ -9109,7 +9118,7 @@
         "implementedBy": [
           {
             "type": "reference",
-            "id": 150,
+            "id": 5032,
             "name": "DefaultTemplateProcessor",
             "location": {
               "page": "custom-directives",
@@ -9136,9 +9145,12 @@
   {
     "slug": "shady",
     "title": "ShadyCSS/DOM",
+    "versionLinks": {
+      "v2": "api/templates/"
+    },
     "items": [
       {
-        "id": 21,
+        "id": 4903,
         "name": "render",
         "kind": 64,
         "kindString": "Function",
@@ -9161,7 +9173,7 @@
         ],
         "signatures": [
           {
-            "id": 22,
+            "id": 4904,
             "name": "render",
             "kind": 4096,
             "kindString": "Call signature",
@@ -9172,7 +9184,7 @@
             },
             "parameters": [
               {
-                "id": 23,
+                "id": 4905,
                 "name": "result",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -9183,7 +9195,7 @@
                 }
               },
               {
-                "id": 24,
+                "id": 4906,
                 "name": "container",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -9216,14 +9228,14 @@
                 }
               },
               {
-                "id": 25,
+                "id": 4907,
                 "name": "options",
                 "kind": 32768,
                 "kindString": "Parameter",
                 "flags": {},
                 "type": {
                   "type": "reference",
-                  "id": 17,
+                  "id": 4899,
                   "name": "ShadyRenderOptions",
                   "location": {
                     "page": "shady",
@@ -9253,7 +9265,7 @@
         }
       },
       {
-        "id": 11,
+        "id": 4893,
         "name": "shadyTemplateFactory",
         "kind": 64,
         "kindString": "Function",
@@ -9275,7 +9287,7 @@
         ],
         "signatures": [
           {
-            "id": 12,
+            "id": 4894,
             "name": "shadyTemplateFactory",
             "kind": 4096,
             "kindString": "Call signature",
@@ -9285,7 +9297,7 @@
             },
             "parameters": [
               {
-                "id": 13,
+                "id": 4895,
                 "name": "scopeName",
                 "kind": 32768,
                 "kindString": "Parameter",
@@ -9302,28 +9314,28 @@
             "type": {
               "type": "reflection",
               "declaration": {
-                "id": 14,
+                "id": 4896,
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
                 "flags": {},
                 "signatures": [
                   {
-                    "id": 15,
+                    "id": 4897,
                     "name": "__type",
                     "kind": 4096,
                     "kindString": "Call signature",
                     "flags": {},
                     "parameters": [
                       {
-                        "id": 16,
+                        "id": 4898,
                         "name": "result",
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {},
                         "type": {
                           "type": "reference",
-                          "id": 396,
+                          "id": 5278,
                           "name": "TemplateResult",
                           "location": {
                             "page": "templates",
@@ -9334,7 +9346,7 @@
                     ],
                     "type": {
                       "type": "reference",
-                      "id": 416,
+                      "id": 5298,
                       "name": "Template",
                       "location": {
                         "page": "custom-directives",
@@ -9362,14 +9374,14 @@
         }
       },
       {
-        "id": 17,
+        "id": 4899,
         "name": "ShadyRenderOptions",
         "kind": 256,
         "kindString": "Interface",
         "flags": {},
         "children": [
           {
-            "id": 20,
+            "id": 4902,
             "name": "eventContext",
             "kind": 1024,
             "kindString": "Property",
@@ -9410,7 +9422,7 @@
             }
           },
           {
-            "id": 18,
+            "id": 4900,
             "name": "scopeName",
             "kind": 1024,
             "kindString": "Property",
@@ -9444,7 +9456,7 @@
             }
           },
           {
-            "id": 19,
+            "id": 4901,
             "name": "templateFactory",
             "kind": 1024,
             "kindString": "Property",
@@ -9490,9 +9502,9 @@
             "title": "Properties",
             "kind": 1024,
             "children": [
-              20,
-              18,
-              19
+              4902,
+              4900,
+              4901
             ]
           }
         ],
@@ -9511,7 +9523,7 @@
             "typeArguments": [
               {
                 "type": "reference",
-                "id": 343,
+                "id": 5225,
                 "name": "RenderOptions",
                 "location": {
                   "page": "templates",
@@ -9541,7 +9553,7 @@
             "typeArguments": [
               {
                 "type": "reference",
-                "id": 343,
+                "id": 5225,
                 "name": "RenderOptions",
                 "location": {
                   "page": "templates",

--- a/packages/lit-dev-api/api-data/lit-html-1/symbols.json
+++ b/packages/lit-dev-api/api-data/lit-html-1/symbols.json
@@ -161,7 +161,7 @@
   ],
   "$render": [
     {
-      "page": "templates",
+      "page": "shady",
       "anchor": "render"
     },
     {

--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -65,8 +65,8 @@
     {% if showOldDocsBanner %}
       <litdev-banner>
         You're viewing docs for an older version of Lit. Click
-        <a href="{{ versions[latestVersion].path }}">here</a>
-        for the latest version.
+        <a href="{{ versions[latestVersion].path }}/{{ versionLinks[latestVersion] }}">
+        here</a> for the latest version.
       </litdev-banner>
     {% endif %}
 

--- a/packages/lit-dev-content/site/_includes/docs.html
+++ b/packages/lit-dev-content/site/_includes/docs.html
@@ -1,5 +1,13 @@
 {% extends 'default.html' %}
 
+<!-- When we're rendering API docs, our "versionLinks" data doesn't come from
+     markdown frontmatter, instead it comes from the API JSON data.
+     TODO(aomarks) There must be some way to assign "versionLinks" to
+     "data.otherVersions" from api.html, but I haven't figure out how! -->
+{% if not versionLinks %}
+  {% set versionLinks = data.versionLinks %}
+{% endif %}
+
 {% block head %}
   {% inlinecss "docs.css" %}
   {% inlinejs "pages/docs.js" %}

--- a/packages/lit-dev-content/site/_includes/site-nav.html
+++ b/packages/lit-dev-content/site/_includes/site-nav.html
@@ -4,11 +4,11 @@
    <litdev-version-selector>
       <select name="version">
         {% for version, versionData in versions %}
-          <option value="{{ key }}"
+          <option value="{{ version }}"
             {% if version == selectedVersion %}
               selected
             {% else %}
-              data-path="{{ versionData.path }}/"
+              data-path="{{ versionData.path }}/{{ versionLinks[version] }}"
             {% endif %}>
             {{ versionData.label }}
           </option>

--- a/packages/lit-dev-content/site/docs/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/components/decorators.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Decorators
   parent: Components
   order: 8
+versionLinks:
+  v1: components/decorators/
 ---
 
 Decorators are special functions that can modify the behavior of classes, class methods, and class fields. Lit uses decorators to provide declarative APIs for things like registering elements, reactive properties, and queries.

--- a/packages/lit-dev-content/site/docs/components/defining.md
+++ b/packages/lit-dev-content/site/docs/components/defining.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Defining
   parent: Components
   order: 1
+versionLinks:
+  v1: components/templates/
 ---
 
 Define a Lit component by creating a class extending `LitElement` and registering your class with the browser:

--- a/packages/lit-dev-content/site/docs/components/events.md
+++ b/packages/lit-dev-content/site/docs/components/events.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Events
   parent: Components
   order: 7
+versionLinks:
+  v1: components/events/
 ---
 
 Events are the standard way that elements communicate changes. These changes typically occur due to user interaction. For example, a button dispatches a click event when a user clicks on it; an input dispatches a change event when the user enters a value in it.

--- a/packages/lit-dev-content/site/docs/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/components/lifecycle.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Lifecycle
   parent: Components
   order: 5
+versionLinks:
+  v1: components/lifecycle/
 ---
 
 Lit components use the standard custom element lifecycle methods. In addition Lit introduces a reactive update cycle that renders changes to DOM when reactive properties change.

--- a/packages/lit-dev-content/site/docs/components/overview.md
+++ b/packages/lit-dev-content/site/docs/components/overview.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Overview
   parent: Components
   order: 0
+versionLinks:
+  v1: components/templates/
 ---
 
 A Lit component is a reusable piece of UI. You can think of a Lit component as a container that has some state and that displays a UI based on its state. It can also react to user input, fire events—anything you'd expect a UI component to do. And a Lit component is an HTML element, so it has all of the standard element APIs.

--- a/packages/lit-dev-content/site/docs/components/properties.md
+++ b/packages/lit-dev-content/site/docs/components/properties.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Reactive properties
   parent: Components
   order: 3
+versionLinks:
+  v1: components/properties/
 ---
 
 Lit components receive input and store their state as JavaScript class fields or properties. *Reactive properties* are properties that can trigger the reactive update cycle when changed, re-rendering the component, and optionally be read or written to attributes.

--- a/packages/lit-dev-content/site/docs/components/rendering.md
+++ b/packages/lit-dev-content/site/docs/components/rendering.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Rendering
   parent: Components
   order: 2
+versionLinks:
+  v1: components/templates/
 ---
 
 Add a template to your component to define what it should render. Templates can include _expressions_, which are placeholders for dynamic content.

--- a/packages/lit-dev-content/site/docs/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/components/shadow-dom.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Shadow DOM
   parent: Components
   order: 6
+versionLinks:
+  v1: components/templates/#accessing-nodes-in-the-shadow-dom
 ---
 
 Lit components use [shadow DOM](https://developers.google.com/web/fundamentals/web-components/shadowdom) to encapsulate their DOM. Shadow DOM provides a way to add a separate isolated and encapsulated DOM tree to an element. DOM encapsulation is the key to unlocking interoperability with any other code—including other web components or Lit components—functioning on the page.

--- a/packages/lit-dev-content/site/docs/components/styles.md
+++ b/packages/lit-dev-content/site/docs/components/styles.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Styles
   parent: Components
   order: 4
+versionLinks:
+  v1: components/styles/
 ---
 
 Your component's template is rendered to its shadow root. The styles you add to your component are automatically _scoped_ to the shadow root and only affect elements in the component's shadow root.

--- a/packages/lit-dev-content/site/docs/getting-started.md
+++ b/packages/lit-dev-content/site/docs/getting-started.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Getting Started
   parent: Introduction
   order: 3
+versionLinks:
+  v1: getting-started/
 ---
 
 There are many ways to get started using Lit, from our Playground and interactive tutorial to installing into an existing project.

--- a/packages/lit-dev-content/site/docs/index.md
+++ b/packages/lit-dev-content/site/docs/index.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: What is Lit?
   parent: Introduction
   order: 1
+versionLinks:
+  v1:
 ---
 
 ![Lit Logo]({{ site.baseurl }}/images/logo.svg){.logo width="425" height="200"}

--- a/packages/lit-dev-content/site/docs/libraries/index.md
+++ b/packages/lit-dev-content/site/docs/libraries/index.md
@@ -3,6 +3,8 @@ title: Related libraries
 eleventyNavigation:
   key: Related libraries
   order: 9
+versionLinks:
+  v1: lit-html/introduction/
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/resources/community.md
+++ b/packages/lit-dev-content/site/docs/resources/community.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Community
   parent: Resources
   order: 1
+versionLinks:
+  v1: resources/community/
 ---
 
 There are many great resources and locations to learn about Lit,

--- a/packages/lit-dev-content/site/docs/templates/conditionals.md
+++ b/packages/lit-dev-content/site/docs/templates/conditionals.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Conditionals
   parent: Templates
   order: 3
+versionLinks:
+  v1: components/templates/#use-properties-loops-and-conditionals-in-a-template
 ---
 
 Since Lit leverages normal Javascript expressions, you can use standard Javascript control flow constructs like [conditional operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator), function calls, and `if` or `switch` statements to render conditional content.

--- a/packages/lit-dev-content/site/docs/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/templates/custom-directives.md
@@ -5,6 +5,8 @@ eleventyNavigation:
   title: Custom directives
   key: Custom directives
   order: 6
+versionLinks:
+  v1: lit-html/creating-directives/
 ---
 
 Directives are objects that customize how Lit renders expressions. Using a directive in your template is like calling a function:

--- a/packages/lit-dev-content/site/docs/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/templates/directives.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Built-in directives
   parent: Templates
   order: 5
+versionLinks:
+  v1: lit-html/template-reference/#built-in-directives
 ---
 
 Directives are functions that can extend Lit by customizing the way an expression renders.

--- a/packages/lit-dev-content/site/docs/templates/expressions.md
+++ b/packages/lit-dev-content/site/docs/templates/expressions.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Expressions
   parent: Templates
   order: 2
+versionLinks:
+  v1: components/templates/#bind-properties-to-templated-elements
 ---
 
 Lit templates can include dynamic values called expressions. An expression can be any JavaScript expression. The expression is evaluated when the template is evaluated, and the result of the expression is included when the template renders. In a Lit component, this means whenever the `render` method is called.

--- a/packages/lit-dev-content/site/docs/templates/lists.md
+++ b/packages/lit-dev-content/site/docs/templates/lists.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Lists
   parent: Templates
   order: 4
+versionLinks:
+  v1: components/templates/#use-properties-loops-and-conditionals-in-a-template
 ---
 
 You can use standard JavaScript constructs to create repeating templates.

--- a/packages/lit-dev-content/site/docs/templates/overview.md
+++ b/packages/lit-dev-content/site/docs/templates/overview.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Overview
   parent: Templates
   order: 1
+versionLinks:
+  v1: components/templates/
 ---
 
 {% todo %}

--- a/packages/lit-dev-content/site/docs/tools/adding-lit.md
+++ b/packages/lit-dev-content/site/docs/tools/adding-lit.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Adding Lit
   parent: Tools
   order: 8
+versionLinks:
+  v1: tools/use/
 ---
 
 Lit doesn't require any specialized tools, and Lit components work in any JavaScript framework or with any server templating system or CMS, so Lit is ideal for adding to existing projects and applications.

--- a/packages/lit-dev-content/site/docs/tools/development.md
+++ b/packages/lit-dev-content/site/docs/tools/development.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Development
   parent: Tools
   order: 3
+versionLinks:
+  v1: lit-html/tools/#development
 ---
 
 During the development phase of your projects, when you're writing Lit components, the following tools can help boost your productivity:

--- a/packages/lit-dev-content/site/docs/tools/overview.md
+++ b/packages/lit-dev-content/site/docs/tools/overview.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Overview
   parent: Tools
   order: 1
+versionLinks:
+  v1: lit-html/tools/
 ---
 
 Lit components are written using plain JavaScript or TypeScript and run out-of-the box on modern browsers with minimal tooling, so you don't _need_ any Lit-specific compilers, tools, or workflows.

--- a/packages/lit-dev-content/site/docs/tools/production.md
+++ b/packages/lit-dev-content/site/docs/tools/production.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Production
   parent: Tools
   order: 6
+versionLinks:
+  v1: tools/build/
 ---
 
 This page focuses on recommendations for building an _application_ that uses Lit components for production.  For recommendations on build steps to perform on source code prior to publishing a reusable Lit _component_ to npm, see [Publishing](/docs/tools/publishing/).

--- a/packages/lit-dev-content/site/docs/tools/publishing.md
+++ b/packages/lit-dev-content/site/docs/tools/publishing.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Publishing
   parent: Tools
   order: 5
+versionLinks:
+  v1: tools/publish/
 ---
 
 This page provides guidelines for publishing a Lit component to [npm](https://www.npmjs.com/), the package manager used by the vast majority of Javascript libraries and developers. See [Starter Kits](/docs/tools/starter-kits/) for reusable component templates set up for publishing to npm.

--- a/packages/lit-dev-content/site/docs/tools/requirements.md
+++ b/packages/lit-dev-content/site/docs/tools/requirements.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Requirements
   parent: Tools
   order: 2
+versionLinks:
+  v1: tools/build/#build-requirements
 ---
 
 The most important things to know about Lit in order to work with various browsers and tools are that:

--- a/packages/lit-dev-content/site/docs/tools/starter-kits.md
+++ b/packages/lit-dev-content/site/docs/tools/starter-kits.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Starter kits
   parent: Tools
   order: 7
+versionLinks:
+  v1: getting-started/#component-project
 ---
 
 The Lit Starter Kits are project templates for reusable Lit components that can be published for others to use.

--- a/packages/lit-dev-content/site/docs/tools/testing.md
+++ b/packages/lit-dev-content/site/docs/tools/testing.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Testing
   parent: Tools
   order: 4
+versionLinks:
+  v1: lit-html/tools/#testing
 ---
 
 Testing ensures your code functions as you intend and saves you from tedious debugging.

--- a/packages/lit-dev-content/site/docs/v1/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v1/components/decorators.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Decorators
   parent: Components
   order: 6
+versionLinks:
+  v2: components/decorators/
 ---
 
 Decorators are special expressions that can alter the behavior of class, class method, and class field declarations. LitElement supplies a set of decorators that reduce the amount of boilerplate code you need to write when defining a component.

--- a/packages/lit-dev-content/site/docs/v1/components/events.md
+++ b/packages/lit-dev-content/site/docs/v1/components/events.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Events
   parent: Components
   order: 4
+versionLinks:
+  v2: components/events/
 ---
 
 ## Where to add your event listeners

--- a/packages/lit-dev-content/site/docs/v1/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/v1/components/lifecycle.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Lifecycle
   parent: Components
   order: 5
+versionLinks:
+  v2: components/lifecycle/
 ---
 
 ## Overview

--- a/packages/lit-dev-content/site/docs/v1/components/properties.md
+++ b/packages/lit-dev-content/site/docs/v1/components/properties.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Properties
   parent: Components
   order: 3
+versionLinks:
+  v2: components/properties/
 ---
 
 ## Overview {#overview}

--- a/packages/lit-dev-content/site/docs/v1/components/styles.md
+++ b/packages/lit-dev-content/site/docs/v1/components/styles.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Styles
   parent: Components
   order: 2
+versionLinks:
+  v2: components/styles/
 ---
 
 This page describes how to add styles to your component.

--- a/packages/lit-dev-content/site/docs/v1/components/templates.md
+++ b/packages/lit-dev-content/site/docs/v1/components/templates.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Templates
   parent: Components
   order: 1
+versionLinks:
+  v2: components/rendering/
 ---
 
 Add a template to your component to define internal DOM to implement your component.

--- a/packages/lit-dev-content/site/docs/v1/components/templates.md
+++ b/packages/lit-dev-content/site/docs/v1/components/templates.md
@@ -162,6 +162,7 @@ html`<ul>
 **repeat directive**. In most cases, `Array.map` is the most efficient way to create a repeating template. In some cases, you may want to consider lit-html's `repeat` directive. In particular, if the repeated elements are stateful, or very expensive to regenerate. For more information, see [Repeating templates with the repeat directive](/docs/v1/lit-html/writing-templates/#repeating-templates) in the lit-html docs.
 
 </div>
+
 #### Conditionals
 
 Render based on a Boolean condition:

--- a/packages/lit-dev-content/site/docs/v1/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v1/getting-started.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Getting started
   parent: Introduction
   order: 2
+versionLinks:
+  v2: getting-started/
 ---
 
 There are two main ways to use LitElement:

--- a/packages/lit-dev-content/site/docs/v1/index.md
+++ b/packages/lit-dev-content/site/docs/v1/index.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: What is LitElement?
   parent: Introduction
   order: 1
+versionLinks:
+  v2:
 ---
 
 LitElement is a simple base class for creating fast, lightweight web components that work in any web page with any framework.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/concepts.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/concepts.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Concepts
   parent: lit-html
   order: 8
+versionLinks:
+  v2: templates/overview/
 ---
 
 lit-html utilizes some unique properties of JavaScript template literals and HTML `<template>` elements to function and achieve fast performance. So it's helpful to understand them first.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/creating-directives.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/creating-directives.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Creating directives
   parent: lit-html
   order: 6
+versionLinks:
+  v2: templates/custom-directives/
 ---
 
 Directives are functions that can customize how lit-html renders values. Template authors can use directives in their templates like other functions:

--- a/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Getting started
   parent: lit-html
   order: 2
+versionLinks:
+  v2: getting-started/
 ---
 
 ## Installation

--- a/packages/lit-dev-content/site/docs/v1/lit-html/introduction.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/introduction.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Introduction
   parent: lit-html
   order: 1
+versionLinks:
+  v2: libraries/standalone-templates/
 ---
 
 ## What is lit-html?

--- a/packages/lit-dev-content/site/docs/v1/lit-html/release-notes.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/release-notes.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Release notes
   parent: lit-html
   order: 10
+versionLinks:
+  v2: releases/upgrade/
 ---
 
 ## lit-html 1.3.0

--- a/packages/lit-dev-content/site/docs/v1/lit-html/rendering-templates.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/rendering-templates.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Rendering templates
   parent: lit-html
   order: 5
+versionLinks:
+  v2: components/rendering/
 ---
 
 A lit-html template expression does not cause any DOM to be created or updated. It's only a description of DOM, called a `TemplateResult`. To actually create or update DOM, you need to pass the `TemplateResult` to the `render()` function, along with a container to render to:

--- a/packages/lit-dev-content/site/docs/v1/lit-html/styling-templates.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/styling-templates.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Styling templates
   parent: lit-html
   order: 4
+versionLinks:
+  v2: components/styles/
 ---
 
 lit-html focuses on one thing: rendering HTML. How you apply styles to the HTML lit-html creates depends on how you're using it—for example, if you're using lit-html inside a component system like LitElement, you can follow the patterns used by that component system.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/template-reference.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/template-reference.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Template syntax reference
   parent: lit-html
   order: 7
+versionLinks:
+  v2: templates/overview/
 ---
 
 lit-html templates are written using JavaScript template literals tagged with the `html` tag. The contents of the literal are mostly plain, declarative, HTML:

--- a/packages/lit-dev-content/site/docs/v1/lit-html/tools.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/tools.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Tools
   parent: lit-html
   order: 9
+versionLinks:
+  v2: tools/overview/
 ---
 
 lit-html is available from the npm registry. If you're already using npm to manage dependencies, you can use lit-html much like any other JavaScript library you install from npm. This section describes some additional tools or plugins you might want to add to your workflow to make it easier to work with lit-html.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/writing-templates.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/writing-templates.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Writing templates
   parent: lit-html
   order: 3
+versionLinks:
+  v2: templates/overview/
 ---
 
 lit-html is a templating library that provides fast, efficient rendering and updating of HTML. It lets you express web UI as a function of data.

--- a/packages/lit-dev-content/site/docs/v1/resources/community.md
+++ b/packages/lit-dev-content/site/docs/v1/resources/community.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Community
   parent: Resources
   order: 1
+versionLinks:
+  v2: resources/community/
 ---
 
 There are many great resources and locations to learn about LitElement and web components,

--- a/packages/lit-dev-content/site/docs/v1/tools/build.md
+++ b/packages/lit-dev-content/site/docs/v1/tools/build.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Build for production
   parent: Tools
   order: 3
+versionLinks:
+  v2: tools/production/
 ---
 
 When building an app that includes LitElement components, you can use common JavaScript build tools like <a href="https://rollupjs.org/" target="_blank" rel="noopener">Rollup</a> or <a href="https://webpack.js.org/" target="_blank" rel="noopener">webpack</a>.

--- a/packages/lit-dev-content/site/docs/v1/tools/publish.md
+++ b/packages/lit-dev-content/site/docs/v1/tools/publish.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Publish a component
   parent: Tools
   order: 1
+versionLinks:
+  v2: tools/publishing/
 ---
 
 This page describes how to publish a LitElement component to npm.

--- a/packages/lit-dev-content/site/docs/v1/tools/use.md
+++ b/packages/lit-dev-content/site/docs/v1/tools/use.md
@@ -4,6 +4,8 @@ eleventyNavigation:
   key: Use a component
   parent: Tools
   order: 2
+versionLinks:
+  v2: tools/overview/
 ---
 
 This page describes how to [use a LitElement component in your application](#use). It also describes how to make sure your deployed code is browser-ready by [building it for production](#build) and [loading the Web Components polyfills](#polyfills).

--- a/packages/lit-dev-content/site/site.json
+++ b/packages/lit-dev-content/site/site.json
@@ -3,11 +3,11 @@
   "latestVersion": "v2",
   "versions": {
     "v1": {
-      "path": "/docs/v1/",
+      "path": "/docs/v1",
       "label": "v1"
     },
     "v2": {
-      "path": "/docs/",
+      "path": "/docs",
       "label": "v2"
     }
   }

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
@@ -65,43 +65,73 @@ export const lit2Config: ApiDocsConfig = {
     {
       slug: 'LitElement',
       title: 'LitElement',
+      versionLinks: {
+        v1: 'api/lit-element/LitElement/',
+      },
     },
     {
       slug: 'ReactiveElement',
       title: 'ReactiveElement',
+      versionLinks: {
+        v1: 'api/lit-element/UpdatingElement/',
+      },
     },
     {
       slug: 'templates',
       title: 'Templates',
+      versionLinks: {
+        v1: 'api/lit-html/templates/',
+      },
     },
     {
       slug: 'styles',
       title: 'Styles',
+      versionLinks: {
+        v1: 'api/lit-element/styles/',
+      },
     },
     {
       slug: 'decorators',
       title: 'Decorators',
+      versionLinks: {
+        v1: 'api/lit-element/decorators/',
+      },
     },
     {
       slug: 'directives',
       title: 'Directives',
       anchorFilter: (node) => node.kindString === 'Function',
+      versionLinks: {
+        v1: 'api/lit-html/directives/',
+      },
     },
     {
       slug: 'custom-directives',
       title: 'Custom directives',
+      versionLinks: {
+        v1: 'api/lit-html/custom-directives/',
+      },
     },
     {
       slug: 'static-html',
       title: 'Static HTML',
+      versionLinks: {
+        v1: 'api/lit-html/templates/',
+      },
     },
     {
       slug: 'controllers',
       title: 'Controllers',
+      versionLinks: {
+        v1: 'api/lit-element/LitElement/',
+      },
     },
     {
       slug: 'misc',
       title: 'Misc',
+      versionLinks: {
+        v1: 'api/lit-element/LitElement/',
+      },
     },
   ],
 

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-element-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-element-2.ts
@@ -38,22 +38,37 @@ export const litElement2Config: ApiDocsConfig = {
     {
       slug: 'LitElement',
       title: 'LitElement',
+      versionLinks: {
+        v2: 'api/LitElement/',
+      },
     },
     {
       slug: 'UpdatingElement',
       title: 'UpdatingElement',
+      versionLinks: {
+        v2: 'api/ReactiveElement/',
+      },
     },
     {
       slug: 'styles',
       title: 'Styles',
+      versionLinks: {
+        v2: 'api/styles/',
+      },
     },
     {
       slug: 'decorators',
       title: 'Decorators',
+      versionLinks: {
+        v2: 'api/decorators/',
+      },
     },
     {
       slug: 'misc',
       title: 'Misc',
+      versionLinks: {
+        v2: 'api/misc/',
+      },
     },
   ],
 

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-html-1.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-html-1.ts
@@ -50,22 +50,37 @@ export const litHtml1Config: ApiDocsConfig = {
     {
       slug: 'templates',
       title: 'Templates',
+      versionLinks: {
+        v2: 'api/templates/',
+      },
     },
     {
       slug: 'directives',
       title: 'Directives',
+      versionLinks: {
+        v2: 'api/directives/',
+      },
     },
     {
       slug: 'custom-directives',
       title: 'Custom directives',
+      versionLinks: {
+        v2: 'api/custom-directives/',
+      },
     },
     {
       slug: 'misc',
       title: 'Misc',
+      versionLinks: {
+        v2: 'api/misc/',
+      },
     },
     {
       slug: 'shady',
       title: 'ShadyCSS/DOM',
+      versionLinks: {
+        v2: 'api/templates/',
+      },
     },
   ],
 

--- a/packages/lit-dev-tools-cjs/src/api-docs/types.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/types.ts
@@ -109,6 +109,7 @@ export interface ApiDocsConfig {
     slug: string;
     title: string;
     anchorFilter?: (node: DeclarationReflection) => boolean;
+    versionLinks?: {[version: string]: string};
   }>;
 
   /**


### PR DESCRIPTION
**Note to reviewers**: I strongly suggest looking at each commit separately.

When switching between v1 and v2 docs, we'll now take you to the most similar page in the other version, instead of just to the landing page.

- Works in either direction
- Works from the "Click here for latest version" link
- Also works from the "Version" switcher
- Configured using front-matter in the markdown files
- For the API, configured from the API config files

I just used my own judgment to find the most similar pages. In a few cases the decision wasn't 100% obvious so feel free to suggest some better ones if you see anything odd.

Plan:

- [X] Serve old article content
- [X] Serve old API content
- [X] Add a "these are old docs" banner
- [X] Add a version switcher
- [X] Make switching versions bring you to the matching page  (this PR)
- [ ] Set up redirects by checking the `Host` header
- [ ] Point old domains at new Cloud project