### PR TITLE
Prevent recursive processing of js/ directory in samples generator

### DIFF
--- a/packages/lit-dev-tools-esm/src/generate-js-samples.ts
+++ b/packages/lit-dev-tools-esm/src/generate-js-samples.ts
@@ -141,7 +141,7 @@ const nonTsFilesWatcher = chokidar
     [
       '.',
       // Don't watch our own output dir.
-      '!js/',
+      '!js/**/*',
       // TypeScript files are handled separately
       '!*.ts',
       '!**/*.ts',


### PR DESCRIPTION
The TS -> JS samples generator emits to the `js/` directory, but we were accidentally including that in the list of paths we watch, triggering an infinite loop of endless nested `js/` folders.