### PR TITLE
Increase renderer timeout

### DIFF
--- a/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
@@ -45,7 +45,7 @@ export class BlockingRenderer {
   private exited = false;
   private renderTimeout: number;
 
-  constructor({renderTimeout = 30000, maxHtmlBytes = 1024 * 1024} = {}) {
+  constructor({renderTimeout = 60_000, maxHtmlBytes = 1024 * 1024} = {}) {
     this.renderTimeout = renderTimeout;
     this.sharedHtml = new Uint8Array(new SharedArrayBuffer(maxHtmlBytes));
     this.worker = new workerthreads.Worker(


### PR DESCRIPTION
Been seeing this error in some runs that have stalled out in the wireit branches, I think because we're doing more things in parallel it's meant that some eleventy rendering has been timing out