### PR TITLE
Further refine Wireit integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You may also prefer to run each dev script in its own terminal:
 cd packages/lit-dev-content
 
 npm run build:ts:watch       # TypeScript
-npm run dev:build:site:watch # Eleventy
+npm run dev:build:eleventy:watch # Eleventy
 npm run dev:serve            # @web/dev-server
 ```
 
@@ -100,7 +100,7 @@ npm start # production server
 cd packages/lit-dev-content
 npm run build:ts:watch     # TypeScript
 npm run build:rollup:watch # Rollup
-npm run build:site:watch   # Eleventy
+npm run build:eleventy:watch   # Eleventy
 ```
 
 Serves at [`http://localhost:6415`](http://localhost:6415)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.1.2",
         "typescript": "^4.4.3",
-        "wireit": "^0.2.0"
+        "wireit": "^0.4.0"
       }
     },
     "node_modules/@actions/cache": {
@@ -4393,6 +4393,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -6289,6 +6295,17 @@
         "read": "1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -7775,20 +7792,23 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.2.0.tgz",
-      "integrity": "sha512-iE+i8PBthGdSrtAhUv+hRv7UV5tsJtAKMs+h1sIZE5ciEqH6kwGqtyirIldxrkSqpn1MfL6tGiQSdas77zPSGQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.4.0.tgz",
+      "integrity": "sha512-gd0394lCFng0IYZoMAJba6/A6W/OMWMOTCSWJqx1PS3PY4tx3v85RTnrMuSMFU5SK3MG8qFGnlVgTDXgRF/eEQ==",
       "dev": true,
       "dependencies": {
         "@actions/cache": "=2.0.2",
+        "braces": "^3.0.2",
         "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11"
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
       },
       "bin": {
         "wireit": "bin/wireit.js"
       },
       "engines": {
-        "node": ">=16.7.0"
+        "node": ">=14.14.0"
       }
     },
     "node_modules/wordwrap": {
@@ -11581,6 +11601,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -13057,6 +13083,17 @@
         "read": "1"
       }
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -14185,14 +14222,17 @@
       }
     },
     "wireit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.2.0.tgz",
-      "integrity": "sha512-iE+i8PBthGdSrtAhUv+hRv7UV5tsJtAKMs+h1sIZE5ciEqH6kwGqtyirIldxrkSqpn1MfL6tGiQSdas77zPSGQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.4.0.tgz",
+      "integrity": "sha512-gd0394lCFng0IYZoMAJba6/A6W/OMWMOTCSWJqx1PS3PY4tx3v85RTnrMuSMFU5SK3MG8qFGnlVgTDXgRF/eEQ==",
       "dev": true,
       "requires": {
         "@actions/cache": "=2.0.2",
+        "braces": "^3.0.2",
         "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11"
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:main": "LITDEV_ENV=local MODE=main lerna run start --scope=lit-dev-server --stream",
     "start:playground": "LITDEV_ENV=local MODE=playground lerna run start --scope=lit-dev-server --stream",
     "start:fake-github": "wireit",
-    "dev": "cd packages/lit-dev-content && npm run build:not-site && (LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules npx eleventy --watch --incremental & npm run build:not-site watch & node ../lit-dev-tools-esm/lib/dev-server.js --open)",
+    "dev": "cd packages/lit-dev-content && npm run build:assets && (LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules npx eleventy --watch --incremental & npm run build:assets watch & node ../lit-dev-tools-esm/lib/dev-server.js --open)",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "nuke": "rm -rf node_modules && npm ci && lerna exec 'rm -rf node_modules' && lerna bootstrap --ci",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
     "typescript": "^4.4.3",
-    "wireit": "^0.2.0"
+    "wireit": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:main": "LITDEV_ENV=local MODE=main lerna run start --scope=lit-dev-server --stream",
     "start:playground": "LITDEV_ENV=local MODE=playground lerna run start --scope=lit-dev-server --stream",
     "start:fake-github": "wireit",
-    "dev": "cd packages/lit-dev-content && npm run build:assets && (LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules npx eleventy --watch --incremental & npm run build:assets watch & node ../lit-dev-tools-esm/lib/dev-server.js --open)",
+    "dev": "cd packages/lit-dev-server && npm run build && cd ../lit-dev-content && (npm run dev:build:assets watch & npm run dev:build:eleventy:watch & node ../lit-dev-tools-esm/lib/dev-server.js --open)",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "nuke": "rm -rf node_modules && npm ci && lerna exec 'rm -rf node_modules' && lerna bootstrap --ci",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
       "dependencies": [
         "./packages/lit-dev-tools-esm:build"
       ],
-      "command": "LITDEV_ENV=local node packages/lit-dev-tools-esm/lib/fake-github-server.js"
+      "command": "LITDEV_ENV=local node packages/lit-dev-tools-esm/lib/fake-github-server.js",
+      "output": []
     }
   },
   "devDependencies": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "fonts:manrope": "wireit",
     "build": "wireit",
