### PR TITLE
implement tutorial gtag

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -649,7 +649,6 @@ export class LitDevTutorial extends LitElement {
       this._idx++;
       this._writeUrl();
       if (this._manifest.steps.length > 1 && this._projectLocation) {
-        // User has advanced in the tutorial and we are on the last step.
         const eventFired = reportTutorialMetrics({
           idx: this._idx,
           tutorialUrl: this._projectLocation,

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -62,9 +62,6 @@ interface ExpandedTutorialStep {
 
 type CheckStatus = 'INDETERMINATE' | 'CHECKING' | 'PASSED' | 'FAILED';
 
-let hasRecordedStart = false;
-let hasRecordedEnd = false;
-
 /**
  * Tutorial controller and text display.
  *
@@ -150,6 +147,16 @@ export class LitDevTutorial extends LitElement {
    * change the page. Used to disable the "Check" code button.
    */
   @state() private _requestSolvedCode = false;
+
+  /**
+   * Whether or not gtag has reported the start of the tutorial.
+   */
+  private _hasRecordedStart = false;
+
+  /**
+   * Whether or not gtag has reported the end of the tutorial.
+   */
+  private _hasRecordedEnd = false;
 
   /**
    * Receives check status messages from the playground and updates the check
@@ -332,8 +339,8 @@ export class LitDevTutorial extends LitElement {
         idx: this._idx,
         numSteps: this._manifest.steps.length,
         tutorialUrl: this._projectLocation,
-        hasRecordedStart,
-        hasRecordedEnd,
+        hasRecordedStart: this._hasRecordedStart,
+        hasRecordedEnd: this._hasRecordedEnd,
       });
 
       this._handleTutorialMetricEvent(eventFired);
@@ -653,8 +660,8 @@ export class LitDevTutorial extends LitElement {
           idx: this._idx,
           tutorialUrl: this._projectLocation,
           numSteps: this._manifest.steps.length,
-          hasRecordedStart,
-          hasRecordedEnd,
+          hasRecordedStart: this._hasRecordedStart,
+          hasRecordedEnd: this._hasRecordedEnd,
         });
 
         this._handleTutorialMetricEvent(eventFired);
@@ -790,15 +797,21 @@ export class LitDevTutorial extends LitElement {
   }
 
   private _handleTutorialMetricEvent(event: TutorialMetricEvent) {
+    if (!event) {
+      return;
+    }
+
     switch (event) {
       case 'tutorial_start':
-        hasRecordedStart = true;
+        this._hasRecordedStart = true;
         break;
       case 'tutorial_end':
-        hasRecordedEnd = true;
+        this._hasRecordedEnd = true;
         break;
       case 'tutorial_progress':
+        break;
       default:
+        ((_event: never) => {})(event);
         break;
     }
   }

--- a/packages/lit-dev-content/src/components/litdev-tutorial.ts
+++ b/packages/lit-dev-content/src/components/litdev-tutorial.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {LitElement, html, nothing} from 'lit';
+import {LitElement, html, nothing, PropertyValues} from 'lit';
 import {property, query, state} from 'lit/decorators.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {when} from 'lit/directives/when.js';
@@ -301,6 +301,13 @@ export class LitDevTutorial extends LitElement {
     // This is a site-specific component, and we want to inherit site-wide
     // styles.
     return this;
+  }
+
+  update(changed: PropertyValues<this>): void {
+    if (this._manifest.header) {
+      document.title = `${this._manifest.header} Tutorial – Lit`;
+    }
+    super.update(changed);
   }
 
   willUpdate(): void {

--- a/packages/lit-dev-content/src/types/gtag.d.ts
+++ b/packages/lit-dev-content/src/types/gtag.d.ts
@@ -1,0 +1,7 @@
+interface Window {
+  gtag?: (
+    interface: 'event',
+    eventName: string,
+    params?: {[param: string]: unknown}
+  ) => void;
+}

--- a/packages/lit-dev-content/src/types/gtag.d.ts
+++ b/packages/lit-dev-content/src/types/gtag.d.ts
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 interface Window {
   gtag?: (
     interface: 'event',

--- a/packages/lit-dev-content/src/util/gtag-helpers.ts
+++ b/packages/lit-dev-content/src/util/gtag-helpers.ts
@@ -26,7 +26,7 @@ export const reportTutorialMetrics = ({
   numSteps,
 }: TutorialMetricsOptions): TutorialMetricEvent => {
   // A user can load a tutorial from a URL at a step that is not 0, hence
-  // we shoul consider whether start has not been recorded already.
+  // we should consider whether start has not been recorded already.
   if (idx === 0 || !hasRecordedStart) {
     // The first tutorial step viewed
     window.gtag?.('event', 'tutorial_start', {

--- a/packages/lit-dev-content/src/util/gtag-helpers.ts
+++ b/packages/lit-dev-content/src/util/gtag-helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export type TutorialMetricsOptions = {
+  idx: number;
+  tutorialUrl: string;
+  hasRecordedStart: boolean;
+  hasRecordedEnd: boolean;
+  numSteps: number;
+};
+
+export type TutorialMetricEvent =
+  | 'tutorial_start'
+  | 'tutorial_progress'
+  | 'tutorial_end'
+  | null;
+export const reportTutorialMetrics = ({
+  idx,
+  tutorialUrl,
+  hasRecordedStart,
+  hasRecordedEnd,
+  numSteps,
+}: TutorialMetricsOptions): TutorialMetricEvent => {
+  if (idx === 0 || !hasRecordedStart) {
+    window.gtag?.('event', 'tutorial_start', {
+      category: 'tutorials',
+      event_label: tutorialUrl,
+      value: idx,
+    });
+    return 'tutorial_start';
+  } else if (idx !== numSteps - 1 && !hasRecordedEnd) {
+    window.gtag?.('event', 'tutorial_progress', {
+      category: 'tutorials',
+      event_label: tutorialUrl,
+      value: idx,
+    });
+    return 'tutorial_progress';
+  } else if (idx === numSteps - 1 && !hasRecordedEnd) {
+    window.gtag?.('event', 'tutorial_end', {
+      category: 'tutorials',
+      event_label: tutorialUrl,
+    });
+    return 'tutorial_end';
+  }
+
+  return null;
+};

--- a/packages/lit-dev-content/src/util/gtag-helpers.ts
+++ b/packages/lit-dev-content/src/util/gtag-helpers.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export type TutorialMetricsOptions = {
+export interface TutorialMetricsOptions {
   idx: number;
   tutorialUrl: string;
   hasRecordedStart: boolean;
   hasRecordedEnd: boolean;
   numSteps: number;
-};
+}
 
 export type TutorialMetricEvent =
   | 'tutorial_start'
@@ -24,7 +24,10 @@ export const reportTutorialMetrics = ({
   hasRecordedEnd,
   numSteps,
 }: TutorialMetricsOptions): TutorialMetricEvent => {
+  // A user can load a tutorial from a URL at a step that is not 0, hence
+  // we shoul consider whether start has not been recorded already.
   if (idx === 0 || !hasRecordedStart) {
+    // The first tutorial step viewed
     window.gtag?.('event', 'tutorial_start', {
       category: 'tutorials',
       event_label: tutorialUrl,
@@ -32,6 +35,7 @@ export const reportTutorialMetrics = ({
     });
     return 'tutorial_start';
   } else if (idx !== numSteps - 1 && !hasRecordedEnd) {
+    // Tutorial progress
     window.gtag?.('event', 'tutorial_progress', {
       category: 'tutorials',
       event_label: tutorialUrl,
@@ -39,6 +43,7 @@ export const reportTutorialMetrics = ({
     });
     return 'tutorial_progress';
   } else if (idx === numSteps - 1 && !hasRecordedEnd) {
+    // Reached the final step of the tutorial
     window.gtag?.('event', 'tutorial_end', {
       category: 'tutorials',
       event_label: tutorialUrl,


### PR DESCRIPTION
Fires tutorial start and end events. Also sets `document.title` which is also useful for gtag events

```
tutorial_start: {
  category: tutorials,
  label: tutorial folder name,
  value: step tutorial page was loaded,
}

tutorial_end {
  category: tutorials,
  label: tutorial folder name,
}
```

## tutorial_start event

fired when the page and manifest area loaded, and includes the step the page was loaded on.

## tutorial_end event

fired when the next button is pressed and the page index matches the length of steps in the laoded manifest -1. Signaling progression

## faults

- start is fired whenever the page loads so that may include reloads
  - can likely be deduplicated by session ID cloud-side
  - hopefully can fire automated event if session has start index of 0 and also fires end event
- if initial page loaded is the final page, then next button cannot be pressed unless they go back and press right
  - doesn't signal progression so this is fine, but may have a mismatched start to end