### PR TITLE
make aside headers same line as content

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -189,36 +189,36 @@ customElements.define('my-element', MyElement);
 You can also insert an aside in your instructions by using the following format:
 
 ```html
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 The first line is always a bolded header.
 
 Make sure to do `this`!
 
-</litdev-aside>
+{% endaside %}
 
-<litdev-aside type="warn" no-header>
+{% aside "warn" no-header %}
 
 The `no-header` will make sure that this line is not bolded.
 
 Beware of `this`!
 
-</litdev-aside>
+{% endaside %}
 
-<litdev-aside type="negative">
+{% aside "negative" %}
 
 Make sure NOT to do `this`!
 
 The following non-header lines here make sense to explain the assertion in
 the header line above.
 
-</litdev-aside>
+{% endaside %}
 
-<litdev-aside type="info">
+{% aside "info" %}
 
 Check out more info [in this docs section](/docs/templates/expressions/#well-formed-html).
 
-</litdev-aside>
+{% endaside %}
 ```
 
 *Note:* markdown will only be parsed as markdown if there is an empty line

--- a/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
+++ b/packages/lit-dev-content/samples/tutorials/CONTRIBUTING.md
@@ -197,7 +197,7 @@ Make sure to do `this`!
 
 {% endaside %}
 
-{% aside "warn" no-header %}
+{% aside "warn" "no-header" %}
 
 The `no-header` will make sure that this line is not bolded.
 

