### PR TITLE
Tweaks to gist metadata file

### DIFF
--- a/packages/lit-dev-content/src/util/gist-conversion.ts
+++ b/packages/lit-dev-content/src/util/gist-conversion.ts
@@ -24,8 +24,15 @@ type GistPlaygroundMetadata = {
 
 /**
  * Filename for gist playground metadata.
+ *
+ * Note that the "zzzzzzzzzz" prefix is chosen to encourage this file to come
+ * last in the list of Gist files. GitHub uses the first file as title of the
+ * Gist, so it's better for that to be one of the user's files. GitHub uses an
+ * unusual sorting scheme where characters like _-@#$ come before letters (see
+ * https://gist.github.com/fliedonion/6057f4a3a533f7992c60), so we can't use any
+ * of those.
  */
-const METADATA_FILENAME = '__lit-dev-playground-metadata__.json';
+const METADATA_FILENAME = 'zzzzzzzzzz-lit-dev-playground-metadata.json';
 
 /**
  * Convert an array of Playground files to a GitHub gist.

--- a/packages/lit-dev-content/src/util/gist-conversion.ts
+++ b/packages/lit-dev-content/src/util/gist-conversion.ts
@@ -59,7 +59,7 @@ export const playgroundToGist = (playgroundFiles: SampleFile[]): GistFiles => {
       .map(({name, content}) => [name, {content}])
   );
   gistFiles[METADATA_FILENAME] = {
-    content: JSON.stringify(metadata),
+    content: JSON.stringify(metadata, null, 2),
   };
   return gistFiles;
 };


### PR DESCRIPTION
- Uses `zzzzzzzzzz` as the prefix for the metadata file instead of `__`, because that will sort last instead of first, allowing one of the user's files to become the implicit Gist title instead of it always being our weird metadata file.

- JSON indent the metadata file -- it might as well be readable.