### PR TITLE
Atom feed improvements for Feedly and others

### DIFF
--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -40,7 +40,7 @@
 
     <link rel="preconnect" href="https://fonts.gstatic.com">
 
-    <link href="/blog/feed.xml" rel="alternate" type="application/atom+xml" data-title="Lit Blog feed">
+    <link href="/blog/atom.xml" rel="alternate" type="application/atom+xml" data-title="Lit Blog feed">
     {% block head %}{% endblock %}
   </head>
   <body>

--- a/packages/lit-dev-content/site/blog/2021-09-22-lit-2-release-livestream.md
+++ b/packages/lit-dev-content/site/blog/2021-09-22-lit-2-release-livestream.md
@@ -6,10 +6,6 @@ summary: "What's new in Lit 2, a big-picture view of Lit usage at Google, and a 
 date: 2021-09-22
 ---
 
-<div class="preamble">
-
 If you weren't able to join us for the Lit 2  release livestream, you can watch the recording on YouTube.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/nfb779XIhsU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-</div>

--- a/packages/lit-dev-content/site/blog/atom.xml.njk
+++ b/packages/lit-dev-content/site/blog/atom.xml.njk
@@ -3,14 +3,16 @@ permalink: blog/atom.xml
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:webfeeds="http://webfeeds.org/rss/1.0">
   <title>Lit Blog</title>
   <subtitle>Latest news, announcements, and highlights from the Lit team and community.</subtitle>
   <link href="https://lit.dev/blog/"/>
   <link href="https://lit.dev/blog/atom.xml" rel="self"/>
   <id>https://lit.dev/blog/</id>
-  <icon>https://lit.dev/images/flame-favicon.svg</icon>
+  <icon>https://lit.dev/images/icon.svg</icon>
   <logo>https://lit.dev/images/logo.svg</logo>
