### PR TITLE
Add @link and @linkcode support in generated API docs

### DIFF
--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.spec.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {test} from 'uvu';
+import * as assert from 'uvu/assert';
+import {linkifySymbolsInCommentsBuilder} from './transformer.js';
+
+const symbolMapFixture1 = {
+  $LitElement: [
+    {
+      page: 'LitElement',
+      anchor: 'LitElement',
+    },
+  ],
+  ['$LitElement.attributeChangedCallback']: [
+    {
+      page: 'LitElement',
+      anchor: 'LitElement.attributeChangedCallback',
+    },
+  ],
+};
+
+test('simple [[`symbol`]] hyperlink', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {},
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('Simple [[`LitElement`]] symbol reference'),
+    'Simple [`LitElement`](LitElement#LitElement) symbol reference'
+  );
+});
+
+test('simple @link', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {},
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('Simple {@link LitElement} symbol reference'),
+    'Simple [LitElement](LitElement#LitElement) symbol reference'
+  );
+});
+
+test('labeled @link', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {},
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('Simple {@link LitElement symbol} reference'),
+    'Simple [symbol](LitElement#LitElement) reference'
+  );
+});
+
+test('simple @linkcode', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {},
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('Simple {@linkcode LitElement symbol} reference'),
+    'Simple [`symbol`](LitElement#LitElement) reference'
+  );
+});
+
+test('simple [[`symbol` | label]] hyperlink', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {},
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+  assert.equal(
+    r('[[`LitElement`| custom label]] reference'),
+    '[`custom label`](LitElement#LitElement) reference'
+  );
+});
+
+test('multiple replacements', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {},
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('[[`LitElement`]] {@linkcode LitElement.attributeChangedCallback}'),
+    '[`LitElement`](LitElement#LitElement) [`LitElement.attributeChangedCallback`](LitElement#LitElement.attributeChangedCallback)'
+  );
+});
+
+test('[[`symbol`]] hyperlink with node context', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {
+      location: {
+        anchor: 'LitElement',
+      },
+    },
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('[[`attributeChangedCallback`]]'),
+    '[`attributeChangedCallback`](LitElement#LitElement.attributeChangedCallback)'
+  );
+});
+
+test('@link hyperlink with node context', () => {
+  const r = linkifySymbolsInCommentsBuilder({
+    node: {
+      location: {
+        anchor: 'LitElement',
+      },
+    },
+    symbolMap: symbolMapFixture1,
+    locationToUrl: ({page, anchor}) => `${page}#${anchor}`,
+  });
+
+  assert.equal(
+    r('{@linkcode attributeChangedCallback}'),
+    '[`attributeChangedCallback`](LitElement#LitElement.attributeChangedCallback)'
+  );
+});

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.spec.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.spec.ts
@@ -84,6 +84,31 @@ const simpleTests: Array<[TestLabel, Input, Expected]> = [
     '[[`LitElement`]] {@linkcode LitElement.attributeChangedCallback}',
     '[`LitElement`](LitElement#LitElement) [`LitElement.attributeChangedCallback`](LitElement#LitElement.attributeChangedCallback)',
   ],
