### PR TITLE
Update generated docs for Lit v2.2.2

### DIFF
--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -6,7 +6,7 @@
       "v1": "api/lit-element/LitElement/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "LitElement",
@@ -18,7 +18,7 @@
         "sources": [
           {
             "fileName": "packages/lit-element/src/lit-element.ts",
-            "line": 87,
+            "line": 115,
             "moduleSpecifier": "lit-element/lit-element.js"
           }
         ],
@@ -75,7 +75,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 986,
+                    "line": 1055,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -169,7 +169,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 518,
+                    "line": 587,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -232,7 +232,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 870,
+                    "line": 939,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -293,7 +293,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 885,
+                    "line": 954,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -365,7 +365,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 374,
+                    "line": 443,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -438,7 +438,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 336,
+                    "line": 405,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -487,7 +487,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 355,
+                    "line": 424,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -562,7 +562,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 160,
+                    "line": 188,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -610,7 +610,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 184,
+                    "line": 212,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -667,7 +667,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 409,
+                    "line": 478,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -732,7 +732,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 674,
+                    "line": 743,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -784,7 +784,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 95,
+                    "line": 123,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -831,7 +831,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 559,
+                    "line": 628,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -916,7 +916,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 441,
+                    "line": 510,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -958,7 +958,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 624,
+                    "line": 693,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1067,7 +1067,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 664,
+                    "line": 733,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1142,7 +1142,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 468,
+                    "line": 537,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1189,7 +1189,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 110,
+                    "line": 138,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -1254,7 +1254,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 196,
+                    "line": 224,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -1289,7 +1289,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 103,
+                    "line": 131,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -1325,7 +1325,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 774,
+                    "line": 843,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1381,7 +1381,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 734,
+                    "line": 803,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1430,7 +1430,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 476,
+                    "line": 545,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1479,7 +1479,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 750,
+                    "line": 819,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1555,7 +1555,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 504,
+                    "line": 573,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1605,7 +1605,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 962,
+                    "line": 1031,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1666,7 +1666,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1414,
+                    "line": 1484,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1682,18 +1682,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -1741,7 +1760,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1349,
+                    "line": 1419,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1794,7 +1813,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 811,
+                    "line": 880,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1831,7 +1850,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 804,
+                    "line": 873,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1872,7 +1891,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1186,
+                    "line": 1255,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -1934,7 +1953,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1081,
+                    "line": 1150,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2043,7 +2062,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1165,
+                    "line": 1234,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2108,7 +2127,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1361,
+                    "line": 1431,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2124,18 +2143,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -2181,7 +2219,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
-                    "line": 128,
+                    "line": 156,
                     "moduleSpecifier": "lit-element/lit-element.js"
                   }
                 ],
@@ -2197,18 +2235,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -2253,7 +2310,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1322,
+                    "line": 1392,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2321,7 +2378,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1396,
+                    "line": 1466,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2337,18 +2394,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -2395,7 +2471,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1272,
+                    "line": 1342,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2408,18 +2484,37 @@
                         "name": "_changedProperties",
                         "kindString": "Parameter",
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -2476,7 +2571,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 409,
+                "line": 605,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -2548,7 +2643,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 399,
+                "line": 595,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -2580,7 +2675,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 418,
+                "line": 614,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -2612,7 +2707,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 403,
+                "line": 599,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -2645,7 +2740,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 394,
+            "line": 590,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -2670,7 +2765,7 @@
       "v1": "api/lit-element/UpdatingElement/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "ReactiveElement",
@@ -2684,7 +2779,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 323,
+            "line": 392,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -2752,7 +2847,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 986,
+                    "line": 1055,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2834,7 +2929,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 518,
+                    "line": 587,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2889,7 +2984,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 870,
+                    "line": 939,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -2950,7 +3045,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 885,
+                    "line": 954,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3022,7 +3117,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 374,
+                    "line": 443,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3087,7 +3182,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 336,
+                    "line": 405,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3128,7 +3223,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 355,
+                    "line": 424,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3194,7 +3289,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 943,
+                    "line": 1012,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3229,7 +3324,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 970,
+                    "line": 1039,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3274,7 +3369,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 409,
+                    "line": 478,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3327,7 +3422,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 674,
+                    "line": 743,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3366,7 +3461,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 433,
+                    "line": 502,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3405,7 +3500,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 559,
+                    "line": 628,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3478,7 +3573,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 441,
+                    "line": 510,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3512,7 +3607,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 624,
+                    "line": 693,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3609,7 +3704,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 664,
+                    "line": 733,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3672,7 +3767,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 468,
+                    "line": 537,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3715,7 +3810,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 925,
+                    "line": 994,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3768,7 +3863,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 774,
+                    "line": 843,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3816,7 +3911,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 734,
+                    "line": 803,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3857,7 +3952,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 476,
+                    "line": 545,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3898,7 +3993,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 750,
+                    "line": 819,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -3962,7 +4057,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 504,
+                    "line": 573,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4004,7 +4099,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 962,
+                    "line": 1031,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4053,7 +4148,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1414,
+                    "line": 1484,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4069,18 +4164,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -4116,7 +4230,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1349,
+                    "line": 1419,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4157,7 +4271,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 811,
+                    "line": 880,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4186,7 +4300,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 804,
+                    "line": 873,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4219,7 +4333,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1186,
+                    "line": 1255,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4269,7 +4383,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1081,
+                    "line": 1150,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4378,7 +4492,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1165,
+                    "line": 1234,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4431,7 +4545,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1361,
+                    "line": 1431,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4447,18 +4561,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -4492,7 +4625,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1374,
+                    "line": 1444,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4508,18 +4641,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -4552,7 +4704,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1322,
+                    "line": 1392,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4628,7 +4780,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1396,
+                    "line": 1466,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4644,18 +4796,37 @@
                           "text": "Map of changed properties with old values"
                         },
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -4690,7 +4861,7 @@
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
-                    "line": 1272,
+                    "line": 1342,
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
@@ -4703,18 +4874,37 @@
                         "name": "_changedProperties",
                         "kindString": "Parameter",
                         "type": {
-                          "type": "reference",
-                          "typeArguments": [
+                          "type": "union",
+                          "types": [
                             {
-                              "type": "intrinsic",
-                              "name": "any"
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "intrinsic",
+                                  "name": "any"
+                                }
+                              ],
+                              "name": "PropertyValueMap",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
+                            },
+                            {
+                              "type": "reference",
+                              "typeArguments": [
+                                {
+                                  "type": "reference",
+                                  "name": "PropertyKey"
+                                },
+                                {
+                                  "type": "intrinsic",
+                                  "name": "unknown"
+                                }
+                              ],
+                              "name": "Map"
                             }
-                          ],
-                          "name": "PropertyValues",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyValues"
-                          }
+                          ]
                         }
                       }
                     ],
@@ -4749,7 +4939,7 @@
         "sources": [
           {
             "fileName": "packages/lit-element/src/lit-element.ts",
-            "line": 56,
+            "line": 84,
             "moduleSpecifier": "lit-element/lit-element.js"
           }
         ],
