### PR TITLE
Disambiguate static HTMLSlotElement syntax and slot instance.

### DIFF
--- a/packages/lit-dev-content/site/docs/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/components/shadow-dom.md
@@ -208,7 +208,7 @@ For more information, see [HTMLSlotElement](https://developer.mozilla.org/en-US/
 ### @queryAssignedElements and @queryAssignedNodes decorators { #query-assigned-nodes }
 
 `@queryAssignedElements` and `@queryAssignedNodes` convert a class property into a getter that returns the result of calling
-[`HTMLSlot.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements) or [`HTMLSlot.assignedNodes`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes) respectively on a given slot in the component's shadow tree.
+[`slot.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements) or [`slot.assignedNodes`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes) respectively on a given slot in the component's shadow tree.
 Use these to query the elements or nodes assigned to a given slot.
 
 Both accept an optional object with the following properties:


### PR DESCRIPTION
Fix as `HTMLSlot` doesn't mean anything. It's neither HTMLSlotElement
which could mislead the reader into thinking `assignedElements`
is static.

Documentation in [section above](https://lit.dev/docs/components/shadow-dom/#:~:text=slot.assignedNodes%20or%20slot.assignedElements) uses `slot` as the implicit reference to the
HTMLSlotElement instance.

Thus this change introduces consistent naming.

Thank you!