### PR TITLE
Update sample config for localization

### DIFF
--- a/packages/lit-dev-content/site/docs/localization/overview.md
+++ b/packages/lit-dev-content/site/docs/localization/overview.md
@@ -359,7 +359,8 @@ blank.
   "targetLocales": ["es-419", "zh-Hans"],
   "tsConfig": "./tsconfig.json",
   "output": {
-    "mode": "runtime"
+    "mode": "runtime",
+    "outputDir": "./src/generated/locales"
   },
   "interchange": {
     "format": "xliff",
@@ -377,7 +378,8 @@ blank.
     "src/**/*.js",
   ]
   "output": {
-    "mode": "runtime"
+    "mode": "runtime",
+    "outputDir": "./src/generated/locales"
   },
   "interchange": {
     "format": "xliff",


### PR DESCRIPTION
The existing sample was missing `output.outputDir` which is always a required field for runtime mode so the cli would error when using provided sample as is.