@@ -4901,7 +5091,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 117,
+            "line": 170,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -4955,7 +5145,7 @@
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
-                "line": 158,
+                "line": 211,
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
@@ -4997,7 +5187,7 @@
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
-                "line": 179,
+                "line": 232,
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
@@ -5040,7 +5230,7 @@
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
-                "line": 205,
+                "line": 258,
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
@@ -5073,7 +5263,7 @@
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
-                "line": 188,
+                "line": 241,
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
@@ -5106,7 +5296,7 @@
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
-                "line": 149,
+                "line": 202,
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
@@ -5139,7 +5329,7 @@
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
-                "line": 165,
+                "line": 218,
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
@@ -5212,7 +5402,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 141,
+            "line": 194,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -5255,7 +5445,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 213,
+            "line": 266,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -5294,324 +5484,15 @@
       },
       {
         "name": "PropertyValues",
-        "kindString": "Interface",
+        "kindString": "Type alias",
         "comment": {
-          "shortText": "Map of changed properties with old values. Takes an optional generic\ninterface corresponding to the declared element properties."
+          "shortText": "A Map of property keys to values.",
+          "text": "Takes an optional type parameter T, which when specified as a non-any,\nnon-unknown type, will make the Map more strongly-typed, associating the map\nkeys with their corresponding value type on T.\n\nUse `PropertyValues<this>` when overriding ReactiveElement.update() and\nother lifecycle methods in order to get stronger type-checking on keys\nand values.\n"
         },
-        "children": [
-          {
-            "name": "forEach",
-            "kindString": "Method",
-            "signatures": [
-              {
-                "name": "forEach",
-                "kindString": "Call signature",
-                "parameters": [
-                  {
-                    "name": "callbackfn",
-                    "kindString": "Parameter",
-                    "type": {
-                      "type": "reflection",
-                      "declaration": {
-                        "name": "__type",
-                        "kindString": "Type literal",
-                        "signatures": [
-                          {
-                            "name": "__type",
-                            "kindString": "Call signature",
-                            "typeParameter": [
-                              {
-                                "name": "K",
-                                "kindString": "Type parameter",
-                                "type": {
-                                  "type": "union",
-                                  "types": [
-                                    {
-                                      "type": "intrinsic",
-                                      "name": "string"
-                                    },
-                                    {
-                                      "type": "intrinsic",
-                                      "name": "number"
-                                    },
-                                    {
-                                      "type": "intrinsic",
-                                      "name": "symbol"
-                                    }
-                                  ]
-                                }
-                              }
-                            ],
-                            "parameters": [
-                              {
-                                "name": "value",
-                                "kindString": "Parameter",
-                                "type": {
-                                  "type": "indexedAccess",
-                                  "indexType": {
-                                    "type": "reference",
-                                    "name": "K"
-                                  },
-                                  "objectType": {
-                                    "type": "reference",
-                                    "name": "T"
-                                  }
-                                }
-                              },
-                              {
-                                "name": "key",
-                                "kindString": "Parameter",
-                                "type": {
-                                  "type": "reference",
-                                  "name": "K"
-                                }
-                              },
-                              {
-                                "name": "map",
-                                "kindString": "Parameter",
-                                "type": {
-                                  "type": "reference",
-                                  "typeArguments": [
-                                    {
-                                      "type": "reference",
-                                      "name": "K"
-                                    },
-                                    {
-                                      "type": "indexedAccess",
-                                      "indexType": {
-                                        "type": "typeOperator",
-                                        "operator": "keyof",
-                                        "target": {
-                                          "type": "reference",
-                                          "name": "T"
-                                        }
-                                      },
-                                      "objectType": {
-                                        "type": "reference",
-                                        "name": "T"
-                                      }
-                                    }
-                                  ],
-                                  "name": "Map"
-                                }
-                              }
-                            ],
-                            "type": {
-                              "type": "intrinsic",
-                              "name": "void"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "name": "thisArg",
-                    "kindString": "Parameter",
-                    "flags": {
-                      "isOptional": true
-                    },
-                    "type": {
-                      "type": "intrinsic",
-                      "name": "unknown"
-                    }
-                  }
-                ],
-                "type": {
-                  "type": "intrinsic",
-                  "name": "void"
-                },
-                "overwrites": {
-                  "type": "reference",
-                  "name": "Map.forEach"
-                }
-              }
-            ],
-            "overwrites": {
-              "type": "reference",
-              "name": "Map.forEach"
-            },
-            "entrypointSources": [
-              {
-                "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "moduleSpecifier": "lit"
-              }
-            ],
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "PropertyValues.forEach"
-            }
-          },
-          {
-            "name": "get",
-            "kindString": "Method",
-            "signatures": [
-              {
-                "name": "get",
-                "kindString": "Call signature",
-                "typeParameter": [
-                  {
-                    "name": "K",
-                    "kindString": "Type parameter",
-                    "type": {
-                      "type": "union",
-                      "types": [
-                        {
-                          "type": "intrinsic",
-                          "name": "string"
-                        },
-                        {
-                          "type": "intrinsic",
-                          "name": "number"
-                        },
-                        {
-                          "type": "intrinsic",
-                          "name": "symbol"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "parameters": [
-                  {
-                    "name": "k",
-                    "kindString": "Parameter",
-                    "type": {
-                      "type": "reference",
-                      "name": "K"
-                    }
-                  }
-                ],
-                "type": {
-                  "type": "indexedAccess",
-                  "indexType": {
-                    "type": "reference",
-                    "name": "K"
-                  },
-                  "objectType": {
-                    "type": "reference",
-                    "name": "T"
-                  }
-                },
-                "overwrites": {
-                  "type": "reference",
-                  "name": "Map.get"
-                }
-              }
-            ],
-            "overwrites": {
-              "type": "reference",
-              "name": "Map.get"
-            },
-            "entrypointSources": [
-              {
-                "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "moduleSpecifier": "lit"
-              }
-            ],
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "PropertyValues.get"
-            }
-          },
-          {
-            "name": "set",
-            "kindString": "Method",
-            "signatures": [
-              {
-                "name": "set",
-                "kindString": "Call signature",
-                "typeParameter": [
-                  {
-                    "name": "K",
-                    "kindString": "Type parameter",
-                    "type": {
-                      "type": "union",
-                      "types": [
-                        {
-                          "type": "intrinsic",
-                          "name": "string"
-                        },
-                        {
-                          "type": "intrinsic",
-                          "name": "number"
-                        },
-                        {
-                          "type": "intrinsic",
-                          "name": "symbol"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "parameters": [
-                  {
-                    "name": "key",
-                    "kindString": "Parameter",
-                    "type": {
-                      "type": "reference",
-                      "name": "K"
-                    }
-                  },
-                  {
-                    "name": "value",
-                    "kindString": "Parameter",
-                    "type": {
-                      "type": "indexedAccess",
-                      "indexType": {
-                        "type": "reference",
-                        "name": "K"
-                      },
-                      "objectType": {
-                        "type": "reference",
-                        "name": "T"
-                      }
-                    }
-                  }
-                ],
-                "type": {
-                  "type": "reference",
-                  "typeArguments": [
-                    {
-                      "type": "reference",
-                      "name": "T"
-                    }
-                  ],
-                  "name": "PropertyValues",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "PropertyValues"
-                  }
-                },
-                "overwrites": {
-                  "type": "reference",
-                  "name": "Map.set"
-                }
-              }
-            ],
-            "overwrites": {
-              "type": "reference",
-              "name": "Map.set"
-            },
-            "entrypointSources": [
-              {
-                "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "moduleSpecifier": "lit"
-              }
-            ],
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "PropertyValues.set"
-            }
-          }
-        ],
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 226,
+            "line": 292,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -5625,37 +5506,45 @@
             }
           }
         ],
-        "extendedTypes": [
-          {
+        "type": {
+          "type": "conditional",
+          "checkType": {
+            "type": "reference",
+            "name": "T"
+          },
+          "extendsType": {
+            "type": "intrinsic",
+            "name": "object"
+          },
+          "trueType": {
             "type": "reference",
             "typeArguments": [
               {
-                "type": "typeOperator",
-                "operator": "keyof",
-                "target": {
-                  "type": "reference",
-                  "name": "T"
-                }
+                "type": "reference",
+                "name": "T"
+              }
+            ],
+            "name": "PropertyValueMap",
+            "location": {
+              "page": "misc",
+              "anchor": "PropertyValueMap"
+            }
+          },
+          "falseType": {
+            "type": "reference",
+            "typeArguments": [
+              {
+                "type": "reference",
+                "name": "PropertyKey"
               },
               {
-                "type": "indexedAccess",
-                "indexType": {
-                  "type": "typeOperator",
-                  "operator": "keyof",
-                  "target": {
-                    "type": "reference",
-                    "name": "T"
-                  }
-                },
-                "objectType": {
-                  "type": "reference",
-                  "name": "T"
-                }
+                "type": "intrinsic",
+                "name": "unknown"
               }
             ],
             "name": "Map"
           }
-        ],
+        },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5666,38 +5555,7 @@
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyValues"
-        },
-        "heritage": [
-          {
-            "type": "reference",
-            "typeArguments": [
-              {
-                "type": "typeOperator",
-                "operator": "keyof",
-                "target": {
-                  "type": "reference",
-                  "name": "T"
-                }
-              },
-              {
-                "type": "indexedAccess",
-                "indexType": {
-                  "type": "typeOperator",
-                  "operator": "keyof",
-                  "target": {
-                    "type": "reference",
-                    "name": "T"
-                  }
-                },
-                "objectType": {
-                  "type": "reference",
-                  "name": "T"
-                }
-              }
-            ],
-            "name": "Map"
-          }
-        ]
+        }
       }
     ]
   },
@@ -5708,7 +5566,7 @@
       "v1": "api/lit-html/templates/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "html",
@@ -5723,7 +5581,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 323,
+            "line": 519,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -5796,7 +5654,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 375,
+            "line": 571,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -5832,7 +5690,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 439,
+            "line": 635,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -5848,7 +5706,7 @@
                 "sources": [
                   {
                     "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                    "line": 172
+                    "line": 311
                   }
                 ],
                 "type": {
@@ -5866,7 +5724,7 @@
                 "sources": [
                   {
                     "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                    "line": 173
+                    "line": 312
                   }
                 ],
                 "signatures": [
@@ -5886,7 +5744,7 @@
                 "sources": [
                   {
                     "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                    "line": 171
+                    "line": 310
                   }
                 ],
                 "signatures": [
@@ -5918,7 +5776,7 @@
             "sources": [
               {
                 "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                "line": 169
+                "line": 308
               }
             ],
             "signatures": [
@@ -6078,7 +5936,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 348,
+            "line": 544,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -6144,7 +6002,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 87,
+            "line": 283,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -6161,7 +6019,7 @@
             "sources": [
               {
                 "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                "line": 29
+                "line": 164
               }
             ],
             "signatures": [
@@ -6242,7 +6100,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 268,
+            "line": 464,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -6284,7 +6142,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 259,
+            "line": 455,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -6314,7 +6172,7 @@
                 "sources": [
                   {
                     "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                    "line": 50
+                    "line": 189
                   }
                 ],
                 "type": {
@@ -6328,7 +6186,7 @@
                 "sources": [
                   {
                     "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                    "line": 51
+                    "line": 190
                   }
                 ],
                 "type": {
@@ -6342,7 +6200,7 @@
                 "sources": [
                   {
                     "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                    "line": 52
+                    "line": 191
                   }
                 ],
                 "type": {
@@ -6357,7 +6215,7 @@
             "sources": [
               {
                 "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                "line": 49
+                "line": 188
               }
             ]
           }
@@ -6383,7 +6241,7 @@
       "v1": "api/lit-element/styles/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "adoptStyles",
@@ -6965,7 +6823,7 @@
       "v1": "api/lit-element/decorators/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "customElement",
@@ -8208,7 +8066,7 @@
       "v1": "api/lit-html/directives/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "asyncAppend",
@@ -11646,7 +11504,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/ref.ts",
-            "line": 134,
+            "line": 150,
             "moduleSpecifier": "lit-html/directives/ref.js"
           }
         ],
@@ -11928,7 +11786,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
-                "line": 92,
+                "line": 108,
                 "moduleSpecifier": "lit-html/directives/ref.js"
               }
             ],
@@ -11972,7 +11830,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
-                "line": 102,
+                "line": 118,
                 "moduleSpecifier": "lit-html/directives/ref.js"
               }
             ],
@@ -12016,7 +11874,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
-                "line": 44,
+                "line": 48,
                 "moduleSpecifier": "lit-html/directives/ref.js"
               }
             ],
@@ -12135,7 +11993,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
-                "line": 48,
+                "line": 52,
                 "moduleSpecifier": "lit-html/directives/ref.js"
               }
             ],
@@ -12213,7 +12071,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/ref.ts",
-            "line": 39,
+            "line": 43,
             "moduleSpecifier": "lit-html/directives/ref.js"
           }
         ],
