### PR TITLE
Fix missing robots.txt sending invalid html 404 page

### DIFF
--- a/packages/lit-dev-content/site/robots.html
+++ b/packages/lit-dev-content/site/robots.html
@@ -1,0 +1,7 @@
+---
+permalink: /robots.txt
+eleventyExcludeFromCollections: true
+layout: ''
+---
+# An empty robots.txt is the same as no robots.txt, except that it prevents
+# sending a 404.html page which is invalid.

--- a/packages/lit-dev-server/src/server.ts
+++ b/packages/lit-dev-server/src/server.ts
@@ -74,6 +74,7 @@ if (mode === 'playground') {
     })
   );
   app.use(redirectMiddleware());
+  app.use(notFoundMiddleware(staticRoot));
 }
 
 app.use(koaConditionalGet()); // Needed for etag
@@ -93,7 +94,6 @@ app.use(
     },
   })
 );
-app.use(notFoundMiddleware(staticRoot));
 
 const server = app.listen(port);
 console.log(`server listening on port ${port}`);


### PR DESCRIPTION
### Context

A missing robots.txt is equivalent to an empty robots.txt.

However after adding a 404 page, we now send invalid html instead of nothing.

This was tested via lighthouse testing which flagged the invalid robots.txt file in the SEO test. After this change, the failing SEO test passes.

I also moved the `notfound-middleware` into the site block, as there is no 404 file defined for the playground branch of the server leading to local errors.

### Testing

Tested against lighthouse test.