### PR TITLE
Fix lit-html 1 release-notes so CSP is satisfied

### DIFF
--- a/packages/lit-dev-content/site/docs/releases/release-notes/release-notes.json
+++ b/packages/lit-dev-content/site/docs/releases/release-notes/release-notes.json
@@ -1,5 +1,4 @@
 
 {
-  "layout": "docs",
-  "permalink": "{{page.filePathStem}}.html"
+  "layout": "docs"
 }

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -23,9 +23,12 @@ export const pageRedirects = new Map([
   // Relocated pages
   ['/docs/libraries/localization',    '/docs/localization/overview/'],
   ['/blog/feed.xml',                  '/blog/atom.xml'],
-  // These were ugly urls, that violated CSP.
-  ['/docs/releases/release-notes/1.3.0.html', '/docs/releases/release-notes/1.3.0'],
-  ['/docs/releases/release-notes/1.2.0.html', '/docs/releases/release-notes/1.2.0']
+  // Urls not ending with '/' violate CSP policies.
+  ['/docs/releases/release-notes/1.3.0.html', '/docs/releases/release-notes/1.3.0/'],
+  ['/docs/releases/release-notes/1.2.0.html', '/docs/releases/release-notes/1.2.0/'],
+  // `.0` is treated as a file extension, ensure it resolves correctly.
+  ['/docs/releases/release-notes/1.3.0',      '/docs/releases/release-notes/1.3.0/'],
+  ['/docs/releases/release-notes/1.2.0',      '/docs/releases/release-notes/1.2.0/']
 ].map(([path, redir]) => [
   // Trailing slashes are required because this redirect map is consulted after
   // standard lit.dev path canonicalization.

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -23,6 +23,9 @@ export const pageRedirects = new Map([
   // Relocated pages
   ['/docs/libraries/localization',    '/docs/localization/overview/'],
   ['/blog/feed.xml',                  '/blog/atom.xml'],
+  // These were ugly urls, that violated CSP.
+  ['/docs/releases/release-notes/1.3.0.html', '/docs/releases/release-notes/1.3.0'],
+  ['/docs/releases/release-notes/1.2.0.html', '/docs/releases/release-notes/1.2.0']
 ].map(([path, redir]) => [
   // Trailing slashes are required because this redirect map is consulted after
   // standard lit.dev path canonicalization.


### PR DESCRIPTION
### Context

Currently there's a bug if you navigate to the following two urls:
 - https://lit.dev/docs/releases/release-notes/1.3.0.html
 - https://lit.dev/docs/releases/release-notes/1.2.0.html

They don't render properly because of CSP violations.

### Why?

Our content security policy middleware expects our documentation to end with `/`, and not `.html`. This change updates these paths so they are now:

 - https://pr631-afe54e8---lit-dev-5ftespv5na-uc.a.run.app/docs/releases/release-notes/1.3.0/
 - https://pr631-afe54e8---lit-dev-5ftespv5na-uc.a.run.app/docs/releases/release-notes/1.2.0/

A redirect is also added from the previous path, and from the URL without the trailing slash, to ensure we always end up on the url with a trailing slash that conforms to CSP policies.

### Alternative considered

An alternative solution would be to expand our CSP policy to include
the 1.2.0.html and 1.3.0.html paths. However this seemed like a special case solution unless there is a reason we want a url ending in `1.2.0.html` for lit-html 1 release notes.

Redirects seemed more idiomatic, but happy to change solution.

### Testing

Local testing was done. For example now we generate a folder `1.2.0` containing an `index.html`, instead of generating a `1.2.0.html` file directly.
I also manually tested the preview deploy url with and without trailing slashes to check redirect.

I also looked for other 11ty configs that may generate raw `.html` files. I think it's just these two routes.