@@ -12259,7 +12117,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/ref.ts",
-            "line": 37,
+            "line": 41,
             "moduleSpecifier": "lit-html/directives/ref.js"
           }
         ],
@@ -13400,12 +13258,12 @@
         },
         "comment": {
           "shortText": "A directive that applies CSS properties to an element.",
-          "text": "`styleMap` can only be used in the `style` attribute and must be the only\nexpression in the attribute. It takes the property names in the `styleInfo`\nobject and adds the property values as CSS properties. Property names with\ndashes (`-`) are assumed to be valid CSS property names and set on the\nelement's style object using `setProperty()`. Names without dashes are\nassumed to be camelCased JavaScript property names and set on the element's\nstyle object using property assignment, allowing the style object to\ntranslate JavaScript-style names to CSS property names.\n\nFor example `styleMap({backgroundColor: 'red', 'border-top': '5px', '--size':\n'0'})` sets the `background-color`, `border-top` and `--size` properties.\n"
+          "text": "`styleMap` can only be used in the `style` attribute and must be the only\nexpression in the attribute. It takes the property names in the\n[styleInfo](/docs/api/directives/#StyleInfo) object and adds the property values as CSS\nproperties. Property names with dashes (`-`) are assumed to be valid CSS\nproperty names and set on the element's style object using `setProperty()`.\nNames without dashes are assumed to be camelCased JavaScript property names\nand set on the element's style object using property assignment, allowing the\nstyle object to translate JavaScript-style names to CSS property names.\n\nFor example `styleMap({backgroundColor: 'red', 'border-top': '5px', '--size':\n'0'})` sets the `background-color`, `border-top` and `--size` properties.\n"
         },
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/style-map.ts",
-            "line": 127,
+            "line": 128,
             "moduleSpecifier": "lit-html/directives/style-map.js"
           }
         ],
@@ -13417,16 +13275,19 @@
               {
                 "name": "styleInfo",
                 "kindString": "Parameter",
-                "comment": {
-                  "text": "\n"
-                },
                 "type": {
                   "type": "reference",
-                  "name": "StyleInfo",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "StyleInfo"
-                  }
+                  "typeArguments": [
+                    {
+                      "type": "reference",
+                      "name": "StyleInfo",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "StyleInfo"
+                      }
+                    }
+                  ],
+                  "name": "Readonly"
                 }
               }
             ],
@@ -13553,11 +13414,17 @@
                     "kindString": "Parameter",
                     "type": {
                       "type": "reference",
-                      "name": "StyleInfo",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "StyleInfo"
-                      }
+                      "typeArguments": [
+                        {
+                          "type": "reference",
+                          "name": "StyleInfo",
+                          "location": {
+                            "page": "directives",
+                            "anchor": "StyleInfo"
+                          }
+                        }
+                      ],
+                      "name": "Readonly"
                     }
                   }
                 ],
@@ -13630,11 +13497,17 @@
                           "isOptional": false,
                           "element": {
                             "type": "reference",
-                            "name": "StyleInfo",
-                            "location": {
-                              "page": "directives",
-                              "anchor": "StyleInfo"
-                            }
+                            "typeArguments": [
+                              {
+                                "type": "reference",
+                                "name": "StyleInfo",
+                                "location": {
+                                  "page": "directives",
+                                  "anchor": "StyleInfo"
+                                }
+                              }
+                            ],
+                            "name": "Readonly"
                           }
                         }
                       ]
@@ -15870,7 +15743,7 @@
       "v1": "api/lit-html/custom-directives/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "AsyncDirective",
