### PR TITLE
[tutorials] fix CSP errors

### DIFF
--- a/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/tutorials-middleware.ts
@@ -39,7 +39,8 @@ export const tutorialsMiddleware = (): Koa.Middleware => async (ctx, next) => {
     !path.startsWith('/tutorials/content/') &&
     path !== '/tutorials/'
   ) {
-    ctx.path = '/tutorials/view/index.html';
+    // must end in / and not /index.html in order to fit CSP middleware filter.
+    ctx.path = '/tutorials/view/';
   }
   await next();
 };


### PR DESCRIPTION
The [tutorials are broken](https://lit.dev/tutorials/?mods=tutorialCatalog) by CSP because [CSP middleware](https://github.com/lit/lit.dev/blob/main/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts#L227) checks `ctx.path.endsWith('/')` and we were manually setting path such that it would break that check and instead serve strict CSP.