-    "build:not-site": "wireit",
+    "build:assets": "wireit",
     "build:site": "wireit",
     "build:site:watch": "wireit",
     "build:ts": "wireit",
@@ -37,7 +37,7 @@
     },
     "prod:build": {
       "dependencies": [
-        "build:not-site"
+        "build:assets"
       ],
       "files": [
         "site/**",
@@ -54,7 +54,7 @@
     },
     "build:site": {
       "dependencies": [
-        "build:not-site"
+        "build:assets"
       ],
       "output": [
         "_site"
@@ -67,12 +67,12 @@
     },
     "build:site:watch": {
       "dependencies": [
-        "build:not-site"
+        "build:assets"
       ],
       "output": [
         "_site"
       ],
-      "#comment": "This is awkward. We want to do the watch part for build:not-site ourselves, but let eleventy do its own watch mode itself. Maybe --incremental will do a quick rebuild of just the changed parts, and we don't need --watch?",
+      "#comment": "This is awkward. We want to do the watch part for build:assets ourselves, but let eleventy do its own watch mode itself. Maybe --incremental will do a quick rebuild of just the changed parts, and we don't need --watch?",
       "files": [
         "site/**",
         ".eleventy.js"
@@ -81,7 +81,7 @@
     },
     "dev:build:site": {
       "dependencies": [
-        "build:not-site"
+        "build:assets"
       ],
       "output": [
         "_dev"
@@ -94,7 +94,7 @@
     },
     "dev:build:site:watch": {
       "dependencies": [
-        "build:not-site"
+        "build:assets"
       ],
       "output": [
         "_dev"
@@ -105,7 +105,7 @@
       ],
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
     },
-    "build:not-site": {
+    "build:assets": {
       "dependencies": [
         "build:ts",
         "build:rollup",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "fonts:manrope": "wireit",
     "build": "wireit",
-    "build:assets": "wireit",
     "build:eleventy": "wireit",
     "build:eleventy:watch": "wireit",
     "build:ts": "wireit",
@@ -19,10 +18,12 @@
     "build:samples": "wireit",
     "build:samples:watch": "npm run build:samples -- watch",
     "dev:build": "wireit",
+    "dev:build:assets": "wireit",
     "dev:build:eleventy": "wireit",
     "dev:build:eleventy:watch": "wireit",
     "dev:serve": "wireit",
-    "prod:build": "wireit"
+    "prod:build": "wireit",
+    "prod:build:assets": "wireit"
   },
   "wireit": {
     "build": {
@@ -37,7 +38,7 @@
     },
     "prod:build": {
       "dependencies": [
-        "build:assets"
+        "prod:build:assets"
       ],
       "files": [
         "site/**",
@@ -54,7 +55,7 @@
     },
     "build:eleventy": {
       "dependencies": [
-        "build:assets"
+        "prod:build:assets"
       ],
       "output": [
         "_site"
@@ -67,7 +68,7 @@
     },
     "build:eleventy:watch": {
       "dependencies": [
-        "build:assets"
+        "prod:build:assets"
       ],
       "output": [
         "_site"
@@ -81,7 +82,7 @@
     },
     "dev:build:eleventy": {
       "dependencies": [
-        "build:assets"
+        "dev:build:assets"
       ],
       "output": [
         "_dev"
@@ -94,7 +95,7 @@
     },
     "dev:build:eleventy:watch": {
       "dependencies": [
-        "build:assets"
+        "dev:build:assets"
       ],
       "output": [
         "_dev"
@@ -105,12 +106,17 @@
       ],
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
     },
-    "build:assets": {
+    "dev:build:assets": {
       "dependencies": [
         "build:ts",
-        "build:rollup",
         "build:samples",
         "fonts:manrope"
+      ]
+    },
+    "prod:build:assets": {
+      "dependencies": [
+        "dev:build:assets",
+        "build:rollup"
       ]
     },
     "fonts:manrope": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -10,8 +10,8 @@
     "fonts:manrope": "wireit",
     "build": "wireit",
     "build:assets": "wireit",
-    "build:site": "wireit",
-    "build:site:watch": "wireit",
+    "build:eleventy": "wireit",
+    "build:eleventy:watch": "wireit",
     "build:ts": "wireit",
     "build:ts:watch": "npm run build:ts -- watch",
     "build:rollup": "wireit",
@@ -19,20 +19,20 @@
     "build:samples": "wireit",
     "build:samples:watch": "npm run build:samples -- watch",
     "dev:build": "wireit",
-    "dev:build:site": "wireit",
-    "dev:build:site:watch": "wireit",
+    "dev:build:eleventy": "wireit",
+    "dev:build:eleventy:watch": "wireit",
     "dev:serve": "wireit",
     "prod:build": "wireit"
   },
   "wireit": {
     "build": {
       "dependencies": [
-        "build:site"
+        "build:eleventy"
       ]
     },
     "dev:build": {
       "dependencies": [
-        "dev:build:site"
+        "dev:build:eleventy"
       ]
     },
     "prod:build": {
@@ -52,7 +52,7 @@
       ],
       "command": "node ../lit-dev-tools-esm/lib/dev-server.js --open"
     },
-    "build:site": {
+    "build:eleventy": {
       "dependencies": [
         "build:assets"
       ],
@@ -65,7 +65,7 @@
       ],
       "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
-    "build:site:watch": {
+    "build:eleventy:watch": {
       "dependencies": [
         "build:assets"
       ],
@@ -79,7 +79,7 @@
       ],
       "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
     },
-    "dev:build:site": {
+    "dev:build:eleventy": {
       "dependencies": [
         "build:assets"
       ],
@@ -92,7 +92,7 @@
       ],
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
-    "dev:build:site:watch": {
+    "dev:build:eleventy:watch": {
       "dependencies": [
         "build:assets"
       ],

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -38,7 +38,8 @@
         "build",
         "../lit-dev-content:build:eleventy"
       ],
-      "command": "node lib/server.js"
+      "command": "node lib/server.js",
+      "output": []
     }
   },
   "dependencies": {

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -36,7 +36,7 @@
     "start": {
       "dependencies": [
         "build",
-        "../lit-dev-content:build:site"
+        "../lit-dev-content:build:eleventy"
       ],
       "command": "node lib/server.js"
     }


### PR DESCRIPTION
- Bump to latest version of Wireit to bring in https://github.com/google/wireit/pull/189, which makes it safe to have multiple concurrent Wireit processes handling overlapping build graphs.

- Added `output:[]` to some server commands, so that they can run concurrently given the above new restriction.

- Renamed `:not-site` scripts to `:assets`, and `:site` scripts to `:eleventy`. I think these are more intuitive names.

- Separated out `dev:build:assets` and `prod:build:assets` scripts. This means that watching dev no longer runs rollup, which was unnecessary because we serve tsc output directly in dev mode.

- Updated the top-level `dev` script:
  - Ensure that the server is built first
  - Simplified to take advantage of safe concurrent Wireit processes

I'll be working on https://github.com/google/wireit/issues/33 next, which should simplify things even further.