### PR TITLE
implement tutorials catalog

### DIFF
--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -37,6 +37,7 @@ export default [
       'lib/components/litdev-example.js',
       'lib/components/litdev-switchable-sample.js',
       'lib/components/litdev-tutorial.js',
+      'lib/components/litdev-tutorial-card.js',
       'lib/components/litdev-search.js',
       'lib/components/playground-elements.js',
       'lib/components/resize-bar.js',

--- a/packages/lit-dev-content/site/css/tutorial-catalog.css
+++ b/packages/lit-dev-content/site/css/tutorial-catalog.css
@@ -1,0 +1,79 @@
+main {
+  display: flex;
+  flex-direction: column;
+}
+
+.category-title {
+  padding-block-start: 0.3em;
+  font-size: 2.2em;
+  font-weight: 400;
+  margin: 0;
+}
+
+.category-subtitle {
+  padding-block-end: 0.8em;
+  margin-block-end: 1.3em;
+  border-block-end: 2px solid var(--color-blue);
+}
+
+.tutorial-category {
+  margin: 0 auto;
+}
+
+.center {
+  display: flex;
+  justify-content: center;
+}
+
+.column {
+  flex-direction: column;
+}
+
+.card-grid {
+  --tutorial-card-width: 300px;
+  --_unit: calc(var(--tutorial-card-width) / 10);
+  padding: var(--_unit);
+  display: grid;
+  gap: var(--_unit);
+  grid-template-columns: repeat(3, 1fr);
+}
+
+/* Help prevent janky layout */
+.card-grid > *:not(:defined) {
+  width: var(--tutorial-card-width);
+  border: 1px solid #3e3e3e;
+  padding: calc(var(--_unit) * 0.5);
+  box-sizing: border-box;
+}
+
+litdev-tutorial-card[size=tiny]:not(:defined) {
+  grid-row: span 1;
+  height: calc(var(--_unit) * 4);
+}
+
+litdev-tutorial-card[size=small]:not(:defined) {
+  grid-row: span 2;
+  height: calc(var(--_unit) * 9);
+}
+
+litdev-tutorial-card[size=medium]:not(:defined) {
+  grid-row: span 3;
+  height: calc(var(--_unit) * 14);
+}
+
+litdev-tutorial-card[size=large]:not(:defined) {
+  grid-row: span 4;
+  height: calc(var(--_unit) * 19);
+}
+
+@media (max-width: 1021px) {
+  .card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 690px) {
+  .card-grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}

--- a/packages/lit-dev-content/site/tutorials/index.html
+++ b/packages/lit-dev-content/site/tutorials/index.html
@@ -11,7 +11,7 @@ title: Tutorials
 
 {% block content %}
 <section class="tutorial-category">
-  <h1 class="category-title" id="learn">Learn</h1>
+  <h1 class="category-title" id="learn-section">Learn</h1>
   <div class="category-subtitle">Learn the features of Lit!</div>
   <div class="center">
     <div class="card-grid">
@@ -38,7 +38,7 @@ title: Tutorials
   </div>
 </section>
 <section class="tutorial-category">
-  <h1 class="category-title" id="build">Build</h1>
+  <h1 class="category-title" id="build-section">Build</h1>
   <div class="category-subtitle">Build new things with Lit!</div>
   <div class="center">
     <div class="card-grid">

--- a/packages/lit-dev-content/site/tutorials/index.html
+++ b/packages/lit-dev-content/site/tutorials/index.html
@@ -1,0 +1,69 @@
+---
+title: Tutorials
+---
+
+{% extends 'default.html' %}
+
+{% block head %}
+  {% inlinecss "tutorial-catalog.css" %}
+  <script type="module" src="{{ site.baseurl }}/js/components/litdev-tutorial-card.js"></script>
+{% endblock %}
+
+{% block content %}
+<section class="tutorial-category">
+  <h1 class="category-title" id="learn">Learn</h1>
+  <div class="category-subtitle">Learn the features of Lit!</div>
+  <div class="center">
+    <div class="card-grid">
+      {% for tutorial in tutorials %}
+        {% if tutorial.category == 'Learn' %}
+          <litdev-tutorial-card
+              size="{{ tutorial.size }}"
+              difficulty="{{ tutorial.difficulty }}"
+              duration="{{ tutorial.duration }}"
+              href="{{ site.baseurl }}/tutorials/{{ tutorial.location }}"
+              {% if tutorial.imgSrc %}
+                img-src="{{ site.baseurl }}/{{ tutorial.imgSrc }}"
+                img-alt="{{ tutorial.imgAlt }}"
+              {% endif %}
+              {% if tutorial.hideDescription %}
+              hide-description
+              {% endif %}>
+            <h1 slot="header">{{ tutorial.header }}</h1>
+            {{ tutorial.description|markdownWithoutHtml|safe }}
+          </litdev-tutorial-card>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</section>
+<section class="tutorial-category">
+  <h1 class="category-title" id="build">Build</h1>
+  <div class="category-subtitle">Build new things with Lit!</div>
+  <div class="center">
+    <div class="card-grid">
+      {% for tutorial in tutorials %}
+        {% if tutorial.category == 'Build' %}
+          <litdev-tutorial-card
+              size="{{ tutorial.size }}"
+              header="{{ tutorial.header }}"
+              difficulty="{{ tutorial.difficulty }}"
+              duration="{{ tutorial.duration }}"
+              href="{{ site.baseurl }}/tutorials/{{ tutorial.location }}"
+              {% if tutorial.imgSrc %}
+                img-src="{{ site.baseurl }}/{{ tutorial.imgSrc }}"
+                img-alt="{{ tutorial.imgAlt }}"
+              {% endif %}
+              {% if tutorial.hideDescription %}
+              hide-description
+              {% endif %}>
+            <h1 slot="header">{{ tutorial.header }}</h1>
+            {{ tutorial.description|markdownWithoutHtml|safe }}
+          </litdev-tutorial-card>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
+++ b/packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
@@ -26,15 +26,16 @@ const loadTutorialData = async (dirname) => {
  *   To be consumed by the tutorials catalog (/tutorials/index.html).
  */
 module.exports = async () => {
+  const tutorials = await Promise.all([
+    // Learn
+    loadTutorialData('intro-to-lit'),
+    loadTutorialData('advanced-templating'),
+
+    // Build
+    loadTutorialData('brick-viewer'),
+  ]);
   /*
    * tutorial data in order of rendering on the page
    */
-  return {eleventyComputed: {tutorials: [
-    // Learn
-    await loadTutorialData('intro-to-lit'),
-    await loadTutorialData('advanced-templating'),
-
-    // Build
-    await loadTutorialData('brick-viewer'),
-  ]}};
+  return {eleventyComputed: {tutorials}};
 }

--- a/packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
+++ b/packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
@@ -1,0 +1,40 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+/**
+ * Given a dirname, will load the tutorial's tutorial.json and description.md,
+ * files and return a full tutorial data object.
+ *
+ * @param {string} dirname Name of the tutorial's directory in /samples
+ * @returns {Promise<Object>} Tutorial data to be consumed by
+ *     /tutorials/index.html
+ */
+const loadTutorialData = async (dirname) => {
+  const tutorialDir = path.resolve(__dirname, '../../samples/tutorials', dirname);
+  const encoding = {encoding: 'utf8'};
+
+  const manifestProm = fs.readFile(path.join(tutorialDir, 'tutorial.json'), encoding);
+  const descriptionProm = fs.readFile(path.join(tutorialDir, 'description.md'), encoding);
+  const [manifest, description] = await Promise.all([manifestProm, descriptionProm]);
+  return {...JSON.parse(manifest), description, location: dirname};
+};
+
+/**
+ * 11ty data JS loader.
+ *
+ * @returns {Promise<{eleventyComputed: {tutorials: Object[]}}>} 11ty data
+ *   To be consumed by the tutorials catalog (/tutorials/index.html).
+ */
+module.exports = async () => {
+  /*
+   * tutorial data in order of rendering on the page
+   */
+  return {eleventyComputed: {tutorials: [
+    // Learn
+    await loadTutorialData('intro-to-lit'),
+    await loadTutorialData('advanced-templating'),
+
+    // Build
+    await loadTutorialData('brick-viewer'),
+  ]}};
+}

--- a/packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
+++ b/packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 const fs = require('fs').promises;
 const path = require('path');
 

--- a/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
@@ -163,7 +163,7 @@ export class LitdevTutorialCard extends LitElement {
 
     :host(:hover) #root,
     :host(:focus-within) #root {
-      /* traslate the root / content to up right */
+      /* translate the root / content to up right */
       transform: translate(
         calc(var(--_unit) * 0.125),
         calc(var(--_unit) * -0.125)
@@ -277,8 +277,11 @@ export class LitdevTutorialCard extends LitElement {
     const hrTrailingS = hrs !== 1 ? 's' : '';
     const minuteTrailingS = mins !== 1 ? 's' : '';
 
+    // TODO(e111077): Make this localizable.
     if (hrs) {
-      return `${hrs} Hr${hrTrailingS} ${mins} Min${minuteTrailingS}`;
+      return `${hrs} Hr${hrTrailingS}${
+        mins ? ` ${mins} Min${minuteTrailingS}` : ''
+      }`;
     }
 
     return `${mins} Minute${minuteTrailingS}`;

--- a/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
@@ -1,0 +1,280 @@
+import {LitElement, html, css} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {when} from 'lit/directives/when.js';
+
+export type CardSize = 'tiny' | 'small' | 'medium' | 'large';
+export type TutorialDifficulty = 'Beginner' | 'Intermediate' | 'Advanced';
+
+@customElement('litdev-tutorial-card')
+export class LitdevTutorialCard extends LitElement {
+  static styles = css`
+    :host {
+      display: inline-flex;
+      --_width: var(--tutorial-card-width, 300px);
+      /* Generate a standardize horizontal grid
+         based off of a unit */
+      --_unit: calc(var(--_width) / 10);
+      --_border-width: 1px;
+      grid-column: span 1;
+      position: relative;
+    }
+
+    :host([size='tiny']) {
+      grid-row: span 1;
+    }
+
+    :host([size='small']) {
+      grid-row: span 2;
+    }
+
+    :host([size='medium']) {
+      grid-row: span 3;
+    }
+
+    :host([size='large']) {
+      grid-row: span 4;
+    }
+
+    #root {
+      width: var(--_width);
+      box-sizing: border-box;
+      padding: calc(var(--_unit) / 2);
+      /* TODO(e111077): change to theme custom prop */
+      border: var(--_border-width) solid #3e3e3e;
+      display: flex;
+      flex-direction: column;
+      text-decoration: none;
+      /* TODO(e111077): change to theme custom prop */
+      color: #3e3e3e;
+      outline: none;
+      position: relative;
+      z-index: 0;
+      /** TODO(e111077): change to theme custom prop */
+      background-color: white;
+    }
+
+    #root > * {
+      margin-block: calc(var(--_unit) * 0.25);
+    }
+
+    #root > *:first-child {
+      margin-block-start: 0;
+    }
+
+    #root > *:last-child {
+      margin-block-end: 0;
+    }
+
+    :host([size='tiny']) #root {
+      /* 5 units = 4 units height + 1 unit grid spacer */
+      height: calc(var(--_unit) * 4);
+    }
+
+    :host([size='small']) #root {
+      /* 10 units = 9 units height + 1 unit grid spacer */
+      height: calc(var(--_unit) * 9);
+    }
+
+    :host([size='medium']) #root {
+      /* 15 units = 14 units height + 1 unit grid spacer */
+      height: calc(var(--_unit) * 14);
+    }
+
+    :host([size='large']) #root {
+      /* 20 units = 19 units height + 1 unit grid spacer */
+      height: calc(var(--_unit) * 19);
+    }
+
+    #image-wrapper {
+      --_height: calc(var(--_unit) * 4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      height: var(--_height);
+      min-height: var(--_height);
+      /* Break out of root padding */
+      margin-inline: calc(var(--_unit) * -0.5);
+    }
+
+    img {
+      width: 100%;
+    }
+
+    #header {
+      font-family: Manrope;
+    }
+
+    #header ::slotted(*) {
+      font-weight: normal;
+      margin: 0;
+      font-size: calc(var(--_unit));
+    }
+
+    #metadata-container {
+      /* TODO(e111077): change to theme custom prop */
+      color: #6f6f6f;
+      display: flex;
+      flex-grow: 1;
+      flex-direction: column;
+      justify-content: space-between;
+      flex-direction: column-reverse;
+    }
+
+    #metadata {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    #description,
+    #metadata {
+      font-family: 'Open Sans', sans-serif;
+      font-size: calc(var(--_unit) * 0.5);
+    }
+
+    #description {
+      overflow-y: hidden;
+    }
+
+    /* Markdown renderer will wrap content in <p> tags. Remove margins on the
+    first and last */
+    #description ::slotted(:first-of-type) {
+      margin-block-start: 0;
+    }
+
+    #description ::slotted(:last-of-type) {
+      margin-block-end: 0;
+    }
+
+    :host::before {
+      content: '';
+      position: absolute;
+      /* Below the content */
+      z-index: -1;
+      inset: 0;
+      transform: translate(0, 0);
+      background-color: var(--color-blue);
+    }
+
+    #root,
+    :host::before {
+      transition: transform 100ms ease-out;
+    }
+
+    :host(:hover) #root,
+    :host(:focus-within) #root {
+      /* traslate the root / content to up right */
+      transform: translate(
+        calc(var(--_unit) * 0.125),
+        calc(var(--_unit) * -0.125)
+      );
+    }
+
+    :host(:hover)::before,
+    :host(:focus-within)::before {
+      /* translate the background down left */
+      transform: translate(
+        calc(var(--_unit) * -0.125),
+        calc(var(--_unit) * 0.125)
+      );
+    }
+
+    @media (prefers-reduced-motion) {
+      :host::before,
+      #root {
+        transition: none;
+      }
+    }
+  `;
+
+  /**
+   * Which card size variant to use:
+   * tiny = 1x0.5
+   * small = 1x1
+   * medium = 1x1.5
+   * large = 1x2
+   */
+  @property({type: String, reflect: true}) size: CardSize = 'small';
+
+  /**
+   * Optional src for the image
+   */
+  @property({attribute: 'img-src'}) imgSrc = '';
+
+  /**
+   * Alt text for the image;
+   */
+  @property({attribute: 'img-alt'}) imgAlt = '';
+
+  /**
+   * Difficulty of the tutorial
+   */
+  @property() difficulty = 'Beginner';
+
+  /**
+   * Duration of the tutorial in minutes
+   */
+  @property({type: Number}) duration = 0;
+
+  /**
+   * Whether or not to hide the description. Used when there is no description
+   * and we don't what the whitespace associated with the node.
+   */
+  @property({type: Boolean, attribute: 'hide-description'}) hideDescription =
+    false;
+
+  /**
+   * Link to tutorial
+   */
+  @property() href = '';
+
+  render() {
+    return html` <a id="root" href=${this.href}>
+      <section id="header">
+        <slot name="header"></slot>
+      </section>
+      ${when(this.imgSrc && this.size !== 'tiny', () => this.renderImg())}
+      ${when(!this.hideDescription, () => this.renderDescription())}
+      <section id="metadata-container">
+        <div id="metadata">
+          <div id="difficulty">${this.difficulty}</div>
+          <div id="duration">${this.calculateDurationStr(this.duration)}</div>
+        </div>
+      </section>
+    </a>`;
+  }
+
+  private renderImg() {
+    return html` <div id="image-wrapper">
+      <img src=${this.imgSrc} alt=${this.imgAlt} />
+    </div>`;
+  }
+
+  private renderDescription() {
+    return html`
+      <section id="description">
+        <slot></slot>
+      </section>
+    `;
+  }
+
+  /**
+   * Calculates the user readable string of "X Hrs Y Mins" or "Z Minutes" if
+   * under an hour given a duration in minutes.
+   *
+   * @param duration Duration in Minutes
+   * @returns A user-readable string of hours and minutes
+   */
+  private calculateDurationStr(duration: number) {
+    const hrs = Math.floor(duration / 60);
+    const mins = duration % 60;
+    const hrTrailingS = hrs !== 1 ? 's' : '';
+    const minuteTrailingS = mins !== 1 ? 's' : '';
+
+    if (hrs) {
+      return `${hrs} Hr${hrTrailingS} ${mins} Min${minuteTrailingS}`;
+    }
+
+    return `${mins} Minute${minuteTrailingS}`;
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
@@ -3,7 +3,7 @@ import {customElement, property} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 
 export type CardSize = 'tiny' | 'small' | 'medium' | 'large';
-export type TutorialDifficulty = 'Beginner' | 'Intermediate' | 'Advanced';
+export type TutorialDifficulty = '' | 'Beginner' | 'Intermediate' | 'Advanced';
 
 @customElement('litdev-tutorial-card')
 export class LitdevTutorialCard extends LitElement {
@@ -209,7 +209,7 @@ export class LitdevTutorialCard extends LitElement {
   /**
    * Difficulty of the tutorial
    */
-  @property() difficulty = 'Beginner';
+  @property() difficulty: TutorialDifficulty = '';
 
   /**
    * Duration of the tutorial in minutes
@@ -235,12 +235,15 @@ export class LitdevTutorialCard extends LitElement {
       </section>
       ${when(this.imgSrc && this.size !== 'tiny', () => this.renderImg())}
       ${when(!this.hideDescription, () => this.renderDescription())}
-      <section id="metadata-container">
-        <div id="metadata">
-          <div id="difficulty">${this.difficulty}</div>
-          <div id="duration">${this.calculateDurationStr(this.duration)}</div>
-        </div>
-      </section>
+      ${when(
+        this.duration || this.difficulty,
+        () => html`<section id="metadata-container">
+          <div id="metadata">
+            <div id="difficulty">${this.difficulty}</div>
+            <div id="duration">${this.calculateDurationStr(this.duration)}</div>
+          </div>
+        </section>`
+      )}
     </a>`;
   }
 
@@ -260,12 +263,15 @@ export class LitdevTutorialCard extends LitElement {
 
   /**
    * Calculates the user readable string of "X Hrs Y Mins" or "Z Minutes" if
-   * under an hour given a duration in minutes.
+   * under an hour given a duration in minutes. Empty string if duration is 0.
    *
    * @param duration Duration in Minutes
    * @returns A user-readable string of hours and minutes
    */
   private calculateDurationStr(duration: number) {
+    if (duration === 0) {
+      return '';
+    }
     const hrs = Math.floor(duration / 60);
     const mins = duration % 60;
     const hrTrailingS = hrs !== 1 ? 's' : '';

--- a/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';

--- a/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
@@ -6,11 +6,30 @@
 
 import type Koa from 'koa';
 
+const TUTORIAL_MOD = 'tutorialCatalog';
+
 /**
- * Koa Middleware to serve '/tutorials/view.html' from '/tutorials/*'.
+ * Koa Middleware to serve '/tutorials/view.html' from '/tutorials/*' and to
+ * redirect to tutorial if tutorialCatalog mod is not enabled.
  */
 export const tutorialsMiddleware = (): Koa.Middleware => async (ctx, next) => {
   const path = ctx.request.path;
+  const modsQuery = ctx.request.query.mods;
+  let hasTutorialsMod = false;
+
+  if (typeof modsQuery === 'string' || modsQuery instanceof String) {
+    hasTutorialsMod = modsQuery.split(' ').includes(TUTORIAL_MOD);
+  } else if (modsQuery instanceof Array) {
+    hasTutorialsMod = modsQuery.includes(TUTORIAL_MOD);
+  }
+
+  // If acccessing /tutorials or /tutorials/ but there is no
+  // ?mods=tutorialCatalog query, then redirect to /tutorial
+  if ((path === '/tutorials/' || path === '/tutorials') && !hasTutorialsMod) {
+    ctx.redirect(
+      `/tutorial${ctx.request.querystring ? `?${ctx.request.querystring}` : ''}`
+    );
+  }
 
   // We want to intercept /tutorials/* but not /tutorials/ itself or the place
   // where we are currently rendering the markdown to html so not


### PR DESCRIPTION
| PR# | Parent | Child |
| -- | -- | -- |
| 4/4 | #661 | none |

## Added

* Added a tutorial catalog
  * Created litdev-tutorial-card
* A data pipeline that renders and creates tutorial manifests

## Particular items that need review

* [ ] Data pipeline architecture
  * [ ] packages/lit-dev-content/site/tutorials/tutorials.11tydata.js
* [ ] Component implementation
  * [ ] packages/lit-dev-content/src/components/litdev-tutorial-card.ts
* [ ] UI of the catalog
  * [ ] packages/lit-dev-content/site/tutorials/index.html
    * Access at the preview link below + /tutorials/
    * How should we go about the categories?
    * Do the categories look good?
    * Arthur should take a look at the wording of the sections and possibly even the sections that should exist