### PR TITLE
Fix broken 404 pages with file extensions and 404 status

### DIFF
--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -234,8 +234,8 @@ export const contentSecurityPolicyMiddleware = (
     }
     ctx.set('Content-Security-Policy', policy);
     await next();
-    if (ctx['404-csp-intercept']) {
-      // If the 404 middleware has run, use a more forgiving CSP policy.
+    if (ctx.status === 404) {
+      // Ensure 404 page can render with less strict policy.
       ctx.set('Content-Security-Policy', entrypointsCsp);
     }
   };

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -212,6 +212,7 @@ export const contentSecurityPolicyMiddleware = (
   );
 
   return async (ctx, next) => {
+    await next();
     let policy: string;
     // Note we can't rely on ctx.type being set by the downstream middleware,
     // because for a 304 Not Modified response, the Content-Type header will not
@@ -223,7 +224,7 @@ export const contentSecurityPolicyMiddleware = (
     // 304 responses, we cover the case where the CSP has changed, but the
     // file's content (and hence ETag) has not. Note this approach would not
     // work if we were using nonces instead of hashes.
-    if (ctx.path.endsWith('/')) {
+    if (ctx.path.endsWith('/') || ctx.status === 404) {
       policy = entrypointsCsp;
     } else if (ctx.path.endsWith('/playground-typescript-worker.js')) {
       policy = playgroundWorkerCsp;
@@ -233,10 +234,5 @@ export const contentSecurityPolicyMiddleware = (
       policy = strictFallbackCsp;
     }
     ctx.set('Content-Security-Policy', policy);
-    await next();
-    if (ctx.status === 404) {
-      // Ensure 404 page can render with less strict policy.
-      ctx.set('Content-Security-Policy', entrypointsCsp);
-    }
   };
 };

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -233,6 +233,10 @@ export const contentSecurityPolicyMiddleware = (
       policy = strictFallbackCsp;
     }
     ctx.set('Content-Security-Policy', policy);
-    return next();
+    await next();
+    if (ctx['404-csp-intercept']) {
+      // If the 404 middleware has run, use a more forgiving CSP policy.
+      ctx.set('Content-Security-Policy', entrypointsCsp);
+    }
   };
 };

--- a/packages/lit-dev-server/src/middleware/notfound-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/notfound-middleware.ts
@@ -18,9 +18,7 @@ export const notFoundMiddleware =
     await next();
 
     if (ctx.status === 404) {
-      // 404-csp-intercept communicates to the CSP middleware that a 404 page
-      // was sent, allowing an adequate CSP policy to be set.
-      ctx['404-csp-intercept'] = true;
       await send(ctx, '/404/index.html', {root: staticRoot});
+      ctx.status = 404;
     }
   };

--- a/packages/lit-dev-server/src/middleware/notfound-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/notfound-middleware.ts
@@ -18,6 +18,9 @@ export const notFoundMiddleware =
     await next();
 
     if (ctx.status === 404) {
+      // 404-csp-intercept communicates to the CSP middleware that a 404 page
+      // was sent, allowing an adequate CSP policy to be set.
+      ctx['404-csp-intercept'] = true;
       await send(ctx, '/404/index.html', {root: staticRoot});
     }
   };


### PR DESCRIPTION
Currently a 404 url that doesn't end in a `/` causes a very strict CSP policy to be sent. This results in a very broken page being rendered on the browser. There was a second bug where a 404 page was always being set to a status of `200`.

Repro for CSP issue: https://lit.dev/test.ext
Repro of 200 status: https://lit.dev/repro/


Thank you to @aomarks for thinking of the general technique and proposing this solution.

Fix is to set a `404` status code after the the notfound middleware sends the 404 html page, and set a less strict CSP policy for 404 status codes.