### PR TITLE
Make API docs analysis more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages/lit-dev-content/temp
 packages/lit-dev-content/samples/js
 
 packages/lit-dev-api/api-data/*/repo/
+packages/lit-dev-api/api-data/*/INSTALLED
 
 # We only want to keep '-linux' screenshots which are tested by Github Actions.
 packages/lit-dev-tests/src/playwright/**/*.png

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
@@ -21,6 +21,7 @@ const srcDir = pathlib.join(litDir, 'src');
 export const lit2Config: ApiDocsConfig = {
   repo: 'lit/lit',
   commit: '4a5369c8c9b282c4f47a70126da11810e9754745',
+  workDir,
   gitDir,
   tsConfigPath: pathlib.join(litDir, 'tsconfig.json'),
   pagesOutPath: pathlib.resolve(workDir, 'pages.json'),
@@ -28,7 +29,13 @@ export const lit2Config: ApiDocsConfig = {
   typedocRoot: pathlib.join(root, 'packages'),
 
   extraSetupCommands: [
-    {cmd: 'npm', args: ['run', 'bootstrap']},
+    {
+      cmd: 'npx',
+      // Only install lit and its dependencies, so that we don't waste time
+      // installing dependencies for packages we don't generate API docs for
+      // (like tests).
+      args: ['lerna', 'bootstrap', '--scope', 'lit', '--include-dependencies'],
+    },
     {
       cmd: 'npx',
       args: [

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-element-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-element-2.ts
@@ -20,6 +20,7 @@ const srcDir = pathlib.join(gitDir, 'src');
 export const litElement2Config: ApiDocsConfig = {
   repo: 'lit/lit-element',
   commit: 'c9b40e6b26dd7a9361e32421a4343949d242e0ca',
+  workDir,
   gitDir,
   tsConfigPath: pathlib.join(gitDir, 'tsconfig.json'),
   pagesOutPath: pathlib.join(workDir, 'pages.json'),

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-html-1.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-html-1.ts
@@ -20,6 +20,7 @@ const srcDir = pathlib.join(gitDir, 'src');
 export const litHtml1Config: ApiDocsConfig = {
   repo: 'lit/lit',
   commit: '022f87d7d1f541738dfec130f3635a6962f53887',
+  workDir,
   gitDir,
   tsConfigPath: pathlib.join(gitDir, 'tsconfig.json'),
   pagesOutPath: pathlib.join(workDir, 'pages.json'),

--- a/packages/lit-dev-tools-cjs/src/api-docs/types.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/types.ts
@@ -50,6 +50,11 @@ export interface ApiDocsConfig {
   commit: string;
 
   /**
+   * Directory we can use for storing data about this repo.
+   */
+  workDir: string;
+
+  /**
    * Location where Git repo will be cloned.
    */
   gitDir: string;


### PR DESCRIPTION
- Only bootstrap lit and its dependencies. We were wasting time installing e.g. test dependencies, plus this seemed to be causing some kind of race condition on some of our machines related to installing playwright. Now we shouldn't be installing playwright at all.

- Do a shallow clone of just the one commit we need for each repo, instead of fetching the full history. Much faster clone step.

- Automatically do a fresh clone/setup for each repo if we didn't manage to complete installation last time (previously we would just check if node_modules/ existed, but that could exist even if some subsequent setup step failed). We do this by writing a special file containing the commit SHA only if clone/setup succeeded. Otherwise we won't see this file, and will assume we need a fresh clone/setup.

- Automatically do a fresh clone/setup if the SHA changed. Previously the build would fail and the user had to delete the repo manually.