@@ -17234,7 +17107,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/lit-html.d.ts",
-                "line": 285
+                "line": 447
               }
             ],
             "signatures": [
@@ -17341,7 +17214,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1449,
+                "line": 1751,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17373,7 +17246,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1450,
+                "line": 1752,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17402,7 +17275,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1451,
+                "line": 1753,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17448,7 +17321,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1458,
+                "line": 1760,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17484,7 +17357,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1444,
+                "line": 1746,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17527,7 +17400,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1470,
+                "line": 1772,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17561,7 +17434,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1443,
+            "line": 1745,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -17736,7 +17609,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1449,
+                "line": 1751,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17776,7 +17649,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1450,
+                "line": 1752,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17813,7 +17686,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1451,
+                "line": 1753,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17867,7 +17740,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1458,
+                "line": 1760,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17911,7 +17784,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1627,
+                "line": 1943,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17946,7 +17819,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1470,
+                "line": 1772,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -17988,7 +17861,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1626,
+            "line": 1942,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -18034,7 +17907,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/lit-html.d.ts",
-                "line": 211
+                "line": 373
               }
             ],
             "signatures": [
@@ -18145,7 +18018,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1068,
+                "line": 1312,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18187,7 +18060,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1067,
+                "line": 1311,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18217,7 +18090,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1175,
+                "line": 1419,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18278,7 +18151,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1148,
+                "line": 1392,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18321,7 +18194,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1167,
+                "line": 1411,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18376,7 +18249,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1066,
+            "line": 1310,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -18693,7 +18566,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/lit-html.d.ts",
-                "line": 318
+                "line": 480
               }
             ],
             "signatures": [
@@ -18774,7 +18647,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1757,
+                "line": 2090,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18803,7 +18676,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1754,
+                "line": 2087,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18845,7 +18718,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1740,
+                "line": 2073,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -18870,7 +18743,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1739,
+            "line": 2072,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -18906,7 +18779,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/lit-html.d.ts",
-                "line": 309
+                "line": 471
               }
             ],
             "signatures": [
@@ -19025,7 +18898,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1449,
+                "line": 1751,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19065,7 +18938,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1450,
+                "line": 1752,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19102,7 +18975,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1451,
+                "line": 1753,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19156,7 +19029,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1458,
+                "line": 1760,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19200,7 +19073,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1658,
+                "line": 1981,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19235,7 +19108,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1470,
+                "line": 1772,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19279,7 +19152,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1729,
+                "line": 2062,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19319,7 +19192,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1657,
+            "line": 1980,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -19620,7 +19493,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1449,
+                "line": 1751,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19660,7 +19533,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1450,
+                "line": 1752,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19697,7 +19570,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1451,
+                "line": 1753,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19751,7 +19624,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1458,
+                "line": 1760,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19795,7 +19668,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1598,
+                "line": 1907,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19830,7 +19703,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1470,
+                "line": 1772,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -19872,7 +19745,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1597,
+            "line": 1906,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -20355,7 +20228,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1057,
+            "line": 1301,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -20491,7 +20364,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 354,
+            "line": 550,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -20524,7 +20397,7 @@
       "v1": "api/lit-html/templates/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "html",
@@ -20539,7 +20412,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/static.ts",
-            "line": 133,
+            "line": 169,
             "moduleSpecifier": "lit-html/static.js"
           }
         ],
@@ -20612,7 +20485,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/static.ts",
-            "line": 55,
+            "line": 93,
             "moduleSpecifier": "lit-html/static.js"
           }
         ],
@@ -20645,27 +20518,8 @@
               }
             ],
             "type": {
-              "type": "reflection",
-              "declaration": {
-                "name": "__type",
-                "kindString": "Type literal",
-                "children": [
-                  {
-                    "name": "_$litStatic$",
-                    "kindString": "Property",
-                    "sources": [
-                      {
-                        "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/static.d.ts",
-                        "line": 39
-                      }
-                    ],
-                    "type": {
-                      "type": "intrinsic",
-                      "name": "unknown"
-                    }
-                  }
-                ]
-              }
+              "type": "reference",
+              "name": "StaticValue"
             }
           }
         ],
@@ -20694,7 +20548,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/static.ts",
-            "line": 141,
+            "line": 177,
             "moduleSpecifier": "lit-html/static.js"
           }
         ],
@@ -20767,7 +20621,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/static.ts",
-            "line": 26,
+            "line": 63,
             "moduleSpecifier": "lit-html/static.js"
           }
         ],
@@ -20786,27 +20640,8 @@
               }
             ],
             "type": {
-              "type": "reflection",
-              "declaration": {
-                "name": "__type",
-                "kindString": "Type literal",
-                "children": [
-                  {
-                    "name": "_$litStatic$",
-                    "kindString": "Property",
-                    "sources": [
-                      {
-                        "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/static.d.ts",
-                        "line": 22
-                      }
-                    ],
-                    "type": {
-                      "type": "intrinsic",
-                      "name": "string"
-                    }
-                  }
-                ]
-              }
+              "type": "reference",
+              "name": "StaticValue"
             }
           }
         ],
@@ -20834,7 +20669,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/static.ts",
-            "line": 72,
+            "line": 109,
             "moduleSpecifier": "lit-html/static.js"
           }
         ],
@@ -21029,7 +20864,7 @@
       "v1": "api/lit-element/LitElement/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "ReactiveController",
@@ -21380,7 +21215,7 @@
       "v1": "api/lit-element/LitElement/"
     },
     "repo": "lit/lit",
