### PR TITLE
Make closing the gist flyout more reliable

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-flyout.ts
+++ b/packages/lit-dev-content/src/components/litdev-flyout.ts
@@ -71,7 +71,7 @@ export class LitDevFlyout extends LitElement {
       if (this.open) {
         this._addEventListeners();
         this.dispatchEvent(new Event('open'));
-      } else {
+      } else if (changed.get('open')) {
         this._removeEventListeners();
         this.dispatchEvent(new Event('closed'));
       }

--- a/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
@@ -115,8 +115,13 @@ export class LitDevPlaygroundShareButton extends LitElement {
   }
 
   override update(changes: PropertyValues) {
-    if (changes.has('_open') && this._open) {
-      this._longUrl?.generateUrl();
+    if (changes.has('_open')) {
+      if (this._open) {
+        this._longUrl?.generateUrl();
+        this.dispatchEvent(new Event('opened'));
+      } else {
+        this.dispatchEvent(new Event('closed'));
+      }
     }
     super.update(changes);
   }

--- a/packages/lit-dev-content/src/pages/playground.ts
+++ b/packages/lit-dev-content/src/pages/playground.ts
@@ -37,6 +37,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const project = $('playground-project')!;
   const shareButton = $('#shareButton')!;
   const shareSnackbar = $('#shareSnackbar')! as Snackbar;
+  const playgroundPreview = $('playground-preview')!;
 
   // TODO(aomarks) A quite gross and fragile loose coupling! This entire module
   // needs to be refactored, probably into one or two custom elements.
@@ -44,6 +45,19 @@ window.addEventListener('DOMContentLoaded', () => {
   const githubApiUrl = newShareButton?.githubApiUrl ?? '';
   if (newShareButton) {
     newShareButton.getProjectFiles = () => project.files;
+
+    // Clicks made on the playground-preview iframe will be handled entirely by
+    // the iframe window, and don't propagate to the host window. That means
+    // that the normal behavior where the share flyout detects clicks outside of
+    // itself in order to close won't work, since it will never see the click
+    // event. To work around this, we temporarily disable pointer-events on the
+    // preview, so that clicks go to our host window instead.
+    newShareButton.addEventListener('opened', () => {
+      playgroundPreview.style.pointerEvents = 'none';
+    });
+    newShareButton.addEventListener('closed', () => {
+      playgroundPreview.style.pointerEvents = 'unset';
+    });
   } else {
     console.error('Missing litdev-playground-share-button');
   }

--- a/packages/lit-dev-tests/src/playwright/playground.spec.ts
+++ b/packages/lit-dev-tests/src/playwright/playground.spec.ts
@@ -389,4 +389,34 @@ test.describe('Playground', () => {
       'backendErrorWritingGist.png'
     );
   });
+
+  test('close share flyout by clicking outside of the flyout', async ({
+    page,
+  }) => {
+    await page.goto('/playground/?mods=gists');
+
+    await page.click('litdev-playground-share-button');
+    await page.waitForSelector('litdev-playground-share-button litdev-flyout', {
+      state: 'visible',
+    });
+
+    await page.click('main');
+    await page.waitForSelector('litdev-playground-share-button litdev-flyout', {
+      state: 'hidden',
+    });
+  });
+
+  test('close share flyout by clicking share button again', async ({page}) => {
+    await page.goto('/playground/?mods=gists');
+
+    await page.click('litdev-playground-share-button');
+    await page.waitForSelector('litdev-playground-share-button litdev-flyout', {
+      state: 'visible',
+    });
+
+    await page.click('litdev-playground-share-button');
+    await page.waitForSelector('litdev-playground-share-button litdev-flyout', {
+      state: 'hidden',
+    });
+  });
 });


### PR DESCRIPTION
- You can now close the flyout by clicking the "Share" button again. Previously this didn't work because clicking on it 1. caused the flyout to close itself (because it closes itself when it detects a click outside of itself), and then 2. the share button to open the flyout again (because it naively opened for every click).

- You can now close the flyout by clicking on the preview. Previously this didn't work because those clicks went to the iframe window, and never reached the host window. Now we temporarily set `pointer-events: none` when the flyout is open so that the main window gets those events instead.