### PR TITLE
Fix minor typo in live directive paragraph

### DIFF
--- a/packages/lit-dev-content/site/docs/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/templates/directives.md
@@ -1197,7 +1197,7 @@ customElements.define('my-element', MyElement);
 
 {% endswitchable-sample %}
 
-`live()` performs a strict equality check agains the live DOM value, and if
+`live()` performs a strict equality check against the live DOM value, and if
 the new value is equal to the live value, does nothing. This means that
 `live()` should not be used when the expression will cause a type conversion. If
 you use `live()` with an attribute expression, make sure that only strings are


### PR DESCRIPTION
Fixing a minor typo in the live directive description. Changed `agains` to `against`.

PS - When doing a search across files, I saw that there are two more instances of the typo (below). However, I wasn't sure how to rebuild these. I tried running `npm run build` from `/packages/lit-dev-api/package.json` but it didn't seem to work. I can gladly update this PR if I can get some guidance on how to do so!
- `/packages/lit-dev-api/api-data/lit-2/pages.json`
- `/packages/lit-dev-api/api-data/lit-html-1/pages.json`