### PR TITLE
Fix a typo in the shadow dom docs

### DIFF
--- a/packages/lit-dev-content/site/docs/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/components/shadow-dom.md
@@ -262,7 +262,7 @@ By default, LitElement creates an open `shadowRoot` and renders inside it, produ
     <p>child 2</p>
 ```
 
-There are two ways to customize the render root use by LitElement:
+There are two ways to customize the render root used by LitElement:
 
 * Setting `shadowRootOptions`.
 * Implementing the `createRenderRoot` method.


### PR DESCRIPTION
In `/packages/lit-dev-content/site/docs/components/shadow-dom.md`, update `use` to `used`.