-    "commit": "ff9d64eeff66f7b6c2a33283eb79d571f2e63728",
+    "commit": "6022c984b35e6aa4b6403048ffee3c8d01a8ad2c",
     "items": [
       {
         "name": "defaultConverter",
@@ -21391,7 +21226,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 239,
+            "line": 308,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -21416,6 +21251,3163 @@
         }
       },
       {
+        "name": "LitUnstable",
+        "kindString": "Namespace",
+        "comment": {
+          "shortText": "Contains types that are part of the unstable debug API.",
+          "text": "Everything in this API is not stable and may change or be removed in the future,\neven on patch releases.\n"
+        },
+        "children": [
+          {
+            "name": "DebugLog",
+            "kindString": "Namespace",
+            "comment": {
+              "shortText": "When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,\nwe will emit 'lit-debug' events to window, with live details about the update and render\nlifecycle. These can be useful for writing debug tooling and visualizations.",
+              "text": "Please be aware that running with window.emitLitDebugLogEvents has performance overhead,\nmaking certain operations that are normally very cheap (like a no-op render) much slower,\nbecause we must copy data and dispatch events.\n"
+            },
+            "children": [
+              {
+                "name": "BeginRender",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "container",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 53,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "reference",
+                          "name": "HTMLElement",
+                          "externalLocation": {
+                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
+                          }
+                        },
+                        {
+                          "type": "reference",
+                          "name": "DocumentFragment",
+                          "externalLocation": {
+                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.BeginRender.container"
+                    }
+                  },
+                  {
+                    "name": "id",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 51,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "number"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.BeginRender.id"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 50,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "begin render"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.BeginRender.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 54,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.BeginRender.options"
+                    }
+                  },
+                  {
+                    "name": "part",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 55,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "ChildPart",
+                          "location": {
+                            "page": "custom-directives",
+                            "anchor": "ChildPart"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.BeginRender.part"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 52,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.BeginRender.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 49,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.BeginRender"
+                }
+              },
+              {
+                "name": "CommitAttribute",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "element",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 135,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Element",
+                      "externalLocation": {
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitAttribute.element"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 134,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit attribute"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitAttribute.kind"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 136,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "string"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitAttribute.name"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 138,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitAttribute.options"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 137,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitAttribute.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 133,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitAttribute"
+                }
+              },
+              {
+                "name": "CommitBooleanAttribute",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "element",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 151,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Element",
+                      "externalLocation": {
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.element"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 150,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit boolean attribute"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.kind"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 152,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "string"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.name"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 154,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.options"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 153,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "boolean"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 149,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
+                }
+              },
+              {
+                "name": "CommitEventListener",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "addListener",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 167,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "boolean"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.addListener"
+                    }
+                  },
+                  {
+                    "name": "element",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 159,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Element",
+                      "externalLocation": {
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.element"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 158,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit event listener"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.kind"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 160,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "string"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.name"
+                    }
+                  },
+                  {
+                    "name": "oldListener",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 162,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.oldListener"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 163,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.options"
+                    }
+                  },
+                  {
+                    "name": "removeListener",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 165,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "boolean"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.removeListener"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 161,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitEventListener.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 157,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitEventListener"
+                }
+              },
+              {
+                "name": "CommitNode",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 126,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit node"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNode.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 130,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNode.options"
+                    }
+                  },
+                  {
+                    "name": "parent",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 128,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "Disconnectable",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "Disconnectable"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNode.parent"
+                    }
+                  },
+                  {
+                    "name": "start",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 127,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Node"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNode.start"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 129,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Node"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNode.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 125,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitNode"
+                }
+              },
+              {
+                "name": "CommitNothingToChildEntry",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "end",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 113,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "literal",
+                          "value": null
+                        },
+                        {
+                          "type": "reference",
+                          "name": "ChildNode"
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.end"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 111,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit nothing to child"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 115,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.options"
+                    }
+                  },
+                  {
+                    "name": "parent",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 114,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "Disconnectable",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "Disconnectable"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.parent"
+                    }
+                  },
+                  {
+                    "name": "start",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 112,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "ChildNode"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.start"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 110,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
+                }
+              },
+              {
+                "name": "CommitProperty",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "element",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 143,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Element",
+                      "externalLocation": {
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitProperty.element"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 142,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit property"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitProperty.kind"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 144,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "string"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitProperty.name"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 146,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitProperty.options"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 145,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitProperty.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 141,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitProperty"
+                }
+              },
+              {
+                "name": "CommitText",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 119,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit text"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitText.kind"
+                    }
+                  },
+                  {
+                    "name": "node",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 120,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Text"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitText.node"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 122,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitText.options"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 121,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitText.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 118,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitText"
+                }
+              },
+              {
+                "name": "CommitToElementBinding",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "element",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 172,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Element",
+                      "externalLocation": {
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.element"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 171,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "commit to element binding"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 174,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.options"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 173,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 170,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
+                }
+              },
+              {
+                "name": "EndRender",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "container",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 61,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "reference",
+                          "name": "HTMLElement",
+                          "externalLocation": {
+                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
+                          }
+                        },
+                        {
+                          "type": "reference",
+                          "name": "DocumentFragment",
+                          "externalLocation": {
+                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.EndRender.container"
+                    }
+                  },
+                  {
+                    "name": "id",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 59,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "number"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.EndRender.id"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 58,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "end render"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.EndRender.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 62,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.EndRender.options"
+                    }
+                  },
+                  {
+                    "name": "part",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 63,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "ChildPart",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.EndRender.part"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 60,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.EndRender.value"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 57,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.EndRender"
+                }
+              },
+              {
+                "name": "SetPartValue",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 92,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "set part"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.SetPartValue.kind"
+                    }
+                  },
+                  {
+                    "name": "part",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 93,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Part",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.SetPartValue.part"
+                    }
+                  },
+                  {
+                    "name": "templateInstance",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 97,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "TemplateInstance"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.SetPartValue.templateInstance"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 94,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.SetPartValue.value"
+                    }
+                  },
+                  {
+                    "name": "valueIndex",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 95,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "intrinsic",
+                      "name": "number"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.SetPartValue.valueIndex"
+                    }
+                  },
+                  {
+                    "name": "values",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 96,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "intrinsic",
+                        "name": "unknown"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.SetPartValue.values"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 91,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.SetPartValue"
+                }
+              },
+              {
+                "name": "TemplateInstantiated",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "fragment",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 70,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Node"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.fragment"
+                    }
+                  },
+                  {
+                    "name": "instance",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 68,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "TemplateInstance"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.instance"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 66,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "template instantiated"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 69,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.options"
+                    }
+                  },
+                  {
+                    "name": "parts",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 71,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "intrinsic",
+                            "name": "undefined"
+                          },
+                          {
+                            "type": "reference",
+                            "name": "Part",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "Part"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.parts"
+                    }
+                  },
+                  {
+                    "name": "template",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 67,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "reference",
+                          "name": "Template"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "CompiledTemplate",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "CompiledTemplate"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.template"
+                    }
+                  },
+                  {
+                    "name": "values",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 72,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "intrinsic",
+                        "name": "unknown"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.values"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 65,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
+                }
+              },
+              {
+                "name": "TemplateInstantiatedAndUpdated",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "fragment",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 79,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Node"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.fragment"
+                    }
+                  },
+                  {
+                    "name": "instance",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 77,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "TemplateInstance"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.instance"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 75,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "template instantiated and updated"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 78,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.options"
+                    }
+                  },
+                  {
+                    "name": "parts",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 80,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "intrinsic",
+                            "name": "undefined"
+                          },
+                          {
+                            "type": "reference",
+                            "name": "Part",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "Part"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.parts"
+                    }
+                  },
+                  {
+                    "name": "template",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 76,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "reference",
+                          "name": "Template"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "CompiledTemplate",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "CompiledTemplate"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.template"
+                    }
+                  },
+                  {
+                    "name": "values",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 81,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "intrinsic",
+                        "name": "unknown"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.values"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 74,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
+                }
+              },
+              {
+                "name": "TemplatePrep",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "clonableTemplate",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 46,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "HTMLTemplateElement",
+                      "externalLocation": {
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplatePrep.clonableTemplate"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 43,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "template prep"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplatePrep.kind"
+                    }
+                  },
+                  {
+                    "name": "parts",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 47,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "reference",
+                        "name": "TemplatePart"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplatePrep.parts"
+                    }
+                  },
+                  {
+                    "name": "strings",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 45,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "TemplateStringsArray"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplatePrep.strings"
+                    }
+                  },
+                  {
+                    "name": "template",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 44,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "Template"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplatePrep.template"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 42,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.TemplatePrep"
+                }
+              },
+              {
+                "name": "TemplateUpdating",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "instance",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 86,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "reference",
+                      "name": "TemplateInstance"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateUpdating.instance"
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 84,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "template updating"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateUpdating.kind"
+                    }
+                  },
+                  {
+                    "name": "options",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 87,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "undefined"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "RenderOptions",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateUpdating.options"
+                    }
+                  },
+                  {
+                    "name": "parts",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 88,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "intrinsic",
+                            "name": "undefined"
+                          },
+                          {
+                            "type": "reference",
+                            "name": "Part",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "Part"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateUpdating.parts"
+                    }
+                  },
+                  {
+                    "name": "template",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 85,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "reference",
+                          "name": "Template"
+                        },
+                        {
+                          "type": "reference",
+                          "name": "CompiledTemplate",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "CompiledTemplate"
+                          }
+                        }
+                      ]
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateUpdating.template"
+                    }
+                  },
+                  {
+                    "name": "values",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-html/src/lit-html.ts",
+                        "line": 89,
+                        "moduleSpecifier": "lit-html/lit-html.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "array",
+                      "elementType": {
+                        "type": "intrinsic",
+                        "name": "unknown"
+                      }
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "LitUnstable.DebugLog.TemplateUpdating.values"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 83,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.TemplateUpdating"
+                }
+              },
+              {
+                "name": "CommitPartEntry",
+                "kindString": "Type alias",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 100,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "type": {
+                  "type": "union",
+                  "types": [
+                    {
+                      "type": "reference",
+                      "name": "CommitNothingToChildEntry",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitText",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitText"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitNode",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitNode"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitAttribute",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitAttribute"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitProperty",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitProperty"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitBooleanAttribute",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitEventListener",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitEventListener"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitToElementBinding",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
+                      }
+                    }
+                  ]
+                },
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.CommitPartEntry"
+                }
+              },
+              {
+                "name": "Entry",
+                "kindString": "Type alias",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-html/src/lit-html.ts",
+                    "line": 33,
+                    "moduleSpecifier": "lit-html/lit-html.js"
+                  }
+                ],
+                "type": {
+                  "type": "union",
+                  "types": [
+                    {
+                      "type": "reference",
+                      "name": "TemplatePrep",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplatePrep"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "TemplateInstantiated",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "TemplateInstantiatedAndUpdated",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "TemplateUpdating",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplateUpdating"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "BeginRender",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.BeginRender"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "EndRender",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.EndRender"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "CommitPartEntry",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitPartEntry"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "SetPartValue",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.SetPartValue"
+                      }
+                    }
+                  ]
+                },
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "LitUnstable.DebugLog.Entry"
+                }
+              }
+            ],
+            "sources": [
+              {
+                "fileName": "packages/lit-html/src/lit-html.ts",
+                "line": 32,
+                "moduleSpecifier": "lit-html/lit-html.js"
+              }
+            ],
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "LitUnstable.DebugLog"
+            }
+          }
+        ],
+        "sources": [
+          {
+            "fileName": "packages/lit-html/src/lit-html.ts",
+            "line": 21,
+            "moduleSpecifier": "lit-html/lit-html.js"
+          }
+        ],
+        "entrypointSources": [
+          {
+            "fileName": "packages/lit/src/index.ts",
+            "line": 10,
+            "moduleSpecifier": "lit"
+          }
+        ],
+        "location": {
+          "page": "misc",
+          "anchor": "LitUnstable"
+        }
+      },
+      {
         "name": "notEqual",
         "kindString": "Function",
         "flags": {
@@ -21427,7 +24419,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 289,
+            "line": 358,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -21472,6 +24464,241 @@
         }
       },
       {
+        "name": "ReactiveUnstable",
+        "kindString": "Namespace",
+        "comment": {
+          "shortText": "Contains types that are part of the unstable debug API.",
+          "text": "Everything in this API is not stable and may change or be removed in the future,\neven on patch releases.\n"
+        },
+        "children": [
+          {
+            "name": "DebugLog",
+            "kindString": "Namespace",
+            "comment": {
+              "shortText": "When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,\nwe will emit 'lit-debug' events to window, with live details about the update and render\nlifecycle. These can be useful for writing debug tooling and visualizations.",
+              "text": "Please be aware that running with window.emitLitDebugLogEvents has performance overhead,\nmaking certain operations that are normally very cheap (like a no-op render) much slower,\nbecause we must copy data and dispatch events.\n"
+            },
+            "children": [
+              {
+                "name": "Update",
+                "kindString": "Interface",
+                "children": [
+                  {
+                    "name": "kind",
+                    "kindString": "Property",
+                    "sources": [
+                      {
+                        "fileName": "packages/reactive-element/src/reactive-element.ts",
+                        "line": 123,
+                        "moduleSpecifier": "reactive-element/reactive-element.js"
+                      }
+                    ],
+                    "type": {
+                      "type": "literal",
+                      "value": "update"
+                    },
+                    "entrypointSources": [
+                      {
+                        "fileName": "packages/lit/src/index.ts",
+                        "line": 10,
+                        "moduleSpecifier": "lit"
+                      }
+                    ],
+                    "location": {
+                      "page": "misc",
+                      "anchor": "ReactiveUnstable.DebugLog.Update.kind"
+                    }
+                  }
+                ],
+                "sources": [
+                  {
+                    "fileName": "packages/reactive-element/src/reactive-element.ts",
+                    "line": 122,
+                    "moduleSpecifier": "reactive-element/reactive-element.js"
+                  }
+                ],
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "ReactiveUnstable.DebugLog.Update"
+                }
+              },
+              {
+                "name": "Entry",
+                "kindString": "Type alias",
+                "sources": [
+                  {
+                    "fileName": "packages/reactive-element/src/reactive-element.ts",
+                    "line": 121,
+                    "moduleSpecifier": "reactive-element/reactive-element.js"
+                  }
+                ],
+                "type": {
+                  "type": "reference",
+                  "name": "Update",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "ReactiveUnstable.DebugLog.Update"
+                  }
+                },
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "ReactiveUnstable.DebugLog.Entry"
+                }
+              }
+            ],
+            "sources": [
+              {
+                "fileName": "packages/reactive-element/src/reactive-element.ts",
+                "line": 120,
+                "moduleSpecifier": "reactive-element/reactive-element.js"
+              }
+            ],
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "ReactiveUnstable.DebugLog"
+            }
+          }
+        ],
+        "sources": [
+          {
+            "fileName": "packages/reactive-element/src/reactive-element.ts",
+            "line": 109,
+            "moduleSpecifier": "reactive-element/reactive-element.js"
+          }
+        ],
+        "entrypointSources": [
+          {
+            "fileName": "packages/lit/src/index.ts",
+            "line": 10,
+            "moduleSpecifier": "lit"
+          }
+        ],
+        "location": {
+          "page": "misc",
+          "anchor": "ReactiveUnstable"
+        }
+      },
+      {
+        "name": "Unstable",
+        "kindString": "Namespace",
+        "comment": {
+          "shortText": "Contains types that are part of the unstable debug API.",
+          "text": "Everything in this API is not stable and may change or be removed in the future,\neven on patch releases.\n"
+        },
+        "children": [
+          {
+            "name": "DebugLog",
+            "kindString": "Namespace",
+            "comment": {
+              "shortText": "When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,\nwe will emit 'lit-debug' events to window, with live details about the update and render\nlifecycle. These can be useful for writing debug tooling and visualizations.",
+              "text": "Please be aware that running with window.emitLitDebugLogEvents has performance overhead,\nmaking certain operations that are normally very cheap (like a no-op render) much slower,\nbecause we must copy data and dispatch events.\n"
+            },
+            "children": [
+              {
+                "name": "Entry",
+                "kindString": "Type alias",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-element/src/lit-element.ts",
+                    "line": 76,
+                    "moduleSpecifier": "lit-element/lit-element.js"
+                  }
+                ],
+                "type": {
+                  "type": "union",
+                  "types": [
+                    {
+                      "type": "reference",
+                      "name": "LitUnstable.DebugLog.Entry",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.Entry"
+                      }
+                    },
+                    {
+                      "type": "reference",
+                      "name": "ReactiveUnstable.DebugLog.Entry",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "ReactiveUnstable.DebugLog.Entry"
+                      }
+                    }
+                  ]
+                },
+                "entrypointSources": [
+                  {
+                    "fileName": "packages/lit/src/index.ts",
+                    "line": 10,
+                    "moduleSpecifier": "lit"
+                  }
+                ],
+                "location": {
+                  "page": "misc",
+                  "anchor": "Unstable.DebugLog.Entry"
+                }
+              }
+            ],
+            "sources": [
+              {
+                "fileName": "packages/lit-element/src/lit-element.ts",
+                "line": 75,
+                "moduleSpecifier": "lit-element/lit-element.js"
+              }
+            ],
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "Unstable.DebugLog"
+            }
+          }
+        ],
+        "sources": [
+          {
+            "fileName": "packages/lit-element/src/lit-element.ts",
+            "line": 64,
+            "moduleSpecifier": "lit-element/lit-element.js"
+          }
+        ],
+        "entrypointSources": [
+          {
+            "fileName": "packages/lit/src/index.ts",
+            "line": 10,
+            "moduleSpecifier": "lit"
+          }
+        ],
+        "location": {
+          "page": "misc",
+          "anchor": "Unstable"
+        }
+      },
+      {
         "name": "CompiledTemplate",
         "kindString": "Interface",
         "children": [
@@ -21484,7 +24711,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 280,
+                "line": 476,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -21513,7 +24740,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 283,
+                "line": 479,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -21537,7 +24764,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 278,
+            "line": 474,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -21595,7 +24822,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 275,
+                "line": 471,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -21622,7 +24849,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 270,
+            "line": 466,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -21644,7 +24871,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 504,
+            "line": 724,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -21666,7 +24893,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 866,
+            "line": 1102,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -21722,7 +24949,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 281,
+            "line": 350,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -21772,7 +24999,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 266,
+            "line": 462,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -21811,7 +25038,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 315,
+            "line": 384,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
@@ -21823,7 +25050,7 @@
             "sources": [
               {
                 "fileName": "lit-dev-api/api-data/lit-2/repo/packages/reactive-element/reactive-element.d.ts",
-                "line": 135
+                "line": 170
               }
             ],
             "signatures": [
@@ -21865,6 +25092,367 @@
         }
       },
       {
+        "name": "PropertyValueMap",
+        "kindString": "Interface",
+        "comment": {
+          "shortText": "Do not use, instead prefer [`PropertyValues`](/docs/api/ReactiveElement/#PropertyValues)."
+        },
+        "children": [
+          {
+            "name": "delete",
+            "kindString": "Method",
+            "signatures": [
+              {
+                "name": "delete",
+                "kindString": "Call signature",
+                "typeParameter": [
+                  {
+                    "name": "K",
+                    "kindString": "Type parameter",
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "string"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "number"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "symbol"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "name": "k",
+                    "kindString": "Parameter",
+                    "type": {
+                      "type": "reference",
+                      "name": "K"
+                    }
+                  }
+                ],
+                "type": {
+                  "type": "intrinsic",
+                  "name": "boolean"
+                },
+                "overwrites": {
+                  "type": "reference",
+                  "name": "Map.delete"
+                }
+              }
+            ],
+            "overwrites": {
+              "type": "reference",
+              "name": "Map.delete"
+            },
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "PropertyValueMap.delete"
+            }
+          },
+          {
+            "name": "get",
+            "kindString": "Method",
+            "signatures": [
+              {
+                "name": "get",
+                "kindString": "Call signature",
+                "typeParameter": [
+                  {
+                    "name": "K",
+                    "kindString": "Type parameter",
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "string"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "number"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "symbol"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "name": "k",
+                    "kindString": "Parameter",
+                    "type": {
+                      "type": "reference",
+                      "name": "K"
+                    }
+                  }
+                ],
+                "type": {
+                  "type": "indexedAccess",
+                  "indexType": {
+                    "type": "reference",
+                    "name": "K"
+                  },
+                  "objectType": {
+                    "type": "reference",
+                    "name": "T"
+                  }
+                },
+                "overwrites": {
+                  "type": "reference",
+                  "name": "Map.get"
+                }
+              }
+            ],
+            "overwrites": {
+              "type": "reference",
+              "name": "Map.get"
+            },
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "PropertyValueMap.get"
+            }
+          },
+          {
+            "name": "has",
+            "kindString": "Method",
+            "signatures": [
+              {
+                "name": "has",
+                "kindString": "Call signature",
+                "typeParameter": [
+                  {
+                    "name": "K",
+                    "kindString": "Type parameter",
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "string"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "number"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "symbol"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "name": "k",
+                    "kindString": "Parameter",
+                    "type": {
+                      "type": "reference",
+                      "name": "K"
+                    }
+                  }
+                ],
+                "type": {
+                  "type": "intrinsic",
+                  "name": "boolean"
+                },
+                "overwrites": {
+                  "type": "reference",
+                  "name": "Map.has"
+                }
+              }
+            ],
+            "overwrites": {
+              "type": "reference",
+              "name": "Map.has"
+            },
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "PropertyValueMap.has"
+            }
+          },
+          {
+            "name": "set",
+            "kindString": "Method",
+            "signatures": [
+              {
+                "name": "set",
+                "kindString": "Call signature",
+                "typeParameter": [
+                  {
+                    "name": "K",
+                    "kindString": "Type parameter",
+                    "type": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "intrinsic",
+                          "name": "string"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "number"
+                        },
+                        {
+                          "type": "intrinsic",
+                          "name": "symbol"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "parameters": [
+                  {
+                    "name": "key",
+                    "kindString": "Parameter",
+                    "type": {
+                      "type": "reference",
+                      "name": "K"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "kindString": "Parameter",
+                    "type": {
+                      "type": "indexedAccess",
+                      "indexType": {
+                        "type": "reference",
+                        "name": "K"
+                      },
+                      "objectType": {
+                        "type": "reference",
+                        "name": "T"
+                      }
+                    }
+                  }
+                ],
+                "type": {
+                  "type": "reference",
+                  "typeArguments": [
+                    {
+                      "type": "reference",
+                      "name": "T"
+                    }
+                  ],
+                  "name": "PropertyValueMap",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "PropertyValueMap"
+                  }
+                },
+                "overwrites": {
+                  "type": "reference",
+                  "name": "Map.set"
+                }
+              }
+            ],
+            "overwrites": {
+              "type": "reference",
+              "name": "Map.set"
+            },
+            "entrypointSources": [
+              {
+                "fileName": "packages/lit/src/index.ts",
+                "line": 10,
+                "moduleSpecifier": "lit"
+              }
+            ],
+            "location": {
+              "page": "misc",
+              "anchor": "PropertyValueMap.set"
+            }
+          }
+        ],
+        "sources": [
+          {
+            "fileName": "packages/reactive-element/src/reactive-element.ts",
+            "line": 301,
+            "moduleSpecifier": "reactive-element/reactive-element.js"
+          }
+        ],
+        "typeParameter": [
+          {
+            "name": "T",
+            "kindString": "Type parameter"
+          }
+        ],
+        "extendedTypes": [
+          {
+            "type": "reference",
+            "typeArguments": [
+              {
+                "type": "reference",
+                "name": "PropertyKey"
+              },
+              {
+                "type": "intrinsic",
+                "name": "unknown"
+              }
+            ],
+            "name": "Map"
+          }
+        ],
+        "entrypointSources": [
+          {
+            "fileName": "packages/lit/src/index.ts",
+            "line": 10,
+            "moduleSpecifier": "lit"
+          }
+        ],
+        "location": {
+          "page": "misc",
+          "anchor": "PropertyValueMap"
+        },
+        "heritage": [
+          {
+            "type": "reference",
+            "typeArguments": [
+              {
+                "type": "reference",
+                "name": "PropertyKey"
+              },
+              {
+                "type": "intrinsic",
+                "name": "unknown"
+              }
+            ],
+            "name": "Map"
+          }
+        ]
+      },
+      {
         "name": "RootPart",
         "kindString": "Interface",
         "comment": {
@@ -21880,7 +25468,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1068,
+                "line": 1312,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -21930,7 +25518,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1067,
+                "line": 1311,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -21968,7 +25556,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1175,
+                "line": 1419,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -22037,7 +25625,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1148,
+                "line": 1392,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -22088,7 +25676,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
-                "line": 1167,
+                "line": 1411,
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
@@ -22193,7 +25781,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 1423,
+            "line": 1725,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -22235,7 +25823,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
-            "line": 104,
+            "line": 300,
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
@@ -22252,7 +25840,7 @@
             "sources": [
               {
                 "fileName": "lit-dev-api/api-data/lit-2/repo/packages/lit-html/lit-html.d.ts",
-                "line": 41
+                "line": 176
               }
             ],
             "signatures": [
@@ -22301,7 +25889,7 @@
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
-            "line": 313,
+            "line": 382,
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],

--- a/packages/lit-dev-api/api-data/lit-2/symbols.json
+++ b/packages/lit-dev-api/api-data/lit-2/symbols.json
@@ -545,6 +545,26 @@
     {
       "page": "custom-directives",
       "anchor": "PropertyPart.element"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.element"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.element"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.element"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.element"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.element"
     }
   ],
   "$AttributePart.element": [
@@ -573,6 +593,22 @@
     {
       "page": "custom-directives",
       "anchor": "AttributePartInfo.name"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.name"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.name"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.name"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.name"
     }
   ],
   "$AttributePart.name": [
@@ -608,6 +644,58 @@
     },
     {
       "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.options"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.options"
+    },
+    {
+      "page": "misc",
       "anchor": "RootPart.options"
     }
   ],
