### PR TITLE
Use wireit in most of our scripts to track dependencies, add caching, and as a universally useful watch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ test-results
 
 *.tsbuildinfo
 lerna-debug.log
+
+.wireit

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ package-lock.json
 # TODO(aomarks) Would be nice to format samples, but Prettier doesn't always do
 # a great job compared to our manual formatting.
 /packages/lit-dev-content/samples/
+
+.wireit

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "lerna": "^4.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.1.2",
-        "typescript": "^4.4.3"
+        "typescript": "^4.4.3",
+        "wireit": "^0.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1530,6 +1531,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -1683,6 +1697,15 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1840,6 +1863,33 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/chownr": {
       "version": "2.0.0",
@@ -2774,6 +2824,20 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3538,6 +3602,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -4890,6 +4966,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -6160,6 +6245,18 @@
         "once": "^1.3.0"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7215,6 +7312,22 @@
       "dev": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wireit": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
+      "integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11"
+      },
+      "bin": {
+        "wireit": "bin/wireit.js"
+      },
+      "engines": {
+        "node": ">=16.7.0"
       }
     },
     "node_modules/wordwrap": {
@@ -8701,6 +8814,16 @@
         "color-convert": "^2.0.1"
       }
     },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -8839,6 +8962,12 @@
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8962,6 +9091,22 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "chownr": {
       "version": "2.0.0",
@@ -9700,6 +9845,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -10298,6 +10450,15 @@
       "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-boolean-object": {
@@ -11358,6 +11519,12 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -12325,6 +12492,15 @@
         "once": "^1.3.0"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -13116,6 +13292,16 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "wireit": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
+      "integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "bootstrap": "lerna bootstrap --ci",
-    "build": "lerna run build --stream",
+    "build": "wireit",
     "start": "run-p -r start:main start:playground start:fake-github",
     "start:main": "LITDEV_ENV=local MODE=main lerna run start --scope=lit-dev-server --stream",
     "start:playground": "LITDEV_ENV=local MODE=playground lerna run start --scope=lit-dev-server --stream",
-    "start:fake-github": "LITDEV_ENV=local node packages/lit-dev-tools-esm/lib/fake-github-server.js",
-    "dev": "cd packages/lit-dev-content && (npm run build:ts:watch -- --preserveWatchOutput & npm run dev:build:site:watch & npm run dev:serve)",
+    "start:fake-github": "wireit",
+    "dev": "cd packages/lit-dev-content && (npm run dev:build:site:watch & npm run dev:serve)",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "nuke": "rm -rf node_modules && npm ci && lerna exec 'rm -rf node_modules' && lerna bootstrap --ci",
@@ -23,6 +23,24 @@
     "test:links:redirects": "lerna run test:links:redirects --stream",
     "test:links:internal": "lerna run test:links:internal --stream",
     "test:links:external": "lerna run test:links:external --stream"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "./packages/lit-dev-api:build",
+        "./packages/lit-dev-content:build",
+        "./packages/lit-dev-server:build",
+        "./packages/lit-dev-tests:build",
+        "./packages/lit-dev-tools-cjs:build",
+        "./packages/lit-dev-tools-esm:build"
+      ]
+    },
+    "start:fake-github": {
+      "dependencies": [
+        "./packages/lit-dev-tools-esm:build"
+      ],
+      "command": "LITDEV_ENV=local node packages/lit-dev-tools-esm/lib/fake-github-server.js"
+    }
   },
   "devDependencies": {
     "lerna": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lerna": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
-    "typescript": "^4.4.3"
+    "typescript": "^4.4.3",
+    "wireit": "^0.1.1"
   }
 }

