### PR TITLE
Fix Atom feed.xml minification bug

### DIFF
--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -195,7 +195,13 @@ ${content}
   });
 
   eleventyConfig.addTransform('htmlMinify', function (content, outputPath) {
-    if (DEV || !outputPath.endsWith('.html')) {
+    if (
+      DEV ||
+      !outputPath.endsWith('.html') ||
+      // TODO(aomarks) How can we get Eleventy to not treat this XML file as a
+      // directory with an index.html?
+      outputPath.includes('feed.xml')
+    ) {
       return content;
     }
     const minified = htmlMinifier.minify(content, {


### PR DESCRIPTION
Oops -- the blog Atom feed is getting minified as HTML, which makes it invalid for some reason.

This is a quick fix, because there's actually a deeper issue here. Eleventy is outputting the Atom feed to `/blog/feed.xml/index.html` -- which is totally wrong. It's ok temporarily, since `/blog/feed.xml` gets served correctly anyway through this layout, but I'll send another followup once I figure out how to get Eleventy to do the right thing.