### PR TITLE
[tutorials] make "after" directory optional

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -99,9 +99,10 @@ interface TutorialManifest {
   steps: {
     // Title of the current step
     title: string;
-    // If false or omitted, the "after" code will beset to the "before" code of
+    // If false or omitted, the "after" code will be set to the "before" code of
     // the next step. This is useful for reducing code duplication when the
-    // next step is the resolved code for the previous step.
+    // next step is the "solved" code for the previous step.
+    //
     // Set to true if there is an "after" directory for this step or if it is
     // the last step in the tutorial.
     hasAfter?: boolean;

--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -98,6 +98,12 @@ interface TutorialManifest {
   steps: {
     // Title of the current step
     title: string;
+    // If false or omitted, the "after" code will beset to the "before" code of
+    // the next step. This is useful for reducing code duplication when the
+    // next step is the resolved code for the previous step.
+    // Set to true if there is an "after" directory for this step or if it is
+    // the last step in the tutorial.
+    hasAfter?: boolean;
   }[]
 }
 ```

--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Lit tutorials are a way to provide a guided, interactive learning experience to 
 
 * `before/` holds the playground project for what is first presented to the user
 * `after/` holds the playground project for when the user clicks the `solve` button.
+  * If `hasAfter` is `false` or `undefined` for this step's metadata in `tutorial.json`, then the `after/` directory is optional and the step will load the next step's `before/` directory
 </details>
 
 <details>

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/00/after/index.html
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/00/after/index.html
@@ -1,1 +1,0 @@
-<div>Hello world step 1 completed!</div>

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/00/after/project.json
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/00/after/project.json
@@ -1,6 +1,0 @@
-{
-  "extends": "/samples/base.json",
-  "files": {
-    "index.html": {}
-  }
-}

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/00/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/00/before/index.html
@@ -1,1 +1,4 @@
-<div>Hello world step 1!</div>
+<div>
+  There is no "after" directory in this one. The "after" code is the "before"
+  code of the next step
+</div>

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/01/after/index.html
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/01/after/index.html
@@ -1,1 +1,1 @@
-<div>Hello world completed!</div>
+<div>This is the "after" code of the last step!</div>

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/01/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/01/before/index.html
@@ -1,1 +1,1 @@
-<div>Hello world!</div>
+<div>This is the "before" Code of step 2</div>

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/tutorial.json
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/tutorial.json
@@ -11,7 +11,8 @@
         "title": "Advanced Templating!"
       },
       {
-        "title": "Yer done!"
+        "title": "Yer done!",
+        "hasAfter": true
       }
     ]
 }

--- a/packages/lit-dev-content/samples/tutorials/brick-viewer/tutorial.json
+++ b/packages/lit-dev-content/samples/tutorials/brick-viewer/tutorial.json
@@ -8,10 +8,12 @@
   "imgAlt": "This is the Lit icon",
   "steps": [
     {
-      "title": "Build a Brick Viewer"
+      "title": "Build a Brick Viewer",
+      "hasAfter": true
     },
     {
-      "title": "Ya Bricked it!"
+      "title": "Ya Bricked it!",
+      "hasAfter": true
     }
   ]
 }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/tutorial.json
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/tutorial.json
@@ -6,28 +6,36 @@
   "category": "Learn",
   "steps": [
     {
-      "title": "Lit tutorial"
+      "title": "Lit tutorial",
+      "hasAfter": true
     },
     {
-      "title": "Define a component"
+      "title": "Define a component",
+      "hasAfter": true
     },
     {
-      "title": "Properties and expressions"
+      "title": "Properties and expressions",
+      "hasAfter": true
     },
     {
-      "title": "Declarative event listeners"
+      "title": "Declarative event listeners",
+      "hasAfter": true
     },
     {
-      "title": "More expressions"
+      "title": "More expressions",
+      "hasAfter": true
     },
     {
-      "title": "Template logic"
+      "title": "Template logic",
+      "hasAfter": true
     },
     {
-      "title": "Styles"
+      "title": "Styles",
+      "hasAfter": true
     },
     {
-      "title": "Finishing touches"
+      "title": "Finishing touches",
+      "hasAfter": true
     }
   ]
 }

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -29,6 +29,7 @@ import {Task, TaskStatus} from '@lit-labs/task';
 
 export interface TutorialStep {
   title: string;
+  hasAfter?: boolean;
 }
 
 export interface TutorialManifest {
@@ -520,6 +521,13 @@ export class LitDevTutorial extends LitElement {
    */
   private _idxToInfo(idx: number): ExpandedTutorialStep {
     const slug = this._idxToSlug(idx);
+    // The "after"'s code is located in the before dir of the next step
+    let afterSlug = `${this._idxToSlug(idx + 1)}/before`;
+
+    // if the user specified this step has an after, use that
+    if (this._manifest.steps[idx].hasAfter) {
+      afterSlug = `${slug}/after`;
+    }
 
     const firstUrl = this.useOldUrl
       ? '/tutorial/'
@@ -534,7 +542,7 @@ export class LitDevTutorial extends LitElement {
       url: idx === 0 ? firstUrl : nextUrl,
       htmlSrc: `/tutorials/content/${this._projectLocation}/${slug}/`,
       projectSrcBefore: `${this._samplesRoot}/tutorials/${this._projectLocation}/${slug}/before/project.json`,
-      projectSrcAfter: `${this._samplesRoot}/tutorials/${this._projectLocation}/${slug}/after/project.json`,
+      projectSrcAfter: `${this._samplesRoot}/tutorials/${this._projectLocation}/${afterSlug}/project.json`,
     };
   }
 }


### PR DESCRIPTION
Tutorial manifest now has 

```ts
interface TutorialStep {
  title: string;
  hasAfter?: boolean;
}
```

if `hasAfter` is not defined, then the `solve` button will load the `before/` directory of the next step. If `hasAfter` is defined as `true` for that step, then the `solve` button will load the `after/` directory of that step.

Commits without tutorial refactoring:

https://github.com/lit/lit.dev/pull/686/files/8b816e8017d2fa80fe2301573ec1f80b5f05854f..HEAD