@@ -637,6 +725,10 @@
     {
       "page": "custom-directives",
       "anchor": "AttributePartInfo.strings"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.strings"
     }
   ],
   "$AttributePart.strings": [
@@ -1491,6 +1583,46 @@
     {
       "page": "directives",
       "anchor": "Ref.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.value"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.value"
     }
   ],
   "$Ref.value": [
@@ -1841,6 +1973,1052 @@
     {
       "page": "directives",
       "anchor": "when"
+    }
+  ],
+  "$LitUnstable": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable"
+    }
+  ],
+  "$DebugLog": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog"
+    },
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog"
+    },
+    {
+      "page": "misc",
+      "anchor": "Unstable.DebugLog"
+    }
+  ],
+  "$LitUnstable.DebugLog": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog"
+    }
+  ],
+  "$BeginRender": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender"
+    }
+  ],
+  "$container": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.container"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.container"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender.container": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.container"
+    }
+  ],
+  "$id": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.id"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.id"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender.id": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.id"
+    }
+  ],
+  "$kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.kind"
+    },
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog.Update.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.options"
+    }
+  ],
+  "$part": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.part"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.part"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.part"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender.part": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.part"
+    }
+  ],
+  "$LitUnstable.DebugLog.BeginRender.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.BeginRender.value"
+    }
+  ],
+  "$CommitAttribute": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitAttribute": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitAttribute.element": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.element"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitAttribute.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitAttribute.name": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.name"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitAttribute.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitAttribute.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitAttribute.value"
+    }
+  ],
+  "$CommitBooleanAttribute": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitBooleanAttribute": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitBooleanAttribute.element": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.element"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitBooleanAttribute.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitBooleanAttribute.name": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.name"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitBooleanAttribute.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitBooleanAttribute.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.value"
+    }
+  ],
+  "$CommitEventListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener"
+    }
+  ],
+  "$addListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.addListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.addListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.addListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.element": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.element"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.name": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.name"
+    }
+  ],
+  "$oldListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.oldListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.oldListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.oldListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.options"
+    }
+  ],
+  "$removeListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.removeListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.removeListener": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.removeListener"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitEventListener.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitEventListener.value"
+    }
+  ],
+  "$CommitNode": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNode": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNode.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNode.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.options"
+    }
+  ],
+  "$parent": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.parent"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.parent"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNode.parent": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.parent"
+    }
+  ],
+  "$start": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.start"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.start"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNode.start": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.start"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNode.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNode.value"
+    }
+  ],
+  "$CommitNothingToChildEntry": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNothingToChildEntry": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
+    }
+  ],
+  "$end": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.end"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNothingToChildEntry.end": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.end"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNothingToChildEntry.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNothingToChildEntry.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNothingToChildEntry.parent": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.parent"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitNothingToChildEntry.start": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.start"
+    }
+  ],
+  "$CommitProperty": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitProperty": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitProperty.element": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.element"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitProperty.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitProperty.name": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.name"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitProperty.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitProperty.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitProperty.value"
+    }
+  ],
+  "$CommitText": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitText": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitText.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.kind"
+    }
+  ],
+  "$node": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.node"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitText.node": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.node"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitText.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitText.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitText.value"
+    }
+  ],
+  "$CommitToElementBinding": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitToElementBinding": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitToElementBinding.element": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.element"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitToElementBinding.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitToElementBinding.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitToElementBinding.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitToElementBinding.value"
+    }
+  ],
+  "$EndRender": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender.container": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.container"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender.id": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.id"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender.part": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.part"
+    }
+  ],
+  "$LitUnstable.DebugLog.EndRender.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.EndRender.value"
+    }
+  ],
+  "$SetPartValue": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue.part": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.part"
+    }
+  ],
+  "$templateInstance": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.templateInstance"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue.templateInstance": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.templateInstance"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue.value": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.value"
+    }
+  ],
+  "$valueIndex": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.valueIndex"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue.valueIndex": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.valueIndex"
+    }
+  ],
+  "$values": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.values"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.values"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.values"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.values"
+    },
+    {
+      "page": "misc",
+      "anchor": "CompiledTemplateResult.values"
+    }
+  ],
+  "$LitUnstable.DebugLog.SetPartValue.values": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.SetPartValue.values"
+    }
+  ],
+  "$TemplateInstantiated": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
+    }
+  ],
+  "$fragment": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.fragment"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.fragment"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.fragment": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.fragment"
+    }
+  ],
+  "$instance": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.instance"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.instance"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.instance"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.instance": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.instance"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.options"
+    }
+  ],
+  "$parts": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.parts"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.parts"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.parts"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.parts"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.parts": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.parts"
+    }
+  ],
+  "$template": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.template"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.template"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.template"
+    },
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.template"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.template": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.template"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiated.values": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiated.values"
+    }
+  ],
+  "$TemplateInstantiatedAndUpdated": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.fragment": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.fragment"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.instance": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.instance"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.parts": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.parts"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.template": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.template"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.values": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.values"
+    }
+  ],
+  "$TemplatePrep": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplatePrep": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep"
+    }
+  ],
+  "$clonableTemplate": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.clonableTemplate"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplatePrep.clonableTemplate": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.clonableTemplate"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplatePrep.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplatePrep.parts": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.parts"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplatePrep.strings": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.strings"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplatePrep.template": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplatePrep.template"
+    }
+  ],
+  "$TemplateUpdating": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating.instance": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.instance"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating.kind": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.kind"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating.options": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.options"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating.parts": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.parts"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating.template": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.template"
+    }
+  ],
+  "$LitUnstable.DebugLog.TemplateUpdating.values": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.TemplateUpdating.values"
+    }
+  ],
+  "$CommitPartEntry": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitPartEntry"
+    }
+  ],
+  "$LitUnstable.DebugLog.CommitPartEntry": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.CommitPartEntry"
+    }
+  ],
+  "$Entry": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.Entry"
+    },
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog.Entry"
+    },
+    {
+      "page": "misc",
+      "anchor": "Unstable.DebugLog.Entry"
+    }
+  ],
+  "$LitUnstable.DebugLog.Entry": [
+    {
+      "page": "misc",
+      "anchor": "LitUnstable.DebugLog.Entry"
+    }
+  ],
+  "$ReactiveUnstable": [
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable"
+    }
+  ],
+  "$ReactiveUnstable.DebugLog": [
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog"
+    }
+  ],
+  "$Update": [
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog.Update"
+    }
+  ],
+  "$ReactiveUnstable.DebugLog.Update": [
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog.Update"
+    }
+  ],
+  "$ReactiveUnstable.DebugLog.Update.kind": [
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog.Update.kind"
+    }
+  ],
+  "$ReactiveUnstable.DebugLog.Entry": [
+    {
+      "page": "misc",
+      "anchor": "ReactiveUnstable.DebugLog.Entry"
+    }
+  ],
+  "$Unstable": [
+    {
+      "page": "misc",
+      "anchor": "Unstable"
+    }
+  ],
+  "$Unstable.DebugLog": [
+    {
+      "page": "misc",
+      "anchor": "Unstable.DebugLog"
+    }
+  ],
+  "$Unstable.DebugLog.Entry": [
+    {
+      "page": "misc",
+      "anchor": "Unstable.DebugLog.Entry"
     }
   ],
   "$CSSResult": [
@@ -2761,12 +3939,6 @@
       "anchor": "CompiledTemplateResult"
     }
   ],