+  [
+    '[[symbol | `label`] backticks correctly handled',
+    '[[LitElement | `styles`]]',
+    '[`styles`](LitElement#LitElement)',
+  ],
+  [
+    'No symbol reference - @link',
+    'No {@link MissingSymbol} ref',
+    'No MissingSymbol ref',
+  ],
+  [
+    'No symbol reference - @linkcode',
+    'No {@linkcode MissingSymbol} ref',
+    'No `MissingSymbol` ref',
+  ],
+  [
+    'No symbol reference - labeled @link',
+    'No {@link MissingSymbol symbol} ref',
+    'No symbol ref',
+  ],
+  [
+    'No symbol reference - labeled @linkcode',
+    'No {@linkcode MissingSymbol symbol} ref',
+    'No `symbol` ref',
+  ],
 ];
 
 simpleTests.forEach(([label, input, expected]: [TestLabel, Input, Expected]) =>

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -565,15 +565,17 @@ export class ApiDocsTransformer {
   };
 
   /**
-   * Convert [[ symbol ]] references in comments into hyperlinks.
+   * Convert [[ symbol ]], `@link`, and `@linkcode` comments into hyperlinks.
    *
-   * Also support `@link` and `@linkcode`, with optional label
-   * after a pipe. See these real examples and how the show up in
-   * your IDE:
+   * Suppports the following examples:
+   *  * Example link to {@link ApiDocsTransformer} symbol.
+   *  * Example monospace link to {@linkcode ApiDocsTransformer}.
+   *  * {@link ApiDocsTransformer Example labeled link.}
+   *  * {@linkcode ApiDocsTransformer Example monospace labeled link.}
    *
-   *  * Link to {@link ApiDocsTransformer}.
-   *  * Code link for {@linkcode ApiDocsTransformer}.
-   *  * {@link ApiDocsTransformer Click here for transformer.}
+   * Also supports these deprecated examples which don't have IDE hyperlinks:
+   *  * [[`ApiDocsTransformer`]]
+   *  * [[`ApiDocsTransformer`| Example labeled link.]]
    *
    * TODO(aomarks) This should probably technically be factored out and called
    * directly from Eleventy, because the URL we generate depends on the
@@ -745,9 +747,10 @@ export class ApiDocsTransformer {
 }
 
 /**
- * Returns a replace function that converts `[[symbol]]` doc links into markdown
- * anchor links.
- * See https://typedoc.org/guides/doccomments/#symbol-references for formats.
+ * Returns a string replacer function that converts jsdoc links into markdown
+ * hyperlinks that are used in the generated API documentation.
+ *
+ * See {@linkcode ApiDocsTransformer.linkifySymbolsInComments} for more info.
  */
 export function linkifySymbolsInCommentsBuilder({
   node,
@@ -781,15 +784,18 @@ export function linkifySymbolsInCommentsBuilder({
         break;
       }
     }
+
     const isCodeFenced = (anchorText: string) =>
       from.startsWith('{@linkcode') || from.startsWith('[[`')
         ? `\`${anchorText}\``
         : anchorText;
+
     if (results && results.length === 1) {
       return `[${isCodeFenced(label || symbol)}](${locationToUrl(results[0])})`;
     }
     return isCodeFenced(label || symbol);
   };
+
   return (comment: string) =>
     comment
       .replace(/\[\[[\s`]*(.+?)(?:[\s`]*\|[\s`]*(.+?))?[\s`]*\]\]/g, replacer)

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -785,15 +785,17 @@ export function linkifySymbolsInCommentsBuilder({
       }
     }
 
-    const isCodeFenced = (anchorText: string) =>
-      from.startsWith('{@linkcode') || from.startsWith('[[`')
+    const hyperlinkTextFormat = (anchorText: string) =>
+      from.startsWith('{@linkcode') || from.startsWith('[[')
         ? `\`${anchorText}\``
         : anchorText;
 
     if (results && results.length === 1) {
-      return `[${isCodeFenced(label || symbol)}](${locationToUrl(results[0])})`;
+      return `[${hyperlinkTextFormat(label || symbol)}](${locationToUrl(
+        results[0]
+      )})`;
     }
-    return isCodeFenced(label || symbol);
+    return hyperlinkTextFormat(label || symbol);
   };
 
   return (comment: string) =>

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -567,7 +567,7 @@ export class ApiDocsTransformer {
   /**
    * Convert [[ symbol ]], `@link`, and `@linkcode` comments into hyperlinks.
    *
-   * Suppports the following examples:
+   * Supports the following examples:
    *  * Example link to {@link ApiDocsTransformer} symbol.
    *  * Example monospace link to {@linkcode ApiDocsTransformer}.
    *  * {@link ApiDocsTransformer Example labeled link.}


### PR DESCRIPTION
Addresses issue https://github.com/lit/lit.dev/issues/503

With this change, we can generate API docs that support the `@link` and `@linkcode` jsdoc attributes.

Symbol resolution is unchanged, and I've added an additional regex to capture these two new attributes. Further I've also modified the backtick handling so it matches what the IDE renders on hover.

### Testing

 - Manual integration testing done against the following Lit core PR: https://github.com/lit/lit/pull/2370. See screenshots in that PR for why `@link` and `@linkcode` may be preferable.
 - Unit tested against supported syntactic structures.
 - Github Action checks that pull requests don't change the generated API docs without committing the change. This helped me ensure that this change is completely backwards compatible. (Thanks aomarks for that test!)


### Caveats

This PR doesn't exhaustively handle all `@link` syntactic structures mentioned on [jsdoc.app](https://jsdoc.app/tags-inline-link.html). For example we do not handle: `[link text]{@link namepathOrURL}` or `{@link namepathOrURL|link text}`. This was done intentionally as VsCode doesn't support these structures.

`[link text]{@link ApiDocsTransformer}` renders as:
<img width="283" alt="Screen Shot 2021-12-22 at 12 04 09 PM" src="https://user-images.githubusercontent.com/15080861/147149160-32bc1236-1bb7-43a2-bcaf-9396453f31e9.png">


`{@link ApiDocsTransformer|label}` renders with the pipe in the label:
<img width="81" alt="Screen Shot 2021-12-22 at 12 06 27 PM" src="https://user-images.githubusercontent.com/15080861/147149282-6834818a-2148-4f36-ae2a-a06772ed9373.png">


