### PR TITLE
Increase tutorial-card image height

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial-card.ts
@@ -92,7 +92,7 @@ export class LitdevTutorialCard extends LitElement {
     }
 
     #image-wrapper {
-      --_height: calc(var(--_unit) * 4);
+      --_height: calc(var(--_unit) * 5);
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
increase image height to 5x unit so that the image ratio is 2:1 rather than 5:2