-  "$values": [
-    {
-      "page": "misc",
-      "anchor": "CompiledTemplateResult.values"
-    }
-  ],
   "$CompiledTemplateResult.values": [
     {
       "page": "misc",
@@ -2899,46 +4071,58 @@
       "anchor": "PropertyDeclarations"
     }
   ],
-  "$PropertyValues": [
+  "$PropertyValueMap": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues"
+      "page": "misc",
+      "anchor": "PropertyValueMap"
     }
   ],
-  "$forEach": [
+  "$delete": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues.forEach"
+      "page": "misc",
+      "anchor": "PropertyValueMap.delete"
     }
   ],
-  "$PropertyValues.forEach": [
+  "$PropertyValueMap.delete": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues.forEach"
+      "page": "misc",
+      "anchor": "PropertyValueMap.delete"
     }
   ],
   "$get": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues.get"
+      "page": "misc",
+      "anchor": "PropertyValueMap.get"
     }
   ],
-  "$PropertyValues.get": [
+  "$PropertyValueMap.get": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues.get"
+      "page": "misc",
+      "anchor": "PropertyValueMap.get"
+    }
+  ],
+  "$has": [
+    {
+      "page": "misc",
+      "anchor": "PropertyValueMap.has"
+    }
+  ],
+  "$PropertyValueMap.has": [
+    {
+      "page": "misc",
+      "anchor": "PropertyValueMap.has"
     }
   ],
   "$set": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues.set"
