### PR TITLE
Add 404 not found page

### DIFF
--- a/packages/lit-dev-content/site/404.html
+++ b/packages/lit-dev-content/site/404.html
@@ -1,0 +1,18 @@
+---
+title: Not Found
+---
+
+{% extends 'default.html' %}
+
+{% block head %}
+  {% inlinecss "404.css" %}
+{% endblock %}
+
+{% block content %}
+
+<article id="container-404">
+  <h1>404</h1>
+  <p>Sorry, we couldn't find that page.</p>
+</article>
+
+{% endblock %}

--- a/packages/lit-dev-content/site/css/404.css
+++ b/packages/lit-dev-content/site/css/404.css
@@ -1,0 +1,16 @@
+#container-404 {
+  max-width: 800px;
+  margin: auto;
+  padding: 64px 0;
+  text-align: center;
+}
+
+h1 {
+  color: #555;
+  font-size: 42px;
+  font-weight: 400;
+}
+
+#footerTop {
+  border-top: 1px solid var(--color-blue);
+}

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -16,6 +16,7 @@
     "koa": "^2.13.0",
     "koa-conditional-get": "^3.0.0",
     "koa-etag": "^4.0.0",
+    "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",
     "lit-dev-tools-cjs": "^0.0.0",
     "node-fetch": "^3.0.0"
@@ -24,6 +25,7 @@
     "@types/koa": "^2.11.6",
     "@types/koa-conditional-get": "^2.0.0",
     "@types/koa-etag": "^3.0.0",
+    "@types/koa-send": "^4.1.3",
     "@types/koa-static": "^4.0.1",
     "@types/node-fetch": "^3.0.3"
   }

--- a/packages/lit-dev-server/src/middleware/notfound-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/notfound-middleware.ts
@@ -12,12 +12,12 @@ import type Koa from 'koa';
  * Creates a Koa middleware that serves a 404.html page on 404 status codes.
  */
 export const notFoundMiddleware =
-  (staticPath: string): Koa.Middleware =>
+  (staticRoot: string): Koa.Middleware =>
   async (ctx, next) => {
     // Run other middleware first, so the 404 is handled last.
     await next();
 
     if (ctx.status === 404) {
-      await send(ctx, '/404/index.html', {root: staticPath});
+      await send(ctx, '/404/index.html', {root: staticRoot});
     }
   };

--- a/packages/lit-dev-server/src/middleware/notfound-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/notfound-middleware.ts
@@ -9,11 +9,14 @@ import send from 'koa-send';
 import type Koa from 'koa';
 
 /**
- * Create a Koa middleware that serves a 404.html page on 404 status codes.
+ * Creates a Koa middleware that serves a 404.html page on 404 status codes.
  */
 export const notFoundMiddleware =
   (staticPath: string): Koa.Middleware =>
-  async (ctx) => {
+  async (ctx, next) => {
+    // Run other middleware first, so the 404 is handled last.
+    await next();
+
     if (ctx.status === 404) {
       await send(ctx, '/404/index.html', {root: staticPath});
     }

--- a/packages/lit-dev-server/src/middleware/notfound-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/notfound-middleware.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import send from 'koa-send';
+
+import type Koa from 'koa';
+
+/**
+ * Create a Koa middleware that serves a 404.html page on 404 status codes.
+ */
+export const notFoundMiddleware =
+  (staticPath: string): Koa.Middleware =>
+  async (ctx) => {
+    if (ctx.status === 404) {
+      await send(ctx, '/404/index.html', {root: staticPath});
+    }
+  };

--- a/packages/lit-dev-server/src/server.ts
+++ b/packages/lit-dev-server/src/server.ts
@@ -16,6 +16,7 @@ import {playgroundMiddleware} from './middleware/playground-middleware.js';
 import {tutorialsMiddleware} from './middleware/tutorials-middleware.js';
 import {contentSecurityPolicyMiddleware} from './middleware/content-security-policy-middleware.js';
 import {createGitHubTokenExchangeMiddleware} from './middleware/github-token-exchange-middleware.js';
+import {notFoundMiddleware} from './middleware/notfound-middleware.js';
 import {getEnvironment} from 'lit-dev-tools-cjs/lib/lit-dev-environments.js';
 
 const ENV = getEnvironment();
@@ -92,6 +93,7 @@ app.use(
     },
   })
 );
+app.use(notFoundMiddleware(staticRoot));
 
 const server = app.listen(port);
 console.log(`server listening on port ${port}`);


### PR DESCRIPTION
Issue: https://github.com/lit/lit.dev/issues/666

Previously 404 status would return "Not found" text without any user action to return to lit.dev flow. This change adds a very lightweight 404 page and not found middleware.

Previous behavior: https://lit.dev/invalid/path
New behavior: https://pr668-bd7a32c---lit-dev-5ftespv5na-uc.a.run.app/invalid/path

### How

 - Installed https://github.com/koajs/send (a transitive dependency of koajs static) for streaming a file.
 - Added a lightweight notfound middleware as a final middleware that intercepts 404 status codes.
 - Light 404.html and 404.css (inspired by the Blog index styles).

### Testing

This was tested manually.

Screenshot:
<img width="1884" alt="Screen Shot 2022-01-27 at 9 34 03 AM" src="https://user-images.githubusercontent.com/15080861/151412637-f21e5555-b6f5-4fc9-9812-1a6e689944c2.png">

