### PR TITLE
Remove data- prefix from atom feed <link> title attribute

### DIFF
--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -40,7 +40,7 @@
 
     <link rel="preconnect" href="https://fonts.gstatic.com">
 
-    <link href="/blog/atom.xml" rel="alternate" type="application/atom+xml" data-title="Lit Blog feed">
+    <link href="/blog/atom.xml" rel="alternate" type="application/atom+xml" title="Lit Blog feed">
     {% block head %}{% endblock %}
   </head>
   <body>


### PR DESCRIPTION
Fixes https://github.com/lit/lit.dev/pull/617

I cribbed this from web.dev, but as @simevidas points out, it seems like it should just be `title` (since the `title` attribute is defined at https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title, and at least one browser extension uses it to show a name of the feed, whereas a `data-` attribute is just user data that shouldn't have any defined semantics external to the site).