+  <webfeeds:icon>https://lit.dev/images/icon.svg</webfeeds:icon>
+  <webfeeds:logo>https://lit.dev/images/logo.svg</webfeeds:logo>
   <updated>{{ collections.blogPosts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
   {%- for post in collections.blogPosts %}
     {% set absolutePostUrl %}{{ post.url | url | absoluteUrl("https://lit.dev/") }}{% endset %}

--- a/packages/lit-dev-content/site/blog/atom.xml.njk
+++ b/packages/lit-dev-content/site/blog/atom.xml.njk
@@ -25,7 +25,7 @@ eleventyExcludeFromCollections: true
       <summary>{{ post.data.summary }}</summary>
       <author>
         <name>{{ author.name }}</name>
-        {% if author.twitter %}
+        {% if author.links.twitter %}
           <uri>https://twitter.com/{{ author.links.twitter }}</uri>
         {% elif author.links.github %}
           <uri>https://github.com/{{ author.links.github }}</uri>

--- a/packages/lit-dev-content/site/blog/atom.xml.njk
+++ b/packages/lit-dev-content/site/blog/atom.xml.njk
@@ -1,5 +1,5 @@
 ---
-permalink: blog/feed.xml
+permalink: blog/atom.xml
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -7,7 +7,7 @@ eleventyExcludeFromCollections: true
   <title>Lit Blog</title>
   <subtitle>Latest news, announcements, and highlights from the Lit team and community.</subtitle>
   <link href="https://lit.dev/blog/"/>
-  <link href="https://lit.dev/blog/feed.xml" rel="self"/>
+  <link href="https://lit.dev/blog/atom.xml" rel="self"/>
   <id>https://lit.dev/blog/</id>
   <icon>https://lit.dev/images/flame-favicon.svg</icon>
   <logo>https://lit.dev/images/logo.svg</logo>

--- a/packages/lit-dev-content/site/blog/atom.xml.njk
+++ b/packages/lit-dev-content/site/blog/atom.xml.njk
@@ -6,8 +6,8 @@ eleventyExcludeFromCollections: true
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:webfeeds="http://webfeeds.org/rss/1.0">
   <title>Lit Blog</title>
   <subtitle>Latest news, announcements, and highlights from the Lit team and community.</subtitle>
-  <link href="https://lit.dev/blog/"/>
-  <link href="https://lit.dev/blog/atom.xml" rel="self"/>
+  <link rel="alternate" href="https://lit.dev/blog/"/>
+  <link rel="self" href="https://lit.dev/blog/atom.xml"/>
   <id>https://lit.dev/blog/</id>
   <icon>https://lit.dev/images/icon.svg</icon>
   <logo>https://lit.dev/images/logo.svg</logo>

--- a/packages/lit-dev-content/site/blog/index.html
+++ b/packages/lit-dev-content/site/blog/index.html
@@ -20,7 +20,7 @@ splash: lit-shapes.svg
           major release announcements and showcases cool stuff being built with Lit.</p>
 
       <p>For updates, follow <a href="https://twitter.com/buildWithLit">@buildWithLit</a>
-      on Twitter or add our <a href="{{ site.baseurl }}/blog/feed.xml">Atom
+      on Twitter or add our <a href="{{ site.baseurl }}/blog/atom.xml">Atom
       feed</a> to your feed reader.</p>
     </div>
 

--- a/packages/lit-dev-content/site/images/icon.svg
+++ b/packages/lit-dev-content/site/images/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-30 -10 220 220" width="220" height="220">
+<path fill="#00e8ff" d="M40 120l20-60l90 90l-30 50l-40-40h-20"/>
+<path fill="#283198" d="M80 160v-80l40-40v80M0 160l40 40l20-40l-20-40h-20"/>
+<path fill="#324fff" d="M40 120v-80l40-40v80M120 200v-80l40-40v80M0 160v-80l40 40"/>
+<path fill="#0ff" d="M40 200v-80l40 40"/>
+</svg>

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -202,6 +202,15 @@ export const contentSecurityPolicyMiddleware = (
   // discussion of why this is a good practice.
   const strictFallbackCsp = makePolicy(`default-src 'none'`);
 
+  // Chrome automatically displays XML files with its own little XML viewer. But
+  // that viewer is affected by our CSP! Let it work for when people look at our
+  // blog Atom XML feed directly.
+  const atomXmlFeedCsp = makePolicy(
+    `style-src 'unsafe-inline'`,
+    `img-src data:`,
+    `default-src 'none'`
+  );
+
   return async (ctx, next) => {
     let policy: string;
     // Note we can't rely on ctx.type being set by the downstream middleware,
@@ -218,6 +227,8 @@ export const contentSecurityPolicyMiddleware = (
       policy = entrypointsCsp;
     } else if (ctx.path.endsWith('/playground-typescript-worker.js')) {
       policy = playgroundWorkerCsp;
+    } else if (ctx.path.endsWith('/atom.xml')) {
+      policy = atomXmlFeedCsp;
     } else {
       policy = strictFallbackCsp;
     }

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -22,6 +22,7 @@ export const pageRedirects = new Map([
   ['/msg/expression-in-textarea',     '/docs/templates/expressions/#invalid-locations'],
   // Relocated pages
   ['/docs/libraries/localization',    '/docs/localization/overview/'],
+  ['/blog/feed.xml',                  '/blog/atom.xml'],
 ].map(([path, redir]) => [
   // Trailing slashes are required because this redirect map is consulted after
   // standard lit.dev path canonicalization.


### PR DESCRIPTION
- Adds `webfeeds:icon` and `webfeeds:logo` tags, which Feedly apparently depends on (even though Atom already specifies its own `<icon>` and `<logo>` tags...)

- Adds a new `icon.svg` to use instead of `flame.svg`, which is square and has a little padding. Feedly crops non-square images, so the logo was getting cut off.

- Fixes broken Twitter links.

- Fixes missing `rel=alternate` attribute.

- Added a CSP policy to allow the built-in Chrome XML viewer to display the Atom feed nicely.

- Renames the feed from `feed.xml` to `atom.xml`. The originally published feed which was invalid caused Feedly to do some caching that means that no articles show up, and the icon is missing, even after clicking its reload button and waiting a few hours. A different URL will be a different feed from Feedly's perspective, so we get a reset. `atom.xml` is probably a better name anyway, to distinguish it from a hypothetical `rss.xml` that we could have (and maybe we'll find a reason to have both for some reason). Included a 301 redirect in case somebody has already subscribed.

Proof:

<img src="https://user-images.githubusercontent.com/48894/145913582-f15bf1a1-9157-457b-afd0-09023b9de05c.png" width="500px">

<img src="https://user-images.githubusercontent.com/48894/145913725-02528259-849c-47f6-b774-b435881c6239.png" width="500px">
