### PR TITLE
Filter inline TOC by attribute instead of by deleting id.

### DIFF
--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -8163,7 +8163,8 @@
                     "name": "AsyncAppendDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "AsyncAppendDirective"
+                      "anchor": "AsyncAppendDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -8227,7 +8228,8 @@
                   "name": "AsyncAppendDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "AsyncAppendDirective"
+                    "anchor": "AsyncAppendDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -8720,7 +8722,8 @@
             "name": "AsyncReplaceDirective",
             "location": {
               "page": "directives",
-              "anchor": "AsyncReplaceDirective"
+              "anchor": "AsyncReplaceDirective",
+              "excludeFromTOC": true
             }
           }
         ],
@@ -8731,13 +8734,19 @@
             "moduleSpecifier": "lit/directives/async-append.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "AsyncAppendDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
             "name": "AsyncReplaceDirective",
             "location": {
               "page": "directives",
-              "anchor": "AsyncReplaceDirective"
+              "anchor": "AsyncReplaceDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -8825,7 +8834,8 @@
                     "name": "AsyncReplaceDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "AsyncReplaceDirective"
+                      "anchor": "AsyncReplaceDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -8880,7 +8890,8 @@
                   "name": "AsyncReplaceDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "AsyncReplaceDirective"
+                    "anchor": "AsyncReplaceDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "inheritedFrom": {
@@ -9371,7 +9382,8 @@
             "name": "AsyncAppendDirective",
             "location": {
               "page": "directives",
-              "anchor": "AsyncAppendDirective"
+              "anchor": "AsyncAppendDirective",
+              "excludeFromTOC": true
             }
           }
         ],
@@ -9382,6 +9394,11 @@
             "moduleSpecifier": "lit/directives/async-replace.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "AsyncReplaceDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -9442,7 +9459,8 @@
                     "name": "CacheDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "CacheDirective"
+                      "anchor": "CacheDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -9506,7 +9524,8 @@
                   "name": "CacheDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "CacheDirective"
+                    "anchor": "CacheDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -9696,6 +9715,11 @@
             "moduleSpecifier": "lit/directives/cache.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "CacheDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -9865,7 +9889,8 @@
                   "name": "ClassInfo",
                   "location": {
                     "page": "directives",
-                    "anchor": "ClassInfo"
+                    "anchor": "ClassInfo",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -9880,7 +9905,8 @@
                     "name": "ClassMapDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "ClassMapDirective"
+                      "anchor": "ClassMapDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -9944,7 +9970,8 @@
                   "name": "ClassMapDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "ClassMapDirective"
+                    "anchor": "ClassMapDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -9996,7 +10023,8 @@
                       "name": "ClassInfo",
                       "location": {
                         "page": "directives",
-                        "anchor": "ClassInfo"
+                        "anchor": "ClassInfo",
+                        "excludeFromTOC": true
                       }
                     }
                   }
@@ -10073,7 +10101,8 @@
                             "name": "ClassInfo",
                             "location": {
                               "page": "directives",
-                              "anchor": "ClassInfo"
+                              "anchor": "ClassInfo",
+                              "excludeFromTOC": true
                             }
                           }
                         }
@@ -10152,6 +10181,11 @@
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "ClassMapDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -10212,7 +10246,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/class-map.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "ClassInfo",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "guard",
@@ -10279,7 +10318,8 @@
                     "name": "GuardDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "GuardDirective"
+                      "anchor": "GuardDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -10337,7 +10377,8 @@
                   "name": "GuardDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "GuardDirective"
+                    "anchor": "GuardDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "inheritedFrom": {
@@ -10564,6 +10605,11 @@
             "moduleSpecifier": "lit/directives/guard.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "GuardDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -10951,7 +10997,8 @@
                     "name": "LiveDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "LiveDirective"
+                      "anchor": "LiveDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -11015,7 +11062,8 @@
                   "name": "LiveDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "LiveDirective"
