### PR TITLE
Use semicolon instead of comma for interfaces per style guide.

### DIFF
--- a/packages/lit-dev-content/site/docs/components/defining.md
+++ b/packages/lit-dev-content/site/docs/components/defining.md
@@ -61,7 +61,7 @@ export class MyElement extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "my-element": MyElement,
+    "my-element": MyElement;
   }
 }
 ```

--- a/packages/lit-dev-content/site/docs/tools/publishing.md
+++ b/packages/lit-dev-content/site/docs/tools/publishing.md
@@ -155,7 +155,7 @@ in TypeScript.
 
     declare global {
       interface HTMLElementTagNameMap {
-        "my-element": MyElement,
+        "my-element": MyElement;
       }
     }
     ```


### PR DESCRIPTION
A small syntax change to prefer semicolon for separating interface member declarations.

Style guide reference: https://google.github.io/styleguide/tsguide.html#member-property-declarations