+      "page": "misc",
+      "anchor": "PropertyValueMap.set"
     }
   ],
-  "$PropertyValues.set": [
+  "$PropertyValueMap.set": [
     {
-      "page": "ReactiveElement",
-      "anchor": "PropertyValues.set"
+      "page": "misc",
+      "anchor": "PropertyValueMap.set"
     }
   ],
   "$ReactiveController": [
@@ -3149,6 +4333,12 @@
     {
       "page": "misc",
       "anchor": "Initializer"
+    }
+  ],
+  "$PropertyValues": [
+    {
+      "page": "ReactiveElement",
+      "anchor": "PropertyValues"
     }
   ],
   "$SVGTemplateResult": [

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
@@ -20,7 +20,7 @@ const srcDir = pathlib.join(litDir, 'src');
  */
 export const lit2Config: ApiDocsConfig = {
   repo: 'lit/lit',
-  commit: 'ff9d64eeff66f7b6c2a33283eb79d571f2e63728',
+  commit: '6022c984b35e6aa4b6403048ffee3c8d01a8ad2c',
   workDir,
   gitDir,
   tsConfigPath: pathlib.join(litDir, 'tsconfig.json'),


### PR DESCRIPTION
This updates the generated documentation to be in sync with the latest Lit v2.2.2 release.


Tested manually and by looking over the generated content data.

- Adds the `unstable` debug structures into misc. `ReactiveUnstable`, `Unstable`, and `LitUnstable`.
- Checked generated docs for the new `PropertyValueMap` docs (https://pr745-0a1891e---lit-dev-5ftespv5na-uc.a.run.app/docs/api/ReactiveElement/#PropertyValues).
- Multiple places like [ReactiveElement.firstUpdated](https://pr745-0a1891e---lit-dev-5ftespv5na-uc.a.run.app/docs/api/ReactiveElement/#ReactiveElement.firstUpdated) parameter type changed to point at new PropertyValueMap. See `_changedProperties`.
- New `html` tag function docs: https://pr745-0a1891e---lit-dev-5ftespv5na-uc.a.run.app/docs/api/templates/#html
- `styleMap` directive updates. Note links to StyleInfo seem broken. TODO - make issue. [link](https://pr745-0a1891e---lit-dev-5ftespv5na-uc.a.run.app/docs/api/templates/#html)


Made a tracking issue for `StyleInfo`, https://github.com/lit/lit.dev/issues/746. It's already broken on lit.dev so won't block this change.