### PR TITLE
Tweak appearance of version selector and re-order

### DIFF
--- a/packages/lit-dev-content/site/css/version-selector.css
+++ b/packages/lit-dev-content/site/css/version-selector.css
@@ -1,13 +1,13 @@
 litdev-version-selector > select {
-  background: #d5d5d5aa;
+  background: transparent;
   border-radius: 8px;
-  border: none;
+  border: 1.5px solid #cacaca;
   color: #636363;
   cursor: pointer;
   font-family: 'Manrope', sans-serif;
   font-weight: 600;
   margin-left: -3px;
-  padding: 2px 3px;
+  padding: 1px 3px;
 }
 
 litdev-version-selector > select:hover,
@@ -17,7 +17,12 @@ litdev-version-selector > select:focus,
 }
 
 #mobileSiteNav litdev-version-selector > select {
-  background: #0000004f;
+  border-color: #fff;
   color: #fff;
   margin-left: 5px;
+}
+
+#mobileSiteNav litdev-version-selector > select > option {
+  background: #fff;
+  color: #000;
 }

--- a/packages/lit-dev-content/site/site.json
+++ b/packages/lit-dev-content/site/site.json
@@ -2,13 +2,13 @@
   "selectedVersion": "v2",
   "latestVersion": "v2",
   "versions": {
-    "v1": {
-      "path": "/docs/v1",
-      "label": "v1"
-    },
     "v2": {
       "path": "/docs",
       "label": "v2"
+    },
+    "v1": {
+      "path": "/docs/v1",
+      "label": "v1"
     }
   }
 }


### PR DESCRIPTION
Before: 
<img src="https://user-images.githubusercontent.com/48894/144685698-db60ba52-2b51-4bb9-83f6-104d85e24ead.png" width="200px">

After:
<img src="https://user-images.githubusercontent.com/48894/144685707-8e6292f2-eeb9-42e5-93e9-18170b080450.png" width="200px">

Also the order in the select menu is now v2, v1 instead of v1, v2