### PR TITLE
Implement redesigned asides

### DIFF
--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -77,6 +77,9 @@ module.exports = function (eleventyConfig) {
     '../lit-dev-content/samples/tutorials/**/tutorial.json'
   );
   eleventyConfig.addWatchTarget('../lit-dev-content/samples/tutorials/**/*.md');
+  for (const component of componentsToSSR) {
+    eleventyConfig.addWatchTarget(component);
+  }
 
   // Placeholder shortcode for TODOs
   // Formatting is intentional: outdenting the HTML causes the
@@ -547,6 +550,7 @@ ${content}
 
   eleventyConfig.addPlugin(litPlugin, {
     componentModules,
+    ignoreGlobs: ['**/tutorials/content/**/*']
   });
 
   return {

--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -550,7 +550,7 @@ ${content}
 
   eleventyConfig.addPlugin(litPlugin, {
     componentModules,
-    ignoreGlobs: ['**/tutorials/content/**/*']
+    ignoreGlobs: ['**/tutorials/content/**/*'],
   });
 
   return {

--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -32,6 +32,7 @@ export default [
   {
     input: [
       'lib/components/copy-button.js',
+      'lib/components/litdev-aside.js',
       'lib/components/litdev-banner.js',
       'lib/components/litdev-version-selector.js',
       'lib/components/litdev-drawer.js',

--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -164,28 +164,47 @@ customElements.define('my-element', MyElement);
 You can also insert an aside in your instructions by using the following format:
 
 ```html
-<aside class="positive">
-  Make sure to do <code>this</code>!
-</aside>
+<litdev-aside type="positive">
 
-<aside class="negative">
-  Make sure <b>NOT</b> to do <code>this</code>!
-</aside>
+The first line is always a bolded header.
 
-<aside class="info">
-  Check out more info <a href="https://lit.dev/docs/templates/expressions/?mods=tutorialCatalog#well-formed-html">in this docs section</a>.
-</aside>
+Make sure to do `this`!
+
+</litdev-aside>
+
+<litdev-aside type="warn" no-header>
+
+The `no-header` will make sure that this line is not bolded.
+
+Beware of `this`!
+
+</litdev-aside>
+
+<litdev-aside type="negative">
+
+Make sure NOT to do `this`!
+
+The following non-header lines here make sense to explain the assertion in
+the header line above.
+
+</litdev-aside>
+
+<litdev-aside type="info">
+
+Check out more info [in this docs section](https://lit.dev/docs/templates/expressions/?mods=tutorialCatalog#well-formed-html).
+
+</litdev-aside>
 ```
 
-*Note:* markdown is not rendered inside an aside, you must use HTML.
+*Note:* markdown will only be parsed as markdown if there is an empty line
+between the text and the HTML tag.
 
 The available asides are:
 
 * `positive`
-* `warning`
+* `warn`
 * `negative`
 * `info`
-* `labs`
 
 ## Good tutorial Habits
 

--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -191,7 +191,7 @@ the header line above.
 
 <litdev-aside type="info">
 
-Check out more info [in this docs section](https://lit.dev/docs/templates/expressions/?mods=tutorialCatalog#well-formed-html).
+Check out more info [in this docs section](/docs/templates/expressions/#well-formed-html).
 
 </litdev-aside>
 ```

--- a/packages/lit-dev-content/samples/tutorials/advanced-templating/tutorial.json
+++ b/packages/lit-dev-content/samples/tutorials/advanced-templating/tutorial.json
@@ -7,12 +7,12 @@
   "imgSrc": "images/logo-whitebg-padded-1600x800.png",
   "imgAlt": "This is the Lit icon",
   "steps": [
-      {
-        "title": "Advanced Templating!"
-      },
-      {
-        "title": "Yer done!",
-        "hasAfter": true
-      }
-    ]
+    {
+      "title": "Advanced Templating!"
+    },
+    {
+      "title": "Yer done!",
+      "hasAfter": true
+    }
+  ]
 }

--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -34,6 +34,7 @@
 
     <script type="module" src="{{ site.baseurl }}/js/global/mobile-nav.js"></script>
     <script type="module" src="{{ site.baseurl }}/js/components/litdev-version-selector.js"></script>
+    <script type="module" src="{{ site.baseurl }}/js/components/litdev-aside.js"></script>
 
     <!-- Preload common chunks we always need. Note <link rel="modulepreload">
          isn't yet supported in Firefox or Safari. -->

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -66,7 +66,7 @@ article {
   color: #3E3E3E;
 }
 
-article p {
+article :not(litdev-aside) p {
   margin-block-start: 1.5em;
   margin-block-end: 1.5em;
 }

--- a/packages/lit-dev-content/site/css/tutorial.css
+++ b/packages/lit-dev-content/site/css/tutorial.css
@@ -290,6 +290,10 @@ resize-bar[active] {
 /* Notes and warnings
 /* ------------------------------------ */
 
+#tutorialContent litdev-aside {
+  --lit-dev-aside-border-color: #ccc;
+}
+
 #tutorialContent aside {
   position: relative;
   margin: 1em 0;

--- a/packages/lit-dev-content/site/tutorials/content/advanced-templating/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/advanced-templating/01.md
@@ -33,6 +33,6 @@ the header line above.
 
 <litdev-aside type="info">
 
-Check out more info [in this docs section](https://lit.dev/docs/templates/expressions/?mods=tutorialCatalog#well-formed-html).
+Check out more info [in this docs section](/docs/templates/expressions/#well-formed-html).
 
 </litdev-aside>

--- a/packages/lit-dev-content/site/tutorials/content/advanced-templating/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/advanced-templating/01.md
@@ -5,3 +5,34 @@ See also these tutorials maybe?
 * list
 * list
 * list
+
+<litdev-aside type="positive">
+
+The first line is always a bolded header.
+
+Make sure to do `this`!
+
+</litdev-aside>
+
+<litdev-aside type="warn" no-header>
+
+The `no-header` will make sure that this line is not bolded.
+
+Beware of `this`!
+
+</litdev-aside>
+
+<litdev-aside type="negative">
+
+Make sure NOT to do `this`!
+
+The following non-header lines here make sense to explain the assertion in
+the header line above.
+
+</litdev-aside>
+
+<litdev-aside type="info">
+
+Check out more info [in this docs section](https://lit.dev/docs/templates/expressions/?mods=tutorialCatalog#well-formed-html).
+
+</litdev-aside>

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {css, html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {greenCheckIcon} from '../icons/green-check-icon.js';
+import {redXIcon} from '../icons/red-x-icon.js';
+import {yellowBangIcon} from '../icons/yellow-bang-icon';
+import {blueInfoIcon} from '../icons/blue-info-icon';
+
+export type AsideVariant = 'positive' | 'negative' | 'warn' | 'info';
+
+@customElement('litdev-aside')
+export class LitDevAside extends LitElement {
+  static styles = css`
+    :host {
+      color: currentColor;
+      display: block;
+      margin: 1em 0;
+    }
+
+    aside {
+      display: flex;
+      border-style: solid;
+      border-width: 1px;
+      border-color: var(--lit-dev-aside-border-color, #ccc);
+      padding: 1em 1em 1em 0em;
+    }
+
+    slot {
+      display: block;
+      flex-grow: 1;
+    }
+
+    svg {
+      width: 1.5em;
+      margin-inline: 1em;
+    }
+
+    :host(:not([no-header])) ::slotted(:first-child) {
+      font-weight: bold;
+    }
+
+    ::slotted(*) {
+      margin: 0;
+    }
+  `;
+
+  @property({type: String})
+  type: AsideVariant = 'info';
+
+  @property({type: Boolean, reflect: true, attribute: 'no-header'})
+  noHeader = false;
+
+  render() {
+    return html`
+      <aside>
+        <div>${this._renderIcon()}</div>
+        <slot></slot>
+      </aside>
+    `;
+  }
+
+  private _renderIcon() {
+    switch (this.type) {
+      case 'positive':
+        return greenCheckIcon;
+      case 'negative':
+        return redXIcon;
+      case 'warn':
+        return yellowBangIcon;
+      case 'info':
+        return blueInfoIcon;
+    }
+  }
+}

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -8,8 +8,8 @@ import {css, html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {greenCheckIcon} from '../icons/green-check-icon.js';
 import {redXIcon} from '../icons/red-x-icon.js';
-import {yellowBangIcon} from '../icons/yellow-bang-icon';
-import {blueInfoIcon} from '../icons/blue-info-icon';
+import {yellowBangIcon} from '../icons/yellow-bang-icon.js';
+import {blueInfoIcon} from '../icons/blue-info-icon.js';
 
 export type AsideVariant = 'positive' | 'negative' | 'warn' | 'info';
 

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {css, html, LitElement} from 'lit';
+import {css, html, LitElement, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {greenCheckIcon} from '../icons/green-check-icon.js';
 import {redXIcon} from '../icons/red-x-icon.js';
@@ -74,6 +74,12 @@ export class LitDevAside extends LitElement {
         return yellowBangIcon;
       case 'info':
         return blueInfoIcon;
+      default:
+        const exhaustiveCheck: never = this.type;
+        console.warn(
+          `Received unexpected type for <litdev-aside>: ${exhaustiveCheck}`
+        );
+        return nothing;
     }
   }
 }

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -17,7 +17,6 @@ export type AsideVariant = 'positive' | 'negative' | 'warn' | 'info';
 export class LitDevAside extends LitElement {
   static styles = css`
     :host {
-      color: currentColor;
       display: block;
       margin: 1em 0;
     }
@@ -49,7 +48,7 @@ export class LitDevAside extends LitElement {
     }
   `;
 
-  @property({type: String})
+  @property()
   type: AsideVariant = 'info';
 
   @property({type: Boolean, reflect: true, attribute: 'no-header'})

--- a/packages/lit-dev-content/src/components/ssr.js
+++ b/packages/lit-dev-content/src/components/ssr.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 // list of components that should be rendered on server side
 const componentsToSSR = ['lib/components/litdev-tutorial-card.js'];
 

--- a/packages/lit-dev-content/src/icons/blue-info-icon.ts
+++ b/packages/lit-dev-content/src/icons/blue-info-icon.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+
+// Source: Ocupop Design
+export const blueInfoIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+  <desc>A white letter i in a blue circle</desc>
+  <g>
+    <circle fill="#324fff" cx="62.5" cy="62.5" r="61.5" />
+    <g>
+      <rect x="52.9" y="24.62" fill="#FFF" width="19.2" height="18.94" />
+      <rect x="52.9" y="59.18" fill="#FFF" width="19.2" height="41.2" />
+    </g>
+  </g>
+</svg>`;

--- a/packages/lit-dev-content/src/icons/blue-info-icon.ts
+++ b/packages/lit-dev-content/src/icons/blue-info-icon.ts
@@ -7,7 +7,7 @@
 import {html} from 'lit';
 
 // Source: Ocupop Design
-export const blueInfoIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+export const blueInfoIcon = html`<svg viewBox="0 0 125 125">
   <desc>A white letter i in a blue circle</desc>
   <g>
     <circle fill="#324fff" cx="62.5" cy="62.5" r="61.5" />

--- a/packages/lit-dev-content/src/icons/blue-info-icon.ts
+++ b/packages/lit-dev-content/src/icons/blue-info-icon.ts
@@ -9,11 +9,7 @@ import {html} from 'lit';
 // Source: Ocupop Design
 export const blueInfoIcon = html`<svg viewBox="0 0 125 125">
   <desc>A white letter i in a blue circle</desc>
-  <g>
-    <circle fill="#324fff" cx="62.5" cy="62.5" r="61.5" />
-    <g>
-      <rect x="52.9" y="24.62" fill="#FFF" width="19.2" height="18.94" />
-      <rect x="52.9" y="59.18" fill="#FFF" width="19.2" height="41.2" />
-    </g>
-  </g>
+  <circle fill="#324fff" cx="62.5" cy="62.5" r="61.5" />
+  <rect x="52.9" y="24.62" fill="#FFF" width="19.2" height="18.94" />
+  <rect x="52.9" y="59.18" fill="#FFF" width="19.2" height="41.2" />
 </svg>`;

--- a/packages/lit-dev-content/src/icons/green-check-icon.ts
+++ b/packages/lit-dev-content/src/icons/green-check-icon.ts
@@ -7,11 +7,7 @@
 import {html} from 'lit';
 
 // Source: Ocupop Design
-export const greenCheckIcon = html`<svg
-  x="0px"
-  y="0px"
-  viewBox="0 0 125 125"
->
+export const greenCheckIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
   <desc>A white checkmark in a green circle</desc>
   <circle fill="#19D695" cx="62.5" cy="62.5" r="61.5" />
   <polygon

--- a/packages/lit-dev-content/src/icons/green-check-icon.ts
+++ b/packages/lit-dev-content/src/icons/green-check-icon.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+
+// Source: Ocupop Design
+export const greenCheckIcon = html`<svg
+  x="0px"
+  y="0px"
+  viewBox="0 0 125 125"
+>
+  <desc>A white checkmark in a green circle</desc>
+  <circle fill="#19D695" cx="62.5" cy="62.5" r="61.5" />
+  <polygon
+    fill="#FFF"
+    points="86.07,32.15 52.51,65.71 38.93,52.13 25.36,65.71 52.51,92.85 99.64,45.72 "
+  />
+</svg>`;

--- a/packages/lit-dev-content/src/icons/green-check-icon.ts
+++ b/packages/lit-dev-content/src/icons/green-check-icon.ts
@@ -7,7 +7,7 @@
 import {html} from 'lit';
 
 // Source: Ocupop Design
-export const greenCheckIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+export const greenCheckIcon = html`<svg viewBox="0 0 125 125">
   <desc>A white checkmark in a green circle</desc>
   <circle fill="#19D695" cx="62.5" cy="62.5" r="61.5" />
   <polygon

--- a/packages/lit-dev-content/src/icons/red-x-icon.ts
+++ b/packages/lit-dev-content/src/icons/red-x-icon.ts
@@ -7,12 +7,11 @@
 import {html} from 'lit';
 
 // Source: Ocupop Design
-export const redXIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+export const redXIcon = html`<svg viewBox="0 0 125 125">
   <desc>A white X in a red circle</desc>
   <circle fill="#FF4914" cx="62.5" cy="62.5" r="61.5" />
   <polygon
     fill="#FFF"
-    points="97.91,84.34 76.07,62.5 97.91,40.66 84.34,27.09 62.5,48.93 40.66,27.08 27.09,40.66 48.93,62.5
-48.93,62.5 48.93,62.5 27.09,84.34 40.66,97.91 62.5,76.07 84.34,97.92 "
+    points="97.91,84.34 76.07,62.5 97.91,40.66 84.34,27.09 62.5,48.93 40.66,27.08 27.09,40.66 48.93,62.5 48.93,62.5 48.93,62.5 27.09,84.34 40.66,97.91 62.5,76.07 84.34,97.92 "
   />
 </svg>`;

--- a/packages/lit-dev-content/src/icons/red-x-icon.ts
+++ b/packages/lit-dev-content/src/icons/red-x-icon.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+
+// Source: Ocupop Design
+export const redXIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+  <desc>A white X in a red circle</desc>
+  <circle fill="#FF4914" cx="62.5" cy="62.5" r="61.5" />
+  <polygon
+    fill="#FFF"
+    points="97.91,84.34 76.07,62.5 97.91,40.66 84.34,27.09 62.5,48.93 40.66,27.08 27.09,40.66 48.93,62.5
+48.93,62.5 48.93,62.5 27.09,84.34 40.66,97.91 62.5,76.07 84.34,97.92 "
+  />
+</svg>`;

--- a/packages/lit-dev-content/src/icons/yellow-bang-icon.ts
+++ b/packages/lit-dev-content/src/icons/yellow-bang-icon.ts
@@ -9,11 +9,7 @@ import {html} from 'lit';
 // Source: Ocupop Design
 export const yellowBangIcon = html`<svg viewBox="0 0 125 125">
   <desc>A white exclamation mark in a yellow circle</desc>
-  <g>
-    <circle fill="#F9A012" cx="62.5" cy="62.5" r="61.5" />
-    <g>
-      <rect x="52.9" y="81.69" fill="#FFF" width="19.2" height="19.2" />
-      <rect x="52.9" y="24.12" fill="#FFF" width="19.2" height="41.83" />
-    </g>
-  </g>
+  <circle fill="#F9A012" cx="62.5" cy="62.5" r="61.5" />
+  <rect x="52.9" y="81.69" fill="#FFF" width="19.2" height="19.2" />
+  <rect x="52.9" y="24.12" fill="#FFF" width="19.2" height="41.83" />
 </svg>`;

--- a/packages/lit-dev-content/src/icons/yellow-bang-icon.ts
+++ b/packages/lit-dev-content/src/icons/yellow-bang-icon.ts
@@ -7,7 +7,7 @@
 import {html} from 'lit';
 
 // Source: Ocupop Design
-export const yellowBangIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+export const yellowBangIcon = html`<svg viewBox="0 0 125 125">
   <desc>A white exclamation mark in a yellow circle</desc>
   <g>
     <circle fill="#F9A012" cx="62.5" cy="62.5" r="61.5" />

--- a/packages/lit-dev-content/src/icons/yellow-bang-icon.ts
+++ b/packages/lit-dev-content/src/icons/yellow-bang-icon.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+
+// Source: Ocupop Design
+export const yellowBangIcon = html`<svg x="0px" y="0px" viewBox="0 0 125 125">
+  <desc>A white exclamation mark in a yellow circle</desc>
+  <g>
+    <circle fill="#F9A012" cx="62.5" cy="62.5" r="61.5" />
+    <g>
+      <rect x="52.9" y="81.69" fill="#FFF" width="19.2" height="19.2" />
+      <rect x="52.9" y="24.12" fill="#FFF" width="19.2" height="41.83" />
+    </g>
+  </g>
+</svg>`;


### PR DESCRIPTION
fixes #751

The goal in the end is to SSR these without hydration, but due to limitations with declarative shadow dom, we cannot do this for the tutorials section as it will mess up the styling. But as of now all the content is in the light dom so it doesn't necessarily matter right now.

They look like so:

![image](https://user-images.githubusercontent.com/5981958/163056922-2a4fddea-0246-49c4-b458-0264ae062c36.png)
