### PR TITLE
Prevent a render crash if the project path has a trailing slash

### DIFF
--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -169,6 +169,7 @@ export const playgroundPlugin = (
           `Usage {% playground-ide "path/to/project" %}`
       );
     }
+    project = trimTrailingSlash(project);
     const config = await readProjectConfig(project);
     const firstFilename = Object.keys(config.files ?? {})[0];
     const numVisibleLines = await getNumVisibleLinesForProjectFile(
@@ -205,6 +206,7 @@ export const playgroundPlugin = (
             `Usage {% playground-example "project/dir" "filename.js" %}`
         );
       }
+      project = trimTrailingSlash(project);
       const config = await readProjectConfig(project);
       if (!config.files?.[filename]) {
         throw new Error(
@@ -265,3 +267,6 @@ export const playgroundPlugin = (
     (code: string, lang: 'js' | 'ts' | 'html' | 'css') => render(code, lang)
   );
 };
+
+const trimTrailingSlash = (str: string) =>
+  str.endsWith('/') ? str.slice(0, str.length - 1) : str;


### PR DESCRIPTION
Adds support for an intermittent crash in rendering due to manual path concatenation.

For example: `{% playground-example "docs/components/events/child/" "my-element.ts" %}` would
become `"docs/components/events/child//my-element.ts"`.

I would run into the error thrown here: https://github.com/lit/lit.dev/blob/main/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts#L143-L148

Alternative is to explicitly check for a trailing slash and throw, but it's nicer to content authors to support the additional flexibility.

### How to repro bug?

I ran into this while testing the API docs for `@queryAssignedNodes`. I can't tell if there is caching or something else that is making it hard to repro. I ran into the bug initially due to the shortcode in [`events.md`](https://github.com/lit/lit.dev/blob/main/packages/lit-dev-content/site/docs/components/events.md#adding-event-listeners-in-the-element-template). Fixing that case unblocked me. Then I ran into it again after deleting the lit-2 API content.

The error message contained the double `//` which prompted me to this fix.

### Testing

 - Tested manually by building the site.