+                    "anchor": "LiveDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -11199,6 +11247,11 @@
             "moduleSpecifier": "lit/directives/live.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "LiveDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -11474,7 +11527,8 @@
               "name": "Ref",
               "location": {
                 "page": "directives",
-                "anchor": "Ref"
+                "anchor": "Ref",
+                "excludeFromTOC": true
               }
             }
           }
@@ -11521,7 +11575,8 @@
                   "name": "RefOrCallback",
                   "location": {
                     "page": "directives",
-                    "anchor": "RefOrCallback"
+                    "anchor": "RefOrCallback",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -11536,7 +11591,8 @@
                     "name": "RefDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "RefDirective"
+                      "anchor": "RefDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -11599,7 +11655,8 @@
                   "name": "Ref",
                   "location": {
                     "page": "directives",
-                    "anchor": "Ref"
+                    "anchor": "Ref",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -11676,7 +11733,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/ref.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "Ref",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "RefDirective",
@@ -11711,7 +11773,8 @@
                   "name": "RefDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "RefDirective"
+                    "anchor": "RefDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "inheritedFrom": {
@@ -11891,7 +11954,8 @@
                       "name": "RefOrCallback",
                       "location": {
                         "page": "directives",
-                        "anchor": "RefOrCallback"
+                        "anchor": "RefOrCallback",
+                        "excludeFromTOC": true
                       }
                     }
                   }
@@ -12029,7 +12093,8 @@
                             "name": "RefOrCallback",
                             "location": {
                               "page": "directives",
-                              "anchor": "RefOrCallback"
+                              "anchor": "RefOrCallback",
+                              "excludeFromTOC": true
                             }
                           }
                         }
@@ -12092,6 +12157,11 @@
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "RefDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -12129,7 +12199,8 @@
               "name": "Ref",
               "location": {
                 "page": "directives",
-                "anchor": "Ref"
+                "anchor": "Ref",
+                "excludeFromTOC": true
               }
             },
             {
@@ -12185,7 +12256,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/ref.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "RefOrCallback",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "repeat",
@@ -12246,7 +12322,8 @@
                       "name": "KeyFn",
                       "location": {
                         "page": "directives",
-                        "anchor": "KeyFn"
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
                       }
                     },
                     {
@@ -12260,7 +12337,8 @@
                       "name": "ItemTemplate",
                       "location": {
                         "page": "directives",
-                        "anchor": "ItemTemplate"
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
                       }
                     }
                   ]
@@ -12283,7 +12361,8 @@
                   "name": "ItemTemplate",
                   "location": {
                     "page": "directives",
-                    "anchor": "ItemTemplate"
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -12335,7 +12414,8 @@
                   "name": "ItemTemplate",
                   "location": {
                     "page": "directives",
-                    "anchor": "ItemTemplate"
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -12390,7 +12470,8 @@
                       "name": "KeyFn",
                       "location": {
                         "page": "directives",
-                        "anchor": "KeyFn"
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
                       }
                     },
                     {
@@ -12404,7 +12485,8 @@
                       "name": "ItemTemplate",
                       "location": {
                         "page": "directives",
-                        "anchor": "ItemTemplate"
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
                       }
                     }
                   ]
@@ -12424,7 +12506,8 @@
                   "name": "ItemTemplate",
                   "location": {
                     "page": "directives",
-                    "anchor": "ItemTemplate"
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -12486,7 +12569,8 @@
                   "name": "RepeatDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "RepeatDirective"
+                    "anchor": "RepeatDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -12564,7 +12648,8 @@
                       "name": "ItemTemplate",
                       "location": {
                         "page": "directives",
-                        "anchor": "ItemTemplate"
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
                       }
                     }
                   }
@@ -12622,7 +12707,8 @@
                           "name": "KeyFn",
                           "location": {
                             "page": "directives",
-                            "anchor": "KeyFn"
+                            "anchor": "KeyFn",
+                            "excludeFromTOC": true
                           }
                         },
                         {
@@ -12636,7 +12722,8 @@
                           "name": "ItemTemplate",
                           "location": {
                             "page": "directives",
-                            "anchor": "ItemTemplate"
+                            "anchor": "ItemTemplate",
+                            "excludeFromTOC": true
                           }
                         }
                       ]
@@ -12656,7 +12743,8 @@
                       "name": "ItemTemplate",
                       "location": {
                         "page": "directives",
-                        "anchor": "ItemTemplate"
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
                       }
                     }
                   }
@@ -12757,7 +12845,8 @@
                               "name": "KeyFn",
                               "location": {
                                 "page": "directives",
-                                "anchor": "KeyFn"
+                                "anchor": "KeyFn",
+                                "excludeFromTOC": true
                               }
                             },
                             {
@@ -12771,7 +12860,8 @@
                               "name": "ItemTemplate",
                               "location": {
                                 "page": "directives",
-                                "anchor": "ItemTemplate"
+                                "anchor": "ItemTemplate",
+                                "excludeFromTOC": true
                               }
                             }
                           ]
@@ -12787,7 +12877,8 @@
                           "name": "ItemTemplate",
                           "location": {
                             "page": "directives",
-                            "anchor": "ItemTemplate"
+                            "anchor": "ItemTemplate",
+                            "excludeFromTOC": true
                           }
                         }
                       ]
@@ -12868,6 +12959,11 @@
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "RepeatDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -12942,7 +13038,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "ItemTemplate",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "KeyFn",
@@ -13007,7 +13108,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "KeyFn",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "RepeatDirectiveFn",
@@ -13061,7 +13167,8 @@
                       "name": "KeyFn",
                       "location": {
                         "page": "directives",
-                        "anchor": "KeyFn"
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
                       }
                     },
                     {
@@ -13075,7 +13182,8 @@
                       "name": "ItemTemplate",
                       "location": {
                         "page": "directives",
-                        "anchor": "ItemTemplate"
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
                       }
                     }
                   ]
@@ -13098,7 +13206,8 @@
                   "name": "ItemTemplate",
                   "location": {
                     "page": "directives",
-                    "anchor": "ItemTemplate"
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -13146,7 +13255,8 @@
                   "name": "ItemTemplate",
                   "location": {
                     "page": "directives",
-                    "anchor": "ItemTemplate"
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -13197,7 +13307,8 @@
                       "name": "KeyFn",
                       "location": {
                         "page": "directives",
-                        "anchor": "KeyFn"
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
                       }
                     },
                     {
@@ -13211,7 +13322,8 @@
                       "name": "ItemTemplate",
                       "location": {
                         "page": "directives",
-                        "anchor": "ItemTemplate"
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
                       }
                     }
                   ]
@@ -13231,7 +13343,8 @@
                   "name": "ItemTemplate",
                   "location": {
                     "page": "directives",
-                    "anchor": "ItemTemplate"
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
                   }
                 }
               }
@@ -13248,7 +13361,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "RepeatDirectiveFn",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "styleMap",
@@ -13283,7 +13401,8 @@
                       "name": "StyleInfo",
                       "location": {
                         "page": "directives",
-                        "anchor": "StyleInfo"
+                        "anchor": "StyleInfo",
+                        "excludeFromTOC": true
                       }
                     }
                   ],
@@ -13301,7 +13420,8 @@
                     "name": "StyleMapDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "StyleMapDirective"
+                      "anchor": "StyleMapDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -13365,7 +13485,8 @@
                   "name": "StyleMapDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "StyleMapDirective"
+                    "anchor": "StyleMapDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -13420,7 +13541,8 @@
                           "name": "StyleInfo",
                           "location": {
                             "page": "directives",
-                            "anchor": "StyleInfo"
+                            "anchor": "StyleInfo",
+                            "excludeFromTOC": true
                           }
                         }
                       ],
@@ -13503,7 +13625,8 @@
                                 "name": "StyleInfo",
                                 "location": {
                                   "page": "directives",
-                                  "anchor": "StyleInfo"
+                                  "anchor": "StyleInfo",
+                                  "excludeFromTOC": true
                                 }
                               }
                             ],
@@ -13585,6 +13708,11 @@
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "StyleMapDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -13646,7 +13774,12 @@
             "line": 7,
             "moduleSpecifier": "lit/directives/style-map.js"
           }