--- a/packages/lit-dev-api/package.json
+++ b/packages/lit-dev-api/package.json
@@ -6,8 +6,20 @@
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "node ../lit-dev-tools-cjs/lib/api-docs/generate.js",
-    "build:watch": "chokidar 'lit/packages/*/src/**/*.ts' '../lit-dev-tools-cjs/lib/api-docs/**/*.js' -c 'npm run build' --initial"
+    "build": "wireit",
+    "build:watch": "npm run build -- watch"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "../lit-dev-tools-cjs:build"
+      ],
+      "files": [
+        "lit/packages/*/src/**/*.ts"
+      ],
+      "#comment": "We don't declare the api-data directory as output because it's super huge, >1.4GB and 120k files. Maintaining the cache is probably not worth it.",
+      "command": "node ../lit-dev-tools-cjs/lib/api-docs/generate.js"
+    }
   },
   "dependencies": {
     "chokidar-cli": "^2.1.0",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -64,7 +64,7 @@
       "output": [
         "_site"
       ],
-      "#comment": "This is awkward. We want to do the watch part for build:not-site ourselves, but let eleventy do its own watch mode itself.",
+      "#comment": "This is awkward. We want to do the watch part for build:not-site ourselves, but let eleventy do its own watch mode itself. Maybe --incremental will do a quick rebuild of just the changed parts, and we don't need --watch?",
       "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy --watch"
     },
     "dev:build:site": {
@@ -98,12 +98,12 @@
       "output": [
         "site/fonts"
       ],
-      "command": "rm -rf site/fonts temp && mkdir -p site/fonts && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/ && cd ../.. && rm -rf temp"
+      "command": "rm -rf temp && mkdir -p site/fonts && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/ && cd ../.. && rm -rf temp"
     },
     "build:ts": {
       "files": [
         "src/**",
-        "package.json",
+        "tsconfig.json",
         "../../tsconfig.base.json"
       ],
       "output": [
@@ -135,7 +135,7 @@
       "output": [
         "samples/js/**"
       ],
-      "command": "rm -rf samples/js && node ../lit-dev-tools-esm/lib/generate-js-samples.js"
+      "command": "node ../lit-dev-tools-esm/lib/generate-js-samples.js"
     }
   },
   "devDependencies": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -39,6 +39,10 @@
       "dependencies": [
         "build:not-site"
       ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
+      ],
       "command": "NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
     "dev:serve": {
@@ -55,6 +59,10 @@
       "output": [
         "_site"
       ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
+      ],
       "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
     "build:site:watch": {
@@ -65,6 +73,10 @@
         "_site"
       ],
       "#comment": "This is awkward. We want to do the watch part for build:not-site ourselves, but let eleventy do its own watch mode itself. Maybe --incremental will do a quick rebuild of just the changed parts, and we don't need --watch?",
+      "files": [
+        "site/**",
+        ".eleventy.js"
+      ],
       "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy --watch"
     },
     "dev:build:site": {
@@ -74,6 +86,10 @@
       "output": [
         "_dev"
       ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
+      ],
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
     "dev:build:site:watch": {
@@ -82,6 +98,10 @@
       ],
       "output": [
         "_dev"
+      ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
       ],
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
     },

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -7,23 +7,136 @@
   "license": "BSD-3-Clause",
   "main": "_site/index.html",
   "scripts": {
-    "postinstall": "ls site/fonts/manrope* > /dev/null || npm run fonts:manrope",
-    "fonts:manrope": "rm -rf site/fonts temp && mkdir -p site/fonts && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/ && cd ../.. && rm -rf temp",
-    "build": "npm run build:not-site && npm run build:site",
-    "build:not-site": "npm run build:ts && npm run build:rollup && npm run build:samples",
-    "build:site": "rm -rf _site && LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy",
-    "build:site:watch": "npm run build:site -- --watch",
-    "build:ts": "../../node_modules/.bin/tsc",
-    "build:ts:watch": "../../node_modules/.bin/tsc --watch",
-    "build:rollup": "rm -rf rollupout && rollup -c",
-    "build:rollup:watch": "rm -rf rollupout && rollup -c --watch",
-    "build:samples": "rm -rf samples/js && node ../lit-dev-tools-esm/lib/generate-js-samples.js",
-    "build:samples:watch": "npm run build:samples -- --watch",
-    "dev:build": "npm run build:not-site && npm run dev:build:site",
-    "dev:build:site": "rm -rf _dev && LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy",
-    "dev:build:site:watch": "npm run dev:build:site -- --watch --incremental",
-    "dev:serve": "node ../lit-dev-tools-esm/lib/dev-server.js --open",
-    "prod:build": "npm run build:not-site && NODE_OPTIONS=--experimental-vm-modules eleventy"
+    "fonts:manrope": "wireit",
+    "build": "wireit",
+    "build:not-site": "wireit",
+    "build:site": "wireit",
+    "build:site:watch": "wireit",
+    "build:ts": "wireit",
+    "build:ts:watch": "npm run build:ts -- watch",
+    "build:rollup": "wireit",
+    "build:rollup:watch": "npm run build:rollup -- watch",
+    "build:samples": "wireit",
+    "build:samples:watch": "npm run build:samples -- watch",
+    "dev:build": "wireit",
+    "dev:build:site": "wireit",
+    "dev:build:site:watch": "wireit",
+    "dev:serve": "wireit",
+    "prod:build": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:site"
+      ]
+    },
+    "dev:build": {
+      "dependencies": [
+        "dev:build:site"
+      ]
+    },
+    "prod:build": {
+      "dependencies": [
+        "build:not-site"
+      ],
+      "command": "NODE_OPTIONS=--experimental-vm-modules eleventy"
+    },
+    "dev:serve": {
+      "dependencies": [
+        "../lit-dev-tools-esm:build",
+        "dev:build"
+      ],
+      "command": "node ../lit-dev-tools-esm/lib/dev-server.js --open"
+    },
+    "build:site": {
+      "dependencies": [
+        "build:not-site"
+      ],
+      "output": [
+        "_site"
+      ],
+      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
+    },
+    "build:site:watch": {
+      "dependencies": [
+        "build:not-site"
+      ],
+      "output": [
+        "_site"
+      ],
+      "#comment": "This is awkward. We want to do the watch part for build:not-site ourselves, but let eleventy do its own watch mode itself.",
+      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy --watch"
+    },
+    "dev:build:site": {
+      "dependencies": [
+        "build:not-site"
+      ],
+      "output": [
+        "_dev"
+      ],
+      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
+    },
+    "dev:build:site:watch": {
+      "dependencies": [
+        "build:not-site"
+      ],
+      "output": [
+        "_dev"
+      ],
+      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
+    },
+    "build:not-site": {
+      "dependencies": [
+        "build:ts",
+        "build:rollup",
+        "build:samples",
+        "fonts:manrope"
+      ]
+    },
+    "fonts:manrope": {
+      "files": [],
+      "output": [
+        "site/fonts"
+      ],
+      "command": "rm -rf site/fonts temp && mkdir -p site/fonts && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/ && cd ../.. && rm -rf temp"
+    },
+    "build:ts": {
+      "files": [
+        "src/**",
+        "package.json",
+        "../../tsconfig.base.json"
+      ],
+      "output": [
+        "lib"
+      ],
+      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "clean": "if-file-deleted"
+    },
+    "build:rollup": {
+      "dependencies": [
+        "build:ts"
+      ],
+      "files": [
+        "rollup.config.js"
+      ],
+      "output": [
+        "rollupout"
+      ],
+      "command": "rollup -c"
+    },
+    "build:samples": {
+      "dependencies": [
+        "../lit-dev-tools-esm:build"
+      ],
+      "files": [
+        "samples/**",
+        "!samples/js"
+      ],
+      "output": [
+        "samples/js/**"
+      ],
+      "command": "rm -rf samples/js && node ../lit-dev-tools-esm/lib/generate-js-samples.js"
+    }
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.1",

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -24,7 +24,7 @@
       ],
       "files": [
         "src/**",
-        "package.json",
+        "tsconfig.json",
         "../../tsconfig.base.json"
       ],
       "output": [

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -35,9 +35,9 @@
     },
     "start": {
       "dependencies": [
-        "build"
+        "build",
+        "../lit-dev-content:build:site"
       ],
-      "#comment": "These deps aren't complete, this depends on lit-dev-content...",
       "command": "node lib/server.js"
     }
   },

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -8,9 +8,38 @@
   "type": "module",
   "main": "lib/server.js",
   "scripts": {
-    "build": "npm run build:ts",
-    "build:ts": "../../node_modules/.bin/tsc",
-    "start": "node lib/server.js"
+    "build": "wireit",
+    "build:ts": "wireit",
+    "start": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:ts"
+      ]
+    },
+    "build:ts": {
+      "dependencies": [
+        "../lit-dev-tools-cjs:build"
+      ],
+      "files": [
+        "src/**",
+        "package.json",
+        "../../tsconfig.base.json"
+      ],
+      "output": [
+        "lib"
+      ],
+      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "clean": "if-file-deleted"
+    },
+    "start": {
+      "dependencies": [
+        "build"
+      ],
+      "#comment": "These deps aren't complete, this depends on lit-dev-content...",
+      "command": "node lib/server.js"
+    }
   },
   "dependencies": {
     "koa": "^2.13.0",

--- a/packages/lit-dev-tests/package.json
+++ b/packages/lit-dev-tests/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "wireit",
     "start": "cd ../.. && npm run start",
     "test:integration": "playwright install && playwright test --config=lib/playwright.config.js",
     "test:integration:update-golden-screenshots": "npm run test:integration -- --update-snapshots",
@@ -16,6 +16,23 @@
     "test:links:internal:cmd": "wait-on tcp:6415 && broken-link-checker http://localhost:6415 --recursive --exclude-external --ordered",
     "test:links:external": "run-p --race start test:links:external:cmd",
     "test:links:external:cmd": "wait-on tcp:6415 && broken-link-checker http://localhost:6415 --exclude 'http://localhost:8000/dev/' --exclude 'https://www.npmjs.com/*' --exclude 'https://twitter.com/*' --get --recursive --host-requests 1"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "../lit-dev-server:build"
+      ],
+      "files": [
+        "src/**",
+        "tsconfig.json",
+        "../../tsconfig.base.json"
+      ],
+      "output": [
+        "lib"
+      ],
+      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "clean": "if-file-deleted"
+    }
   },
   "dependencies": {
     "@playwright/test": "^1.19.1",

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -6,9 +6,34 @@
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "npm run build:ts",
-    "build:ts": "../../node_modules/.bin/tsc",
-    "test": "uvu ./lib \".spec.js$\""
+    "build": "wireit",
+    "build:ts": "wireit",
+    "test": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:ts"
+      ]
+    },
+    "build:ts": {
+      "files": [
+        "src/**",
+        "package.json"
+      ],
+      "output": [
+        "lib"
+      ],
+      "command": "../../node_modules/.bin/tsc"
+    },
+    "test": {
+      "dependencies": [
+        "build"
+      ],
+      "files": [],
+      "output": [],
+      "command": "uvu ./lib \".spec.js$\""
+    }
   },
   "dependencies": {
     "@types/jsdom": "^16.2.13",

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -19,12 +19,14 @@
     "build:ts": {
       "files": [
         "src/**",
-        "package.json"
+        "package.json",
+        "../../tsconfig.base.json"
       ],
       "output": [
         "lib"
       ],
-      "command": "../../node_modules/.bin/tsc"
+      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "clean": "if-file-deleted"
     },
     "test": {
       "dependencies": [

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -19,7 +19,7 @@
     "build:ts": {
       "files": [
         "src/**",
-        "package.json",
+        "tsconfig.json",
         "../../tsconfig.base.json"
       ],
       "output": [

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -7,8 +7,31 @@
   "license": "BSD-3-Clause",
   "type": "module",
   "scripts": {
-    "build": "npm run build:ts",
-    "build:ts": "../../node_modules/.bin/tsc"
+    "build": "wireit",
+    "build:ts": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:ts"
+      ]
+    },
+    "build:ts": {
+      "dependencies": [
+        "../lit-dev-server:build",
+        "../lit-dev-tools-cjs:build"
+      ],
+      "files": [
+        "src/**",
+        "package.json",
+        "../../tsconfig.base.json"
+      ],
+      "output": [
+        "lib"
+      ],
+      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "clean": "if-file-deleted"
+    }
   },
   "dependencies": {
     "@lit/ts-transformers": "^1.0.0",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -23,7 +23,7 @@
       ],
       "files": [
         "src/**",
-        "package.json",
+        "tsconfig.json",
         "../../tsconfig.base.json"
       ],
       "output": [

--- a/packages/lit-dev-tools-esm/tsconfig.json
+++ b/packages/lit-dev-tools-esm/tsconfig.json
@@ -2,8 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "incremental": true,
+    "tsBuildInfoFile": "lib/.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": []
 }

--- a/packages/lit-dev-tools-esm/tsconfig.json
+++ b/packages/lit-dev-tools-esm/tsconfig.json
@@ -6,8 +6,6 @@
     "incremental": true,
     "tsBuildInfoFile": "lib/.tsbuildinfo"
   },
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
This should behave exactly the same, only now the dependencies are explicit (e.g. if you run `npm test` it will build the typescript if necessary), does caching (so rebuilding or rerunning tests is instant if no TS source files have changed), and supports a watch mode (e.g. with `npm test -- watch`)