### PR TITLE
Fix syntax in choose directive example to use html tagged template literals.

### DIFF
--- a/packages/lit-dev-content/site/blog/2022-01-05-lit-2.1-release.md
+++ b/packages/lit-dev-content/site/blog/2022-01-05-lit-2.1-release.md
@@ -95,10 +95,10 @@ cases. It's like an inline switch statement.
 render() {
   return html`
     ${choose(this.section, [
-      ['home', () => <h1>Home</h1>],
-      ['about', () => <h1>About</h1>]
+      ['home', () => html`<h1>Home</h1>`],
+      ['about', () => html`<h1>About</h1>`]
     ],
-    () => html`<h1>Error</h1>)}
+    () => html`<h1>Error</h1>`)}
   `;
 }
 ```


### PR DESCRIPTION
Small syntactic fix for the `choose` directive example in the blog.