### PR TITLE
Update playground-elements to v0.15.2

### DIFF
--- a/packages/lit-dev-content/package-lock.json
+++ b/packages/lit-dev-content/package-lock.json
@@ -24,7 +24,7 @@
 				"@material/mwc-textfield": "^0.25.1",
 				"lit": "^2.1.0",
 				"minisearch": "^3.0.4",
-				"playground-elements": "^0.15.0",
+				"playground-elements": "^0.15.2",
 				"tarts": "^1.0.0",
 				"tslib": "^2.2.0"
 			},
@@ -5428,9 +5428,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.0.tgz",
-			"integrity": "sha512-K+YbOHnlGSSBMs7SpfUND8uWMF0bjmc60MrANuQ2w+7GAOSXg64I//TuPE+i22e54c84id/Q9n+o1HQjVJ6qRw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
+			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -12003,9 +12003,9 @@
 			"dev": true
 		},
 		"playground-elements": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.0.tgz",
-			"integrity": "sha512-K+YbOHnlGSSBMs7SpfUND8uWMF0bjmc60MrANuQ2w+7GAOSXg64I//TuPE+i22e54c84id/Q9n+o1HQjVJ6qRw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
+			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -67,7 +67,7 @@
     "@material/mwc-textfield": "^0.25.1",
     "lit": "^2.1.0",
     "minisearch": "^3.0.4",
-    "playground-elements": "^0.15.0",
+    "playground-elements": "^0.15.2",
     "tarts": "^1.0.0",
     "tslib": "^2.2.0"
   }

--- a/packages/lit-dev-tools-cjs/package-lock.json
+++ b/packages/lit-dev-tools-cjs/package-lock.json
@@ -18,7 +18,7 @@
 				"jsdom": "^17.0.0",
 				"minisearch": "^3.0.4",
 				"outdent": "^0.8.0",
-				"playground-elements": "^0.15.0",
+				"playground-elements": "^0.15.2",
 				"playwright": "^1.8.0",
 				"source-map": "^0.7.3",
 				"strip-comments": "^2.0.1",
@@ -2567,9 +2567,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.0.tgz",
-			"integrity": "sha512-K+YbOHnlGSSBMs7SpfUND8uWMF0bjmc60MrANuQ2w+7GAOSXg64I//TuPE+i22e54c84id/Q9n+o1HQjVJ6qRw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
+			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -5549,9 +5549,9 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"playground-elements": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.0.tgz",
-			"integrity": "sha512-K+YbOHnlGSSBMs7SpfUND8uWMF0bjmc60MrANuQ2w+7GAOSXg64I//TuPE+i22e54c84id/Q9n+o1HQjVJ6qRw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
+			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -20,7 +20,7 @@
     "jsdom": "^17.0.0",
     "minisearch": "^3.0.4",
     "outdent": "^0.8.0",
-    "playground-elements": "^0.15.0",
+    "playground-elements": "^0.15.2",
     "playwright": "^1.8.0",
     "source-map": "^0.7.3",
     "strip-comments": "^2.0.1",

--- a/packages/lit-dev-tools-esm/package-lock.json
+++ b/packages/lit-dev-tools-esm/package-lock.json
@@ -16,7 +16,7 @@
 				"chokidar": "^3.5.2",
 				"co-body": "^6.1.0",
 				"fast-glob": "^3.2.9",
-				"playground-elements": "^0.15.0",
+				"playground-elements": "^0.15.2",
 				"prettier": "^2.3.2"
 			}
 		},
@@ -1948,9 +1948,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.0.tgz",
-			"integrity": "sha512-K+YbOHnlGSSBMs7SpfUND8uWMF0bjmc60MrANuQ2w+7GAOSXg64I//TuPE+i22e54c84id/Q9n+o1HQjVJ6qRw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
+			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -4121,9 +4121,9 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"playground-elements": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.0.tgz",
-			"integrity": "sha512-K+YbOHnlGSSBMs7SpfUND8uWMF0bjmc60MrANuQ2w+7GAOSXg64I//TuPE+i22e54c84id/Q9n+o1HQjVJ6qRw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
+			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -20,7 +20,7 @@
     "fast-glob": "^3.2.9",
     "lit-dev-server": "^0.0.0",
     "lit-dev-tools-cjs": "^0.0.0",
-    "playground-elements": "^0.15.0",
+    "playground-elements": "^0.15.2",
     "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
Add the following playground-elements changes to Lit.dev:

https://github.com/google/playground-elements/releases/tag/v0.15.1
https://github.com/google/playground-elements/releases/tag/v0.15.2

Functional changes are:

- Make hidden code blocks readonly to prevent accidental erasure.
- Added Ctrl+/ or Cmd+/ hotkey for toggling line comments.

### Testing

CI and manual testing.

- Manually tested readonly and toggling comments.
- Interestingly the readonly behavior and toggling comments can get a bit weird if you select multiple lines containing a folded region. But it seems to work pretty decently with readonly.


Some interesting cases:

Comment toggling the start of the line when multi lines of css:

<img width="487" alt="Screen Shot 2022-03-24 at 5 13 25 PM" src="https://user-images.githubusercontent.com/15080861/160030087-5d465c2b-12fe-4560-803f-a130cc200e49.png">

However if you drag select over the line and toggle comment it works correctly!!!!!
<img width="529" alt="Screen Shot 2022-03-24 at 5 14 57 PM" src="https://user-images.githubusercontent.com/15080861/160030177-ee5f4412-318e-4eaa-936d-51743001e830.png">

It is also not possible to delete into the readonly hidden section which is nice.