-        ]
+        ],
+        "location": {
+          "page": "directives",
+          "anchor": "StyleInfo",
+          "excludeFromTOC": true
+        }
       },
       {
         "name": "templateContent",
@@ -13692,7 +13825,8 @@
                     "name": "TemplateContentDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "TemplateContentDirective"
+                      "anchor": "TemplateContentDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -13756,7 +13890,8 @@
                   "name": "TemplateContentDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "TemplateContentDirective"
+                    "anchor": "TemplateContentDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -13955,6 +14090,11 @@
             "moduleSpecifier": "lit/directives/template-content.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "TemplateContentDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -14042,7 +14182,8 @@
                     "name": "UnsafeHTMLDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "UnsafeHTMLDirective"
+                      "anchor": "UnsafeHTMLDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -14103,7 +14244,8 @@
                   "name": "UnsafeHTMLDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "UnsafeHTMLDirective"
+                    "anchor": "UnsafeHTMLDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "overwrites": {
@@ -14426,7 +14568,8 @@
             "name": "UnsafeSVGDirective",
             "location": {
               "page": "directives",
-              "anchor": "UnsafeSVGDirective"
+              "anchor": "UnsafeSVGDirective",
+              "excludeFromTOC": true
             }
           }
         ],
@@ -14437,6 +14580,11 @@
             "moduleSpecifier": "lit/directives/unsafe-html.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "UnsafeHTMLDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -14524,7 +14672,8 @@
                     "name": "UnsafeSVGDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "UnsafeSVGDirective"
+                      "anchor": "UnsafeSVGDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -14582,7 +14731,8 @@
                   "name": "UnsafeSVGDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "UnsafeSVGDirective"
+                    "anchor": "UnsafeSVGDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "inheritedFrom": {
@@ -14911,7 +15061,8 @@
             "name": "UnsafeHTMLDirective",
             "location": {
               "page": "directives",
-              "anchor": "UnsafeHTMLDirective"
+              "anchor": "UnsafeHTMLDirective",
+              "excludeFromTOC": true
             }
           }
         ],
@@ -14922,13 +15073,19 @@
             "moduleSpecifier": "lit/directives/unsafe-svg.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "UnsafeSVGDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
             "name": "UnsafeHTMLDirective",
             "location": {
               "page": "directives",
-              "anchor": "UnsafeHTMLDirective"
+              "anchor": "UnsafeHTMLDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -14988,7 +15145,8 @@
                     "name": "UntilDirective",
                     "location": {
                       "page": "directives",
-                      "anchor": "UntilDirective"
+                      "anchor": "UntilDirective",
+                      "excludeFromTOC": true
                     }
                   }
                 }
@@ -15043,7 +15201,8 @@
                   "name": "UntilDirective",
                   "location": {
                     "page": "directives",
-                    "anchor": "UntilDirective"
+                    "anchor": "UntilDirective",
+                    "excludeFromTOC": true
                   }
                 },
                 "inheritedFrom": {
@@ -15415,6 +15574,11 @@
             "moduleSpecifier": "lit/directives/until.js"
           }
         ],
+        "location": {
+          "page": "directives",
+          "anchor": "UntilDirective",
+          "excludeFromTOC": true
+        },
         "heritage": [
           {
             "type": "reference",
@@ -16118,7 +16282,8 @@
             "name": "AsyncReplaceDirective",
             "location": {
               "page": "directives",
-              "anchor": "AsyncReplaceDirective"
+              "anchor": "AsyncReplaceDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -16126,7 +16291,8 @@
             "name": "RefDirective",
             "location": {
               "page": "directives",
-              "anchor": "RefDirective"
+              "anchor": "RefDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -16134,7 +16300,8 @@
             "name": "UntilDirective",
             "location": {
               "page": "directives",
-              "anchor": "UntilDirective"
+              "anchor": "UntilDirective",
+              "excludeFromTOC": true
             }
           }
         ],
@@ -18474,7 +18641,8 @@
             "name": "CacheDirective",
             "location": {
               "page": "directives",
-              "anchor": "CacheDirective"
+              "anchor": "CacheDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18482,7 +18650,8 @@
             "name": "ClassMapDirective",
             "location": {
               "page": "directives",
-              "anchor": "ClassMapDirective"
+              "anchor": "ClassMapDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18490,7 +18659,8 @@
             "name": "GuardDirective",
             "location": {
               "page": "directives",
-              "anchor": "GuardDirective"
+              "anchor": "GuardDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18498,7 +18668,8 @@
             "name": "LiveDirective",
             "location": {
               "page": "directives",
-              "anchor": "LiveDirective"
+              "anchor": "LiveDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18506,7 +18677,8 @@
             "name": "RepeatDirective",
             "location": {
               "page": "directives",
-              "anchor": "RepeatDirective"
+              "anchor": "RepeatDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18514,7 +18686,8 @@
             "name": "StyleMapDirective",
             "location": {
               "page": "directives",
-              "anchor": "StyleMapDirective"
+              "anchor": "StyleMapDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18522,7 +18695,8 @@
             "name": "TemplateContentDirective",
             "location": {
               "page": "directives",
-              "anchor": "TemplateContentDirective"
+              "anchor": "TemplateContentDirective",
+              "excludeFromTOC": true
             }
           },
           {
@@ -18530,7 +18704,8 @@
             "name": "UnsafeHTMLDirective",
             "location": {
               "page": "directives",
-              "anchor": "UnsafeHTMLDirective"
+              "anchor": "UnsafeHTMLDirective",
+              "excludeFromTOC": true
             }
           }
         ],

--- a/packages/lit-dev-api/api-data/lit-2/symbols.json
+++ b/packages/lit-dev-api/api-data/lit-2/symbols.json
@@ -1278,7 +1278,8 @@
   "$AsyncAppendDirective": [
     {
       "page": "directives",
-      "anchor": "AsyncAppendDirective"
+      "anchor": "AsyncAppendDirective",
+      "excludeFromTOC": true
     }
   ],
   "$AsyncAppendDirective.constructor": [
@@ -1348,7 +1349,8 @@
   "$AsyncReplaceDirective": [
     {
       "page": "directives",
-      "anchor": "AsyncReplaceDirective"
+      "anchor": "AsyncReplaceDirective",
+      "excludeFromTOC": true
     }
   ],
   "$AsyncReplaceDirective.constructor": [
@@ -1408,7 +1410,8 @@
   "$CacheDirective": [
     {
       "page": "directives",
-      "anchor": "CacheDirective"
+      "anchor": "CacheDirective",
+      "excludeFromTOC": true
     }
   ],
   "$CacheDirective.constructor": [
@@ -1444,7 +1447,8 @@
   "$ClassMapDirective": [
     {
       "page": "directives",
-      "anchor": "ClassMapDirective"
+      "anchor": "ClassMapDirective",
+      "excludeFromTOC": true
     }
   ],
   "$ClassMapDirective.constructor": [
@@ -1468,7 +1472,8 @@
   "$ClassInfo": [
     {
       "page": "directives",
-      "anchor": "ClassInfo"
+      "anchor": "ClassInfo",
+      "excludeFromTOC": true
     }
   ],
   "$classMap": [
@@ -1480,7 +1485,8 @@
   "$GuardDirective": [
     {
       "page": "directives",
-      "anchor": "GuardDirective"
+      "anchor": "GuardDirective",
+      "excludeFromTOC": true
     }
   ],
   "$GuardDirective.constructor": [
@@ -1528,7 +1534,8 @@
   "$LiveDirective": [
     {
       "page": "directives",
-      "anchor": "LiveDirective"
+      "anchor": "LiveDirective",
+      "excludeFromTOC": true
     }
   ],
   "$LiveDirective.constructor": [
@@ -1570,7 +1577,8 @@
   "$Ref": [
     {
       "page": "directives",
-      "anchor": "Ref"
+      "anchor": "Ref",
+      "excludeFromTOC": true
     }
   ],
   "$Ref.constructor": [
@@ -1634,7 +1642,8 @@
   "$RefDirective": [
     {
       "page": "directives",
-      "anchor": "RefDirective"
+      "anchor": "RefDirective",
+      "excludeFromTOC": true
     }
   ],
   "$RefDirective.constructor": [
@@ -1682,7 +1691,8 @@
   "$RefOrCallback": [
     {
       "page": "directives",
-      "anchor": "RefOrCallback"
+      "anchor": "RefOrCallback",
+      "excludeFromTOC": true
     }
   ],
   "$createRef": [
@@ -1700,7 +1710,8 @@
   "$RepeatDirective": [
     {
       "page": "directives",
-      "anchor": "RepeatDirective"
+      "anchor": "RepeatDirective",
+      "excludeFromTOC": true
     }
   ],
   "$RepeatDirective.constructor": [
@@ -1724,19 +1735,22 @@
   "$RepeatDirectiveFn": [
     {
       "page": "directives",
-      "anchor": "RepeatDirectiveFn"
+      "anchor": "RepeatDirectiveFn",
+      "excludeFromTOC": true
     }
   ],
   "$ItemTemplate": [
     {
       "page": "directives",
-      "anchor": "ItemTemplate"
+      "anchor": "ItemTemplate",
+      "excludeFromTOC": true
     }
   ],
   "$KeyFn": [
     {
       "page": "directives",
-      "anchor": "KeyFn"
+      "anchor": "KeyFn",
+      "excludeFromTOC": true
     }
   ],
   "$repeat": [
@@ -1748,7 +1762,8 @@
   "$StyleMapDirective": [
     {
       "page": "directives",
-      "anchor": "StyleMapDirective"
+      "anchor": "StyleMapDirective",
+      "excludeFromTOC": true
     }
   ],
   "$StyleMapDirective.constructor": [
@@ -1772,7 +1787,8 @@
   "$StyleInfo": [
     {
       "page": "directives",
-      "anchor": "StyleInfo"
+      "anchor": "StyleInfo",
+      "excludeFromTOC": true
     }
   ],
   "$styleMap": [
@@ -1784,7 +1800,8 @@
   "$TemplateContentDirective": [
     {
       "page": "directives",
-      "anchor": "TemplateContentDirective"
+      "anchor": "TemplateContentDirective",
+      "excludeFromTOC": true
     }
   ],
   "$TemplateContentDirective.constructor": [
@@ -1814,7 +1831,8 @@
   "$UnsafeHTMLDirective": [
     {
       "page": "directives",
-      "anchor": "UnsafeHTMLDirective"
+      "anchor": "UnsafeHTMLDirective",
+      "excludeFromTOC": true
     }
   ],
   "$UnsafeHTMLDirective.constructor": [
@@ -1876,7 +1894,8 @@
   "$UnsafeSVGDirective": [
     {
       "page": "directives",
-      "anchor": "UnsafeSVGDirective"
+      "anchor": "UnsafeSVGDirective",
+      "excludeFromTOC": true
     }
   ],
   "$UnsafeSVGDirective.constructor": [
@@ -1918,7 +1937,8 @@
   "$UntilDirective": [
     {
       "page": "directives",
-      "anchor": "UntilDirective"
+      "anchor": "UntilDirective",
+      "excludeFromTOC": true
     }
   ],
   "$UntilDirective.constructor": [

--- a/packages/lit-dev-content/site/_includes/api.html
+++ b/packages/lit-dev-content/site/_includes/api.html
@@ -255,7 +255,7 @@ layout: docs
 
 {% for item in data.items %}
   <div class="heading h2">
-    <h2 id="{{ item.location.anchor }}">
+    <h2 id="{{ item.location.anchor }}" {{ "data-toc-exclude" if item.location.excludeFromTOC }}>
       {{ item.name }}
     </h2>
     <span class="kindTag {{ kind(item) }}">

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
@@ -107,7 +107,7 @@ export const lit2Config: ApiDocsConfig = {
     {
       slug: 'directives',
       title: 'Directives',
-      anchorFilter: (node) => node.kindString === 'Function',
+      tocFilter: (node) => node.kindString === 'Function',
       versionLinks: {
         v1: 'api/lit-html/directives/',
       },

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -268,7 +268,11 @@ export class ApiDocsTransformer {
       : node.name;
 
     if (page && anchor) {
-      const location = {page, anchor};
+      const location = {
+        page,
+        anchor,
+        excludeFromTOC: nearestAncestorLocation?.excludeFromTOC,
+      };
       (node as ExtendedDeclarationReflection).location = location;
       this.updateSymbolMap(node.name, location);
       if (location.anchor !== node.name) {
@@ -678,7 +682,7 @@ export class ApiDocsTransformer {
       {
         slug: string;
         title: string;
-        anchorFilter?: (node: DeclarationReflection) => boolean;
+        tocFilter?: (node: DeclarationReflection) => boolean;
         items: Array<DeclarationReflection>;
         repo: string;
         commit: string;
@@ -733,10 +737,10 @@ export class ApiDocsTransformer {
     for (const page of pagesArray) {
       page.items.sort(this.symbolSortFn);
 
-      if (page.anchorFilter) {
-        for (const item of page.items) {
-          if (!page.anchorFilter(item)) {
-            delete (item as ExtendedDeclarationReflection)['location'];
+      if (page.tocFilter) {
+        for (const item of page.items as ExtendedDeclarationReflection[]) {
+          if (!page.tocFilter(item) && item.location) {
+            item.location.excludeFromTOC = true;
           }
         }
       }

--- a/packages/lit-dev-tools-cjs/src/api-docs/types.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/types.ts
@@ -31,6 +31,12 @@ export interface ExtendedSourceReference extends SourceReference {
 export interface Location {
   page: string;
   anchor: string;
+  /**
+   * Prevents this Location from being referenced by the generated Table of
+   * Contents by adding the "data-toc-exclude" attribute to the DOM node.
+   * See https://github.com/JordanShurmer/eleventy-plugin-nesting-toc
+   */
+  excludeFromTOC?: boolean;
 }
 
 /** A link to e.g. MDN. */
@@ -113,7 +119,7 @@ export interface ApiDocsConfig {
   pages: Array<{
     slug: string;
     title: string;
-    anchorFilter?: (node: DeclarationReflection) => boolean;
+    tocFilter?: (node: DeclarationReflection) => boolean;
     versionLinks?: {[version: string]: string};
   }>;
 


### PR DESCRIPTION
A better implementation of https://github.com/lit/lit.dev/pull/747.

Fixes: https://github.com/lit/lit.dev/issues/746
Also fixes: https://github.com/lit/lit.dev/issues/344

### Context

The `anchorFilter` originally deleted the `id` attribute from some of the generated documentation in order to simplify the table of contents generated on the page. This resulted in some fragment urls not linking correctly, i.e.: https://lit.dev/docs/api/directives/#RefOrCallback which doesn't link correctly because the `id` has been removed.

### How

Fixed by using the [`data-toc-exclude`](https://github.com/JordanShurmer/eleventy-plugin-nesting-toc#:~:text=can%20add%20the-,data%2Dtoc%2Dexclude,-attribute%20to%20exclude) boolean attribute that [eleventy-plugin-nesting-toc](https://github.com/JordanShurmer/eleventy-plugin-nesting-toc) uses to filter the TOC.

### Result

 - Some previously unsearchable symbols are now searchable. For example `StyleInfo`.
 - Fixes `{@link}` jsdocs to non function directive symbols.

### Testing

The filter is only used on the directive page. I manually compared the table of contents between [preview deploy](https://pr755-2297b6b---lit-dev-5ftespv5na-uc.a.run.app/docs/api/directives/) and the [production deploy](https://lit.dev/docs/api/directives/).

And the `RefOrCallback` link example now works: https://pr755-551f95e---lit-dev-5ftespv5na-uc.a.run.app/docs/api/directives/#RefOrCallback


