### PR TITLE
litdev-aside space between

### DIFF
--- a/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/03.md
@@ -63,7 +63,6 @@ Simple Attribute Converters.
 If your `toAttribute` is just `toString`, then you can use a Simple Attribute Converter instead of a Complex Attribute Converter.
 
 A Simple Attribute Converter is a function that is equivalent to the `fromAttribue` method of a Complex Attribute Converter object.
-
 [Read more here.](/docs/components/properties/#conversion-converter)
 
 </litdev-aside>

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -43,8 +43,14 @@ export class LitDevAside extends LitElement {
       font-weight: bold;
     }
 
-    ::slotted(*) {
-      margin: 0;
+    ::slotted(:first-of-type),
+    ::slotted(:nth-of-type(2)) {
+      margin-block-start: 0;
+    }
+
+    ::slotted(:first-of-type),
+    ::slotted(:last-of-type) {
+      margin-block-end: 0;
     }
   `;
 


### PR DESCRIPTION
Allows children to do their default margins except between the title and the following paragraph as well as the start and end nodes.

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/5981958/166074127-ccc37cff-f4d2-4dee-acbb-9c8169b1ecc3.png) | ![image](https://user-images.githubusercontent.com/5981958/166074144-742b56ed-6a38-4372-b5e3-61b7e92bf6dd.png) |
| ![image](https://user-images.githubusercontent.com/5981958/166074297-4658b9d6-5154-4429-8e6d-f7a62448eecc.png) | ![image](https://user-images.githubusercontent.com/5981958/166074314-b635f6a6-db22-42cd-b94b-b1a52529a1a9.png) |
| ![image](https://user-images.githubusercontent.com/5981958/166074446-cd15397b-1398-469d-ac53-62488ce14e77.png) | ![image](https://user-images.githubusercontent.com/5981958/166074462-6bbdb8fa-42cc-4b9b-a551-7eadcdeed365.png) |