--- a/packages/lit-dev-content/site/tutorials/content/carousel/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/01.md
@@ -61,7 +61,7 @@ The properties in the `:host` selector are effectively defaults for the
 element and it's important to remember that the user can override
 them to customize the appearance.
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
   Learn more about [theming](/docs/components/styles/#theming),
   [styling](/docs/components/styles/#shadow-dom), and the
@@ -69,4 +69,4 @@ them to customize the appearance.
   and [`:slotted`](/docs/components/styles/#slotted)
   selectors in the Lit documentation.
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/carousel/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/03.md
@@ -58,7 +58,7 @@ Since the selected item is not rendered by Lit, it needs to be managed directly
 with imperative code. The previously selected item is tracked so it can be
 un-slotted when `selected` changes.
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 In most cases, it's not recommended to directly manipulate element light DOM children.
 
@@ -74,7 +74,7 @@ method that removes the need to match the element's `slot` attribute to the
 slot's name. However, at the time this tutorial has been authored, this isn't
 yet widely supported so the code here sets the element's `slot`.
 
-</litdev-aside>
+{% endaside %}
 
 To verify that changing the selected item does what's expected,
 open `index.html` and add a `selected="1"` attribute to the `motion-carousel`

--- a/packages/lit-dev-content/site/tutorials/content/carousel/04.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/04.md
@@ -48,13 +48,13 @@ it should send an event describing what happened so other application code
 can easily respond. The event name is `change` and it sends the selected item
 info as its `detail`.
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 Dispatch events when an element changes state based on user interaction, rather than when properties are set directly.
 
 See the [best practices doc on web.dev](https://web.dev/index.md/#events)
 for more info.
 
-</litdev-aside>
+{% endaside %}
 
 Go ahead and try it out in the preview to make sure everything works.

--- a/packages/lit-dev-content/site/tutorials/content/carousel/08.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/08.md
@@ -7,7 +7,7 @@ similar pattern to position `left` and `width` based on the `selected` item.
 
 Now import the `animate` directive from the `@lit-labs/motion` package.
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
   Packages released under `@lit-labs` aren't quite ready for production.
 
@@ -15,7 +15,7 @@ Now import the `animate` directive from the `@lit-labs/motion` package.
   subject to breaking changes. See the Lit [documentation](/docs/libraries/labs/)
   for more info.
 
-</litdev-aside>
+{% endaside %}
 
 Add the import after the other import statements at the top of the module.
 
@@ -23,12 +23,12 @@ Add the import after the other import statements at the top of the module.
 import {animate} from '@lit-labs/motion';
 ```
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 Normally, you'd also need to add `@lit-labs/motion` to your
 `package.json` but to speed things up, that's already been done.
 
-</litdev-aside>
+{% endaside %}
 
 The `animate` directive will take care of animating the position. It's
 great for ["tweening"](https://en.wikipedia.org/wiki/Inbetweening)
@@ -60,11 +60,11 @@ The `animate` directive is intended to be very simple to use, but it has a lot
 of configuration options. Check out the [@lit-labs/motion readme](https://github.com/lit/lit/blob/main/packages/labs/motion/README.md#lit-labsmotion)
 for more information.
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 Check out this [article on FLIP](https://aerotwist.com/blog/flip-your-animations/)
 to learn more about the technique used by the `animate` directive.
 
-</litdev-aside>
+{% endaside %}
 
 Now try clicking the element...

--- a/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/01.md
@@ -6,13 +6,13 @@ In this example:
   - Displays out the given `date` in a human-readable-format
 - `index.html` passes the the date `05/05/22` to `my-element` as a `Date` object via property
 
-<litdev-aside type="info">
+{% aside "info" %}
 
 Attribute to property conversion is turned off.
 
 This is because the `@property` decorator or `static properties` block will tell Lit to convert a string attribute based on the object passed in as the `type` option. Lit does not know how to handle `type: Date` (string attribute to JS `Date` object conversion), so the only way to pass `date` to `my-element` is via Javascript which may lead to a bad developer experience.
 
-</litdev-aside>
+{% endaside %}
 
 ## Attribute Converters
 
@@ -30,13 +30,13 @@ Lit has several built-in attribute converters. You can choose which built-in con
 
 Notice that Lit does not have a `Date` converter built-in and thus you cannot do `type: Date` to accept a date-string attribute. You can read more on how built-in coverters convert attributes to properties and vice versa in the [Lit documentation](/docs/components/properties/#conversion-type).
 
-<litdev-aside type="negative">
+{% aside "negative" %}
 
 This section is meant for example does not include best-practice code.
 
 This section is shows why you would need custom attribute converters and is not recommended best-practice code. If you'd like to skip to the section in which you write custom attribute converters, go to [step 4](#03).
 
-</litdev-aside>
+{% endaside %}
 
 ## Goal for this step
 

--- a/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/02.md
+++ b/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/02.md
@@ -24,13 +24,13 @@ Now you may notice that the date displayed is not the same as the one you passed
 * On each change convert the `dateStr` to a JS `Date` object
 * Update the `date` property to reflect the user-defined date so that it can be displayed
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 The `willUpdate` method is a good place to reconcile two different reactive properties.
 
 Read more on the Lit lifecycle [here](/docs/components/lifecycle/)!
 
-</litdev-aside>
+{% endaside %}
 
 #### my-element.(ts|js)
 

--- a/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/custom-attribute-converter/03.md
@@ -56,7 +56,7 @@ export const dateConverter = {
 
 {% endswitchable-sample %}
 
-<litdev-aside class="positive">
+{% aside "positive" %}
 
 Simple Attribute Converters.
 
@@ -65,7 +65,8 @@ If your `toAttribute` is just `toString`, then you can use a Simple Attribute Co
 A Simple Attribute Converter is a function that is equivalent to the `fromAttribue` method of a Complex Attribute Converter object.
 [Read more here.](/docs/components/properties/#conversion-converter)
 
-</litdev-aside>
+{% endaside %}
+
 
 
 Congratulations! You've just defined a custom attribute converter! You can read

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/00.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/00.md
@@ -15,23 +15,23 @@ Lit provides APIs to simplify common web components tasks like managing properti
 * What is Lit
 * How to build a Lit component
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 Getting started with lit?
 
 This tutorial focuses on the web components specifications and how Lit works under the hood to help you build web components more easily. For a more general introduction to Lit, take a look at the [Lit docs](/docs/) or [other tutorials](/tutorials/).
 
-</litdev-aside>
+{% endaside %}
 
 ## What you’ll build
 
 * A vanilla thumbs up / down web component
 * A thumbs up / down LitElement-based web component
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 Already know the basics of web components?
 
 Skip to [Lit templates](#09), to see how Lit can help!
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/01.md
@@ -33,13 +33,13 @@ customElements.define('rating-element', RatingElement);
 
 You define a custom element by associating an element class with a tag name. The class must extend `HTMLElement`, and the tag name must must contain a hyphen (`-`) to differentiate it from a native browser elements.
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 Custom Element names are global.
 
 Since `customElements.define` has a global scope, you cannot currently call it more than once for the same tag name even if the same class definition is given.
 
-</litdev-aside>
+{% endaside %}
 
 Place a `<rating-element>` in the document body and see what renders.
 

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/02.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/02.md
@@ -7,13 +7,13 @@ Custom elements come with a set of lifecycle hooks. In this section you'll use t
 
 The `constructor` is called when the element is first created: for example, by calling `document.createElement(‘rating-element')` or `new RatingElement()`. The constructor is a good place to set up your element.
 
-<litdev-aside type="negative">
+{% aside "negative" %}
 
 It's bad practice to do DOM manipulation in the `constructor`.
 
 This is because DOM manipulations can slow down initial load times, and [cause some problems in some edge cases](/playground/#gist=34f89b3c8c1c930b3d943c49656d1f2a).
 
-</litdev-aside>
+{% endaside %}
 
 The `connectedCallback` is called when the custom element is attached to the DOM. This is typically where initial DOM manipulations happen.
 
@@ -98,8 +98,8 @@ export class RatingElement extends HTMLElement {
 
 In the `constructor`, you store an instance *property* called `rating` on the element. In the `connectedCallback`, you add DOM children to `<rating-element>` to display the current rating, together with thumbs up and thumbs down buttons.
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 This example is not following accessibility best practices for controls and inputs.
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/03.md
@@ -83,10 +83,10 @@ An experiment: add a node as a direct child of the `<rating-element>`:
 
 Once the page refreshes, you'll see that the new `<div>` does not show up. This is because shadow DOM has features to control how child nodes—sometimes called *light DOM*—are rendered or *projected* into the shadow DOM.
 
-<litdev-aside type="info">
+{% aside "info" %}
 
 This tutorial doesn't cover light DOM projection.
 
 You can learn more about projection in [this article](https://web.dev/shadowdom-v1/#composition-and-slots) or the [Lit documentation](/docs/components/shadow-dom/#slots).
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/07.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/07.md
@@ -116,13 +116,13 @@ and in the setter, check if the new value is different. If so, adjust the
 `rating` accordingly and, importantly, reflect the `vote` attribute back to the
 host with `this.setAttribute`.
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 It is not recommended to manipulate `rating` inside the `vote` setter in this way.
 
 This is not the most efficient way to update `rating`, but it's the most convenient way for this tutorial.
 
-</litdev-aside>
+{% endaside %}
 
 ## Handle "vote" Attribute Changes
 

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/09.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/09.md
@@ -26,13 +26,13 @@ Template elements also lend themselves to imperative code. In many cases this le
 
 This is where Lit templates comes in! Lit lets you write templates in JavaScript, then efficiently render and re-render those templates together with data to create and update DOM. It is similar to JSX and Virtual DOM libraries but it runs natively in the browser and much more efficiently than VDOM in many cases.
 
-<litdev-aside type="info">
+{% aside "info" %}
 
 This tutorial uses only a few of the features supported by Lit templates.
 
 For full coverage, see [Templates](/docs/templates/overview/) in the Lit documentation.
 
-</litdev-aside>
+{% endaside %}
 
 ## Using Lit templates
 

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/10.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/10.md
@@ -16,11 +16,11 @@ Now that you have gotten rid of the `<template>` element in `index.html`, refact
 
 Lit templates can add an event listener to a node with the `@EVENT_NAME` binding syntax where, in this case, you update the `vote` property every time these buttons are clicked.
 
-<litdev-aside type="info">
+{% aside "info" %}
 
 You can learn more about the Lit binding syntax in the [Lit Expressions documentation](/docs/templates/expressions/).
 
-</litdev-aside>
+{% endaside %}
 
 Next:
 
@@ -122,13 +122,13 @@ set vote(newValue) {
 
 {% endswitchable-sample %}
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 This is not the most efficient way to update the DOM.
 
 Synchronously calling `render()` in the setters of `rating` and `vote` is not the most efficient way to update the DOM, but it is a good way to illustrate where `LitElement` calls `render()` (next step).
 
-</litdev-aside>
+{% endaside %}
 
 Here, you:
 

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/11.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/11.md
@@ -58,11 +58,11 @@ What's changed?
 
 The `css` tag function allows you to define CSS tagged template literals, which enable math, templating, and other features under the hood.
 
-<litdev-aside class="info">
+{% aside "info" %}
 
 For a comprehensive list of styling features, Refer to the [Lit Styles documentation](https://lit.dev/docs/components/styles/).
 
-</litdev-aside>
+{% endaside %}
 
 ## Styling With Lit
 

--- a/packages/lit-dev-content/site/tutorials/content/wc-to-lit/12.md
+++ b/packages/lit-dev-content/site/tutorials/content/wc-to-lit/12.md
@@ -8,11 +8,11 @@
 
 Lit introduces a set of render lifecycle callback methods on top of the native web component callbacks. These callbacks are triggered when declared Lit reactive properties are changed.
 
-<litdev-aside type="info">
+{% aside "info" %}
 
 To learn more about the Lit reactive update cycle, see the [Lit Lifecycle documentation](/docs/components/lifecycle/).
 
-</litdev-aside>
+{% endaside %}
 
 To use this feature, you must statically declare which properties are *Reactive Properties* – properties that will trigger the render lifecycle when changed:
 
@@ -70,13 +70,13 @@ Here, you:
 * Remove the attribute handling logic.
 * Clean up some unnecessary private class members.
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 Pass complex objects as properties.
 
 It is generally good practice to pass complex objects as [properties](/docs/templates/expressions/#property-expressions) rather than [attributes](/docs/templates/expressions/#attribute-expressions). Read more on reactive property attribute conversion in the [Lit documentation](/docs/components/properties/#attributes).
 
-</litdev-aside>
+{% endaside %}
 
 Additionally, the `reflect` flag on the `vote` property will automatically update the host element's `vote` *attribute* that you formerly updated in the `vote` setter. It is necessary to reflect the `vote` attribute so the `:host([vote=up])` styles can be applied.
 

--- a/packages/lit-dev-content/site/tutorials/content/word-viewer/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/word-viewer/01.md
@@ -22,7 +22,7 @@ equivalent of calling `customElements.define`, which registers the custom
 element class with the browser and associates it with the custom element name
 `word-viewer`.
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 A [valid custom element
 name](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name)
@@ -31,7 +31,7 @@ must contain a hyphen.
 This ensures forward compatibility with future tags added to HTML or SVG which
 won't add hyphen containing elements.
 
-</litdev-aside>
+{% endaside %}
 
 ## Rendering
 

--- a/packages/lit-dev-content/site/tutorials/content/word-viewer/02.md
+++ b/packages/lit-dev-content/site/tutorials/content/word-viewer/02.md
@@ -49,7 +49,7 @@ Before moving on, set `words` from an attribute.
 
 The preview should now show `👋.from.html`.
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 Debugging Custom Elements is awesome!
 
@@ -59,4 +59,4 @@ tools already understand how to handle them!
 Change the `words` attribute in your browser's developer tools and note that the
 component reacts to the change.
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/word-viewer/04.md
+++ b/packages/lit-dev-content/site/tutorials/content/word-viewer/04.md
@@ -37,14 +37,14 @@ Define a method `tickToNextWord` bound to the component that will increment
 Calling this method increments our reactive internal state `idx` which will
 schedule an update.
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 Since you'll use this method with `setInterval`, an arrow function can be used
 such that `this` refers to the component. See [the "this"
 problem](https://developer.mozilla.org/en-US/docs/Web/API/setInterval#the_this_problem)
 for more info.
 
-</litdev-aside>
+{% endaside %}
 
 
 To setup the interval and clean up the interval, use the [standard custom
@@ -61,12 +61,12 @@ callbacks](/docs/components/lifecycle/#custom-element-lifecycle)
 // word-viewer.ts
 
   private intervalTimer?: number;
-  
+
   connectedCallback() {
     super.connectedCallback();
     this.intervalTimer = setInterval(this.tickToNextWord, 1000);
   }
-  
+
   disconnectedCallback() {
     super.disconnectedCallback();
     clearInterval(this.intervalTimer);
@@ -79,12 +79,12 @@ callbacks](/docs/components/lifecycle/#custom-element-lifecycle)
 // word-viewer.js
 
   intervalTimer;
-  
+
   connectedCallback() {
     super.connectedCallback();
     this.intervalTimer = setInterval(this.tickToNextWord, 1000);
   }
-  
+
   disconnectedCallback() {
     super.disconnectedCallback();
     clearInterval(this.intervalTimer);
@@ -108,7 +108,7 @@ cleaning up the interval, and `this.tickToNextWord` is no longer called.
 
 The preview should be cycling over individual words.
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 Lit leverages standard [custom element lifecycle
 callbacks](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks).
@@ -118,4 +118,4 @@ to call the `super` implementation so the standard Lit functionality is
 preserved. See [lifecycle
 docs](/docs/components/lifecycle/#custom-element-lifecycle) for more info.
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/word-viewer/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/word-viewer/05.md
@@ -56,11 +56,11 @@ component's [shadow DOM](/docs/components/styles/#shadow-dom)) will not be
 selected.
 
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 Extra credit
 
 Use the [`:host()`](/docs/components/styles/#host) selector so that adding a
 `green` class on the `word-viewer` results in green text.
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/word-viewer/06.md
+++ b/packages/lit-dev-content/site/tutorials/content/word-viewer/06.md
@@ -109,14 +109,14 @@ Finally, bind `this.switchPlayDirection` to invoke when the `<pre>` element is
 clicked using Lit's [declarative event listener
 syntax](/docs/components/events/#adding-event-listeners-in-the-element-template).
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 Event listeners added using the declarative `@` syntax in the template are
 automatically bound to the component, so no arrow function is required. See more
 in the [event
 docs](/docs/components/events/#understanding-this-in-event-listeners).
 
-</litdev-aside>
+{% endaside %}
 
 {% switchable-sample %}
 

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/01.md
@@ -58,11 +58,11 @@ inside the `<ul>` tag.
 
 {% endswitchable-sample %}
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 The index of the item is also made available to the callback function. Check
 out the [map documentation](/docs/templates/directives/#map) for details.
 
-</litdev-aside>
+{% endaside %}
 
 Extra Credit: Try adding an item number to each list item using the index.

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/04.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/04.md
@@ -71,10 +71,10 @@ range of `column` integers from 0 to 7 are generated and mapped to result in a
 `<div>`. The class names and the text content are derived from the
 `row`-`column` coordinate.
 
-<litdev-aside type="info" no-header>
+{% aside "info" "no-header" %}
 
 The `range()` directive's output is customizable by providing additional
 arguments that control `start`, `end`, and the increment `step`. See the [range
 documentation](/docs/templates/directives/#range).
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/05.md
@@ -94,7 +94,7 @@ template to render for each item.
 Confirm that this is working correctly by checking an item and changing the sort
 order. The check mark should now be moving to stay next to its original label.
 
-<litdev-aside type="positive">
+{% aside "positive" %}
 
 The key function provided must return a unique key for an item.
 
@@ -104,4 +104,4 @@ documentation](/docs/templates/directives/#repeat) for more details. Also see
 [When to use map or repeat](/docs/templates/lists/#when-to-use-map-or-repeat)
 for guidance on deciding when to use one or the other.
 
-</listdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/06.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/06.md
@@ -35,7 +35,7 @@ class MyElement extends LitElement {
 
 {% endswitchable-sample %}
 
-<litdev-aside type="warn">
+{% aside "warn" %}
 
 Call `this.requestUpdate()` to render array mutations.
 
@@ -44,7 +44,7 @@ reference stored in `this.things`, Lit will not know that its content has
 changed. Calling `requestUpdate()` triggers the component to update using the
 new contents of the array.
 
-</litdev-aside>
+{% endaside %}
 
 Now register the handler on the button for each item as the array is being
 mapped.
@@ -97,7 +97,7 @@ Now clicking the delete button should remove the item. Note that an inline arrow
 function is used here to create closures such that each list item gets a
 function that calls `_deleteThing` with its own index.
 
-<litdev-aside class="info">
+{% aside "info" %}
 
 While closures will be fine for most cases, there are other ways to achieve this
 behavior.
@@ -109,4 +109,4 @@ convenient way of handling it without attaching event listeners on every item.
 Read more about it in [Listening to events fired from repeated
 templates](/docs/components/events/#listening-to-events-fired-from-repeated-templates).
 
-</litdev-aside>
+{% endaside %}

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -48,8 +48,7 @@ export class LitDevAside extends LitElement {
       display: inline;
     }
 
-    ::slotted(:first-of-type),
-    ::slotted(:nth-of-type(2)) {
+    ::slotted(:first-of-type) {
       margin-block-start: 0;
     }
 

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -39,21 +39,21 @@ export class LitDevAside extends LitElement {
       margin-inline: 1em;
     }
 
-    :host(:not([no-header])) ::slotted(:first-of-type) {
+    :host(:not([no-header])) ::slotted(:first-child) {
       font-weight: bold;
     }
 
-    :host(:not([no-header])) ::slotted(:first-of-type),
-    :host(:not([no-header])) ::slotted(:nth-of-type(2)) {
+    :host(:not([no-header])) ::slotted(:first-child),
+    :host(:not([no-header])) ::slotted(:nth-child(2)) {
       display: inline;
     }
 
-    ::slotted(:first-of-type) {
+    ::slotted(:first-child) {
       margin-block-start: 0;
     }
 
-    ::slotted(:first-of-type),
-    ::slotted(:last-of-type) {
+    ::slotted(:first-child),
+    ::slotted(:last-child) {
       margin-block-end: 0;
     }
   `;

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -10,8 +10,8 @@ import {greenCheckIcon} from '../icons/green-check-icon.js';
 import {redXIcon} from '../icons/red-x-icon.js';
 import {yellowBangIcon} from '../icons/yellow-bang-icon.js';
 import {blueInfoIcon} from '../icons/blue-info-icon.js';
-
-export type AsideVariant = 'positive' | 'negative' | 'warn' | 'info';
+import type {AsideVariant} from 'lit-dev-tools-cjs/src/playground-plugin/plugin.js';
+export type {AsideVariant};
 
 @customElement('litdev-aside')
 export class LitDevAside extends LitElement {

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -41,9 +41,9 @@ export class LitDevAside extends LitElement {
 
     :host(:not([no-header])) ::slotted(:first-of-type) {
       font-weight: bold;
-      display: inline;
     }
 
+    :host(:not([no-header])) ::slotted(:first-of-type),
     :host(:not([no-header])) ::slotted(:nth-of-type(2)) {
       display: inline;
     }

--- a/packages/lit-dev-content/src/components/litdev-aside.ts
+++ b/packages/lit-dev-content/src/components/litdev-aside.ts
@@ -39,8 +39,13 @@ export class LitDevAside extends LitElement {
       margin-inline: 1em;
     }
 
-    :host(:not([no-header])) ::slotted(:first-child) {
+    :host(:not([no-header])) ::slotted(:first-of-type) {
       font-weight: bold;
+      display: inline;
+    }
+
+    :host(:not([no-header])) ::slotted(:nth-of-type(2)) {
+      display: inline;
     }
 
     ::slotted(:first-of-type),

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -54,8 +54,5 @@
     "striptags": "^3.2.0",
     "typedoc": "^0.21.9",
     "uvu": "^0.5.1"
-  },
-  "devDependencies": {
-    "lit-dev-content": "^0.0.0"
   }
 }

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -54,5 +54,8 @@
     "striptags": "^3.2.0",
     "typedoc": "^0.21.9",
     "uvu": "^0.5.1"
+  },
+  "devDependencies": {
+    "lit-dev-content": "^0.0.0"
   }
 }

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -9,7 +9,7 @@ import {outdent} from 'outdent';
 import * as fs from 'fs/promises';
 
 import type {ProjectManifest} from 'playground-elements/shared/worker-api.js';
-import type {AsideVariant} from 'lit-dev-content/src/components/litdev-aside.js';
+export type AsideVariant = 'positive' | 'negative' | 'warn' | 'info';
 
 // TODO(aomarks) There seem to be no typings for 11ty! This person has made
 // some, but they're not in DefinitelyTyped:

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -9,6 +9,7 @@ import {outdent} from 'outdent';
 import * as fs from 'fs/promises';
 
 import type {ProjectManifest} from 'playground-elements/shared/worker-api.js';
+import type {AsideVariant} from 'lit-dev-content/src/components/litdev-aside.js';
 
 // TODO(aomarks) There seem to be no typings for 11ty! This person has made
 // some, but they're not in DefinitelyTyped:
@@ -262,6 +263,73 @@ export const playgroundPlugin = (
     }
     return `<litdev-switchable-sample>${content}</litdev-switchable-sample>`;
   });
+
+  const neverReach = (_value: never, error: string): never => {
+    throw new Error(error);
+  };
+
+  /**
+   * An aside for extra information.
+   *
+   * Usage:
+   *
+   *   {% aside "positive" %}
+   *
+   *   Here is some content! This line is bolded.
+   *
+   *   This line is not bolded but on the same line as the previous one.
+   *
+   *   This line is another paragraph
+   *
+   *   {% endaside %}
+   *
+   *   {% aside "info" "no-header" %}
+   *
+   *   This one does not have a bolded header.
+   *
+   *   {% endaside %}
+   */
+  eleventyConfig.addPairedShortcode(
+    'aside',
+    (content: string, variant: AsideVariant, noHeader = '') => {
+      const acceptableVariants: ['info', 'warn', 'positive', 'negative'] = [
+        'info',
+        'warn',
+        'positive',
+        'negative',
+      ];
+
+      // If statement needs to be written this way to assert exhaustive check.
+      if (
+        acceptableVariants[0] !== variant &&
+        acceptableVariants[1] !== variant &&
+        acceptableVariants[2] !== variant &&
+        acceptableVariants[3] !== variant
+      ) {
+        // This will throw an error at runtime if it does not match and will
+        // throw a TS build time error if we add another variant and forget to
+        // update this file.
+        neverReach(
+          variant,
+          `Invalid {% aside ${variant} %}.` +
+            ` variant "${variant}" is not an acceptable variant of:` +
+            ` ${acceptableVariants.join(', ')}.`
+        );
+      }
+
+      const noHeaderAttribute = noHeader === 'no-header' ? ' no-header' : '';
+      // htmlmin:ignore will prevent minifier from formatting the contents.
+      // otherwise, in the prod build, there will not be a space between the
+      // bolded header and the second line.
+      return (
+        `<litdev-aside variant="${variant}"${noHeaderAttribute}>` +
+        '\n<!-- htmlmin:ignore -->\n\n' +
+        content +
+        '\n\n<!-- htmlmin:ignore -->' +
+        '\n</litdev-aside>'
+      );
+    }
+  );
 
   eleventyConfig.addMarkdownHighlighter(
     (code: string, lang: 'js' | 'ts' | 'html' | 'css') => render(code, lang)


### PR DESCRIPTION
@arthurevans pointed out that aside vertical height is precious space so make bolded title inline instead.

also seems to have been a slight bug with before no-header. OOPS!

| variant | before | after |
| -- | -- | -- |
| with header | ![image](https://user-images.githubusercontent.com/5981958/166391750-8feb9bee-fba4-4015-9208-5136fff7295b.png) | ![image](https://user-images.githubusercontent.com/5981958/166391652-baf91321-fc42-4cca-9a9f-76302d186fe0.png) |
| `no-header` | ![image](https://user-images.githubusercontent.com/5981958/166391964-3e0f4d14-1524-419d-b4e5-3c3498eb2763.png) | ![image](https://user-images.githubusercontent.com/5981958/166391969-767e599e-82a8-4143-bd0e-7d08b1f84caf.png) |
