### PR TITLE
Bump playground-element to 0.15.3

### DIFF
--- a/packages/lit-dev-content/package-lock.json
+++ b/packages/lit-dev-content/package-lock.json
@@ -24,7 +24,7 @@
 				"@material/mwc-textfield": "^0.25.1",
 				"lit": "^2.1.0",
 				"minisearch": "^3.0.4",
-				"playground-elements": "^0.15.2",
+				"playground-elements": "^0.15.3",
 				"tarts": "^1.0.0",
 				"tslib": "^2.2.0"
 			},
@@ -5428,9 +5428,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
-			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.3.tgz",
+			"integrity": "sha512-E1wEgivlI61pFuzL6pVJWYlffIVa5xZ5RXzXvprYL23LCOQZ4r1j9q5bGtK4FzfCDOo/RLSYHUo3BZnUsRtF5A==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -12003,9 +12003,9 @@
 			"dev": true
 		},
 		"playground-elements": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
-			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.3.tgz",
+			"integrity": "sha512-E1wEgivlI61pFuzL6pVJWYlffIVa5xZ5RXzXvprYL23LCOQZ4r1j9q5bGtK4FzfCDOo/RLSYHUo3BZnUsRtF5A==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -67,7 +67,7 @@
     "@material/mwc-textfield": "^0.25.1",
     "lit": "^2.1.0",
     "minisearch": "^3.0.4",
-    "playground-elements": "^0.15.2",
+    "playground-elements": "^0.15.3",
     "tarts": "^1.0.0",
     "tslib": "^2.2.0"
   }

--- a/packages/lit-dev-tools-cjs/package-lock.json
+++ b/packages/lit-dev-tools-cjs/package-lock.json
@@ -18,7 +18,7 @@
 				"jsdom": "^17.0.0",
 				"minisearch": "^3.0.4",
 				"outdent": "^0.8.0",
-				"playground-elements": "^0.15.2",
+				"playground-elements": "^0.15.3",
 				"playwright": "^1.8.0",
 				"source-map": "^0.7.3",
 				"strip-comments": "^2.0.1",
@@ -2567,9 +2567,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
-			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.3.tgz",
+			"integrity": "sha512-E1wEgivlI61pFuzL6pVJWYlffIVa5xZ5RXzXvprYL23LCOQZ4r1j9q5bGtK4FzfCDOo/RLSYHUo3BZnUsRtF5A==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -5549,9 +5549,9 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"playground-elements": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
-			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.3.tgz",
+			"integrity": "sha512-E1wEgivlI61pFuzL6pVJWYlffIVa5xZ5RXzXvprYL23LCOQZ4r1j9q5bGtK4FzfCDOo/RLSYHUo3BZnUsRtF5A==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -20,7 +20,7 @@
     "jsdom": "^17.0.0",
     "minisearch": "^3.0.4",
     "outdent": "^0.8.0",
-    "playground-elements": "^0.15.2",
+    "playground-elements": "^0.15.3",
     "playwright": "^1.8.0",
     "source-map": "^0.7.3",
     "strip-comments": "^2.0.1",

--- a/packages/lit-dev-tools-esm/package-lock.json
+++ b/packages/lit-dev-tools-esm/package-lock.json
@@ -16,7 +16,7 @@
 				"chokidar": "^3.5.2",
 				"co-body": "^6.1.0",
 				"fast-glob": "^3.2.9",
-				"playground-elements": "^0.15.2",
+				"playground-elements": "^0.15.3",
 				"prettier": "^2.3.2"
 			}
 		},
@@ -1948,9 +1948,9 @@
 			}
 		},
 		"node_modules/playground-elements": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
-			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.3.tgz",
+			"integrity": "sha512-E1wEgivlI61pFuzL6pVJWYlffIVa5xZ5RXzXvprYL23LCOQZ4r1j9q5bGtK4FzfCDOo/RLSYHUo3BZnUsRtF5A==",
 			"dependencies": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",
@@ -4121,9 +4121,9 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"playground-elements": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.2.tgz",
-			"integrity": "sha512-XL4MnTIVa/dCWvqAtDgZM9KOyvQtZaas4CEUXrZZmhzFRMRMAe572VBtjpHdulFvn51rJvJsxXcJaTp03RhMBQ==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.15.3.tgz",
+			"integrity": "sha512-E1wEgivlI61pFuzL6pVJWYlffIVa5xZ5RXzXvprYL23LCOQZ4r1j9q5bGtK4FzfCDOo/RLSYHUo3BZnUsRtF5A==",
 			"requires": {
 				"@material/mwc-button": "^0.25.1",
 				"@material/mwc-icon-button": "^0.25.1",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -20,7 +20,7 @@
     "fast-glob": "^3.2.9",
     "lit-dev-server": "^0.0.0",
     "lit-dev-tools-cjs": "^0.0.0",
-    "playground-elements": "^0.15.2",
+    "playground-elements": "^0.15.3",
     "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
Bump playground elements to the release: https://github.com/google/playground-elements/releases/tag/v0.15.3

This fixes a bug with readonly hidden markers leaving behind an invisible character in the editor that cannot be deleted.


### Testing

Manually tested on https://pr737-a0a425e---lit-dev-5ftespv5na-uc.a.run.app/docs/#what-is-it-like-to-develop-with-lit which contains hidden regions.

Previously pressing backspace or delete over the hidden region would get stuck on an invisible readonly marker. Repro on main site: https://lit.dev/docs/#what-is-it-like-to-develop-with-lit

