### PR TITLE
Implement tutorial server redirect middleware

### DIFF
--- a/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type Koa from 'koa';
+
+/**
+ * Koa Middleware to serve '/tutorials/view.html' from '/tutorials/*'.
+ *
+ * @param staticRoot Root of the static server
+ */
+export const tutorialsMiddleware = (): Koa.Middleware => async (ctx, next) => {
+  const path = ctx.request.path;
+
+  /**
+   * We want to intercept /tutorials/* but not /tutorials/ itself or the place
+   * where we are currently rendering the markdown to html so not
+   * /tutorials/content/*
+   */
+  if (
+    path.startsWith('/tutorials/') &&
+    !path.startsWith('/tutorials/content/') &&
+    path !== '/tutorials/'
+  ) {
+    // Serve /tutorials/view/
+    ctx.path = '/tutorials/view/index.html';
+  }
+  await next();
+};

--- a/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
@@ -8,13 +8,11 @@ import type Koa from 'koa';
 
 /**
  * Koa Middleware to serve '/tutorials/view.html' from '/tutorials/*'.
- *
- * @param staticRoot Root of the static server
  */
 export const tutorialsMiddleware = (): Koa.Middleware => async (ctx, next) => {
   const path = ctx.request.path;
 
-  /**
+  /*
    * We want to intercept /tutorials/* but not /tutorials/ itself or the place
    * where we are currently rendering the markdown to html so not
    * /tutorials/content/*
@@ -24,7 +22,6 @@ export const tutorialsMiddleware = (): Koa.Middleware => async (ctx, next) => {
     !path.startsWith('/tutorials/content/') &&
     path !== '/tutorials/'
   ) {
-    // Serve /tutorials/view/
     ctx.path = '/tutorials/view/index.html';
   }
   await next();

--- a/packages/lit-dev-server/src/server.ts
+++ b/packages/lit-dev-server/src/server.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import {redirectMiddleware} from './middleware/redirect-middleware.js';
 import {playgroundMiddleware} from './middleware/playground-middleware.js';
+import {tutorialsMiddleware} from './middleware/tutorials-middleware.js';
 import {contentSecurityPolicyMiddleware} from './middleware/content-security-policy-middleware.js';
 import {createGitHubTokenExchangeMiddleware} from './middleware/github-token-exchange-middleware.js';
 import {getEnvironment} from 'lit-dev-tools-cjs/lib/lit-dev-environments.js';
@@ -76,6 +77,7 @@ if (mode === 'playground') {
 
 app.use(koaConditionalGet()); // Needed for etag
 app.use(koaEtag());
+app.use(tutorialsMiddleware());
 app.use(
   koaStatic(staticRoot, {
     // Serve pre-compressed .br and .gz files if available.

--- a/packages/lit-dev-tools-esm/src/dev-server.ts
+++ b/packages/lit-dev-tools-esm/src/dev-server.ts
@@ -9,6 +9,7 @@ import {fileURLToPath} from 'url';
 import * as pathlib from 'path';
 import {redirectMiddleware} from 'lit-dev-server/lib/middleware/redirect-middleware.js';
 import {playgroundMiddleware} from 'lit-dev-server/lib/middleware/playground-middleware.js';
+import {tutorialsMiddleware} from 'lit-dev-server/lib/middleware/tutorials-middleware.js';
 import {contentSecurityPolicyMiddleware} from 'lit-dev-server/lib/middleware/content-security-policy-middleware.js';
 import {fakeGitHubMiddleware} from './fake-github-middleware.js';
 import {createGitHubTokenExchangeMiddleware} from 'lit-dev-server/lib/middleware/github-token-exchange-middleware.js';
@@ -71,10 +72,12 @@ const removeWatchScriptFromPlaygroundFiles: DevServerPlugin = {
   },
 };
 
+const staticRoot = pathlib.join(CONTENT_PKG, ENV.eleventyOutDir);
+
 startDevServer({
   config: {
     port: ENV.mainPort,
-    rootDir: pathlib.join(CONTENT_PKG, ENV.eleventyOutDir),
+    rootDir: staticRoot,
     plugins: [
       dontResolveBareModulesInPlaygroundFiles,
       removeWatchScriptFromPlaygroundFiles,
@@ -92,6 +95,7 @@ startDevServer({
         githubMainUrl: ENV.githubMainUrl,
       }),
       redirectMiddleware(),
+      tutorialsMiddleware(),
     ],
     watch: true,
     nodeResolve: true,


### PR DESCRIPTION
| PR# | Parent | Child |
| -- | -- | -- |
| 1/4 | none | #655 |

## Added

* A redirect from `/tutorials/*` to `/tutorials/view.html`

## Particular items that need review

* [ ] Tutorial middleware
  * [ ] packages/lit-dev-server/src/middleware/tutorials-middleware.ts