### PR TITLE
Intro to lit updates

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/00/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/00/after/my-element.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('my-element')
-class MyElement extends LitElement {
+export class MyElement extends LitElement {
   @property()
   version = 'COMPLETED';
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/00/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/00/before/my-element.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('my-element')
-class MyElement extends LitElement {
+export class MyElement extends LitElement {
   @property()
   version = 'STARTING';
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/01/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/01/after/my-element.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 
 @customElement('my-element')
-class MyElement extends LitElement {
+export class MyElement extends LitElement {
   render() {
     return html`
       <p>Hello world! From my-element.</p>

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/01/before/my-element.js
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/01/before/my-element.js
@@ -1,2 +1,1 @@
 import {LitElement, html} from 'lit';
-import {customElement} from 'lit/decorators.js';

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/01/before/my-element.js
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/01/before/my-element.js
@@ -1,1 +1,2 @@
-export {};
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators.js';

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/02/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/02/after/my-element.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('my-element')
-class MyElement extends LitElement {
+export class MyElement extends LitElement {
   @property()
   message: string = 'Hello again.';
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/02/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/02/before/my-element.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('my-element')
-class MyElement extends LitElement {
+export class MyElement extends LitElement {
 // TODO: Add a reactive property
 
   render() {

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/03/after/name-tag.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/03/after/name-tag.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('name-tag')
-class NameTag extends LitElement {
+export class NameTag extends LitElement {
   @property()
   name: string = 'Your name here';
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/03/before/name-tag.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/03/before/name-tag.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('name-tag')
-class NameTag extends LitElement {
+export class NameTag extends LitElement {
   @property()
   name: string = 'Your name here';
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/04/after/more-expressions.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/04/after/more-expressions.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('more-expressions')
-class MoreExpressions extends LitElement {
+export class MoreExpressions extends LitElement {
   @property()
   checked: boolean = false;
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/04/before/more-expressions.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/04/before/more-expressions.ts
@@ -2,7 +2,7 @@ import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('more-expressions')
-class MoreExpressions extends LitElement {
+export class MoreExpressions extends LitElement {
   @property()
   checked: boolean = false;
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/after/todo-list.ts
@@ -2,12 +2,12 @@ import {LitElement, html} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 
 @customElement('todo-list')
-class ToDoList extends LitElement {
-  @property()
+export class ToDoList extends LitElement {
+  @property({attribute: false})
   listItems = [
-      { text: 'Start Lit tutorial', completed: true },
-      { text: 'Make to-do list', completed: false }
-    ];
+    { text: 'Start Lit tutorial', completed: true },
+    { text: 'Make to-do list', completed: false }
+  ];
 
   render() {
     return html`
@@ -25,9 +25,9 @@ class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems.push({text: this.input.value, completed: false});
+    this.listItems = [...this.listItems,
+        {text: this.input.value, completed: false}];
     this.input.value = '';
-    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/after/todo-list.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, state, query} from 'lit/decorators.js';
 
 @customElement('todo-list')
 export class ToDoList extends LitElement {
-  @property({attribute: false})
-  listItems = [
+  @state()
+  private _listItems = [
     { text: 'Start Lit tutorial', completed: true },
     { text: 'Make to-do list', completed: false }
   ];
@@ -13,7 +13,7 @@ export class ToDoList extends LitElement {
     return html`
       <h2>To Do</h2>
       <ul>
-        ${this.listItems.map((item) =>
+        ${this._listItems.map((item) =>
           html`<li>${item.text}</li>`)}
       </ul>
       <input id="newitem" aria-label="New item">
@@ -25,7 +25,7 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems = [...this.listItems,
+    this._listItems = [...this._listItems,
         {text: this.input.value, completed: false}];
     this.input.value = '';
   }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/before/todo-list.ts
@@ -2,8 +2,8 @@ import {LitElement, html} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 
 @customElement('todo-list')
-class ToDoList extends LitElement {
-  @property()
+export class ToDoList extends LitElement {
+  @property({attribute: false})
   listItems = [
     { text: 'Start Lit tutorial', completed: true },
     { text: 'Make to-do list', completed: false }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/05/before/todo-list.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, state, query} from 'lit/decorators.js';
 
 @customElement('todo-list')
 export class ToDoList extends LitElement {
-  @property({attribute: false})
-  listItems = [
+  @state()
+  private _listItems = [
     { text: 'Start Lit tutorial', completed: true },
     { text: 'Make to-do list', completed: false }
   ];

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/after/todo-list.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, state, query} from 'lit/decorators.js';
 
 type ToDoItem = {
   text: string,
@@ -15,8 +15,8 @@ export class ToDoList extends LitElement {
     }
   `;
 
-  @property({attribute: false})
-  listItems = [
+  @state()
+  private _listItems = [
     { text: 'Make to-do list', completed: true },
     { text: 'Add some styles', completed: true }
   ];
@@ -25,7 +25,7 @@ export class ToDoList extends LitElement {
     return html`
       <h2>To Do</h2>
       <ul>
-        ${this.listItems.map((item) =>
+        ${this._listItems.map((item) =>
           html`
             <li
                 class=${item.completed ? 'completed' : ''}
@@ -48,7 +48,7 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems = [...this.listItems,
+    this._listItems = [...this._listItems,
         {text: this.input.value, completed: false}];
     this.input.value = '';
   }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/after/todo-list.ts
@@ -48,8 +48,8 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems.push({text: this.input.value, completed: false});
+    this.listItems = [...this.listItems,
+        {text: this.input.value, completed: false}];
     this.input.value = '';
-    this.requestUpdate();
   }
 }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.js
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.js
@@ -1,15 +1,15 @@
-import {LitElement, html} from 'lit';
+import {LitElement, html, css} from 'lit';
 
 export class ToDoList extends LitElement {
   static properties = {
-    listItems: {attribute: false},
+    _listItems: {state: true},
   };
 
   // TODO: Add styles here
 
   constructor() {
     super();
-    this.listItems = [
+    this._listItems = [
       {text: 'Make to-do list', completed: true},
       {text: 'Add some styles', completed: false},
     ];
@@ -19,7 +19,7 @@ export class ToDoList extends LitElement {
     return html`
       <h2>To Do</h2>
       <ul>
-        ${this.listItems.map(
+        ${this._listItems.map(
           (item) => html`
             <li
                 class="TODO"
@@ -43,7 +43,7 @@ export class ToDoList extends LitElement {
   }
 
   addToDo() {
-    this.listItems = [...this.listItems,
+    this._listItems = [...this._listItems,
         {text: this.input.value, completed: false}];
     this.input.value = '';
   }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.js
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.js
@@ -5,9 +5,10 @@ export class ToDoList extends LitElement {
     listItems: {attribute: false},
   };
 
+  // TODO: Add styles here
+
   constructor() {
     super();
-    // TODO: Add styles here
     this.listItems = [
       {text: 'Make to-do list', completed: true},
       {text: 'Add some styles', completed: false},
@@ -42,9 +43,9 @@ export class ToDoList extends LitElement {
   }
 
   addToDo() {
-    this.listItems.push({text: this.input.value, completed: false});
+    this.listItems = [...this.listItems,
+        {text: this.input.value, completed: false}];
     this.input.value = '';
-    this.requestUpdate();
   }
 }
 customElements.define('todo-list', ToDoList);

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.ts
@@ -44,9 +44,9 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems.push({text: this.input.value, completed: false});
+    this.listItems = [...this.listItems,
+        {text: this.input.value, completed: false}];
     this.input.value = '';
-    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/06/before/todo-list.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, state, query} from 'lit/decorators.js';
 
 type ToDoItem = {
   text: string,
@@ -11,8 +11,8 @@ export class ToDoList extends LitElement {
 
   // TODO: Add styles here
 
-  @property({attribute: false})
-  listItems = [
+  @state()
+  private _listItems = [
     { text: 'Make to-do list', completed: true },
     { text: 'Add some styles', completed: false }
   ];
@@ -21,7 +21,7 @@ export class ToDoList extends LitElement {
     return html`
       <h2>To Do</h2>
       <ul>
-        ${this.listItems.map((item) =>
+        ${this._listItems.map((item) =>
           html`
             <li
                 class="TODO"
@@ -44,7 +44,7 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems = [...this.listItems,
+    this._listItems = [...this._listItems,
         {text: this.input.value, completed: false}];
     this.input.value = '';
   }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/after/todo-list.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, state, property, query} from 'lit/decorators.js';
 
 type ToDoItem = {
   text: string,
@@ -15,9 +15,9 @@ export class ToDoList extends LitElement {
     }
   `;
 
-  @property({attribute: false})
-  listItems = [
-    { text: 'Make to-do list', completed: true },
+  @state()
+  private _listItems = [
+  { text: 'Make to-do list', completed: true },
     { text: 'Complete Lit tutorial', completed: false }
   ];
   @property()
@@ -25,8 +25,8 @@ export class ToDoList extends LitElement {
 
   render() {
     const items = this.hideCompleted
-      ? this.listItems.filter((item) => !item.completed)
-      : this.listItems;
+      ? this._listItems.filter((item) => !item.completed)
+      : this._listItems;
     const todos = html`
       <ul>
         ${items.map((item) =>
@@ -76,7 +76,7 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems = [...this.listItems,
+    this._listItems = [...this._listItems,
         {text: this.input.value, completed: false}];
     this.input.value = '';
   }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/after/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/after/todo-list.ts
@@ -76,9 +76,9 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems.push({text: this.input.value, completed: false});
+    this.listItems = [...this.listItems,
+        {text: this.input.value, completed: false}];
     this.input.value = '';
-    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/before/todo-list.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, state, property, query} from 'lit/decorators.js';
 
 type ToDoItem = {
   text: string,
@@ -15,8 +15,8 @@ export class ToDoList extends LitElement {
     }
   `;
 
-  @property({attribute: false})
-  listItems = [
+  @state()
+  private _listItems = [
     { text: 'Make to-do list', completed: true },
     { text: 'Complete Lit tutorial', completed: false }
   ];
@@ -25,7 +25,7 @@ export class ToDoList extends LitElement {
 
   render() {
     // TODO: Replace items definition.
-    const items = this.listItems;
+    const items = this._listItems;
     const todos = html`
       <ul>
         ${items.map((item) =>
@@ -70,7 +70,7 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems = [...this.listItems,
+    this._listItems = [...this._listItems,
         {text: this.input.value, completed: false}];
     this.input.value = '';
   }

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/before/todo-list.ts
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/07/before/todo-list.ts
@@ -70,9 +70,9 @@ export class ToDoList extends LitElement {
   input!: HTMLInputElement;
 
   addToDo() {
-    this.listItems.push({text: this.input.value, completed: false});
+    this.listItems = [...this.listItems,
+        {text: this.input.value, completed: false}];
     this.input.value = '';
-    this.requestUpdate();
   }
 }
 

--- a/packages/lit-dev-content/samples/tutorials/intro-to-lit/tutorial.json
+++ b/packages/lit-dev-content/samples/tutorials/intro-to-lit/tutorial.json
@@ -6,7 +6,7 @@
   "category": "Learn",
   "steps": [
     {
-      "title": "Lit tutorial",
+      "title": "Introduction",
       "hasAfter": true
     },
     {

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/00.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/00.md
@@ -4,6 +4,24 @@ Each step of this tutorial introduces one or two Lit features. Use the interacti
 
 If you get stuck on a step, click **Solve** to see the finished code, or click **Reset** to return to the starting code. The editor shows a basic Lit component like the ones you'll create in the subsequent steps. For now, just try out the **Solve** and **Reset** buttons.
 
+You can do this tutorial in either TypeScript or JavaScript. Change the language by clicking any of the **JS/TS** toggles, which appear in the corner of the editor and in switchable code samples, like this:
+
+{% switchable-sample %}
+
+```ts
+// TypeScript for TypeScript lovers!
+const items: Array<string> | undefined;
+```
+
+```js
+// JavaScript for JavaScript lovers!
+const items;
+```
+
+{% endswitchable-sample %}
+
+The toggles are linked, so the cut and paste code samples should always match the language in the editor. You can switch whenever you want, but note that if you switch languages, you'll lose any changes you've made in the editor.
+
 Lit components are [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components), so they act like regular HTML elements. You can add them to a page with simple HTML tags, like this:
 
 ```html

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/01.md
@@ -19,7 +19,7 @@ In Lit, most things start with defining a _component_. Here we've given you a st
 
     {% endswitchable-sample %}
 
-    The `MyElement` class provides the implementation for your new component, and the `@customElement` decorator registers it with the browser as a new element type named `my-element`.
+    The `MyElement` class provides the implementation for your new component. <ts-js><span slot="ts">The <code>@customElement</code> decorator registers it with the browser as a new element type named <code>my-element</code>.</span><span slot="js">The <code>customElements.define</code> call registers it with the browser as a new element type named <code>my-element</code>.</span></ts-js>
 
     The "TODO" text should disappear from the **Result** pane, showing that the component is defined. But your component is still missing something—it doesn't display anything.
 
@@ -36,3 +36,12 @@ In Lit, most things start with defining a _component_. Here we've given you a st
     The `render()` method defines your component's internal DOM. The `html` tag function processes a template literal and returns a `TemplateResult`—an object that describes the HTML for Lit to render. Every Lit component should include a `render()` method.
 
 You should see the greeting message in the **Result** pane.
+
+{% aside "info" %}
+
+Decorators.
+
+The TypeScript version of this code uses the `@customElement` decorator to register your class with the browser as a new element. The JavaScript version uses `customElements.define()` to do the same thing. This is a matter of style. You can use decorators—or not use decorators—in either language. For more information, see [Decorators](/docs/components/decorators/).
+
+{% endaside %}
+

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/03.md
@@ -8,13 +8,13 @@ Here we've provided a name tag component with a message and an input element. In
 
 *   **Add a declarative event listener.**
 
-    Find the input element and add this expression inside the tag:
+    Find the input element and add a declarative event listener:
 
-    ```html
-    @input=${this.changeName}
+    ```js
+    <input @input=${this.changeName} placeholder="Enter your name">
     ```
 
-    <code>@<var>eventName</var></code> is a special syntax for adding an event handler using an expression.
+    This `@input` expression adds `this.changeName` as an event listener for the input event. (You can use this syntax for any event listener—just replace input with any event name and `this.changeName` with any JavaScript expression that evaluates to an event handler function.)
 
 *   **Add the event handler method.**
 

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/03.md
@@ -14,7 +14,7 @@ Here we've provided a name tag component with a message and an input element. In
     <input @input=${this.changeName} placeholder="Enter your name">
     ```
 
-    This `@input` expression adds `this.changeName` as an event listener for the input event. (You can use this syntax for any event listener—just replace input with any event name and `this.changeName` with any JavaScript expression that evaluates to an event handler function.)
+    This `@input` expression adds `this.changeName` as an event listener for the `input` event. (You can use this syntax for any event listener—just replace input with any event name and `this.changeName` with any JavaScript expression that evaluates to an event handler function.)
 
 *   **Add the event handler method.**
 

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/03.md
@@ -10,7 +10,7 @@ Here we've provided a name tag component with a message and an input element. In
 
     Find the input element and add a declarative event listener:
 
-    ```js
+    ```html
     <input @input=${this.changeName} placeholder="Enter your name">
     ```
 

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
@@ -1,10 +1,6 @@
 Now that you've got some of the basics, we'll introduce a more complicated element. In the remainder of this tutorial, you'll build a to-do list component. Here we've provided some of the boilerplate for your to-do-list.
 
-{% aside "info" %}
-
 Since the list items are private to the component, the `_listItems` property is defined as _internal reactive state_. It works just like a reactive property, but it isn't exposed as an attribute, and shouldn't be accessed from outside the component. For more information, see [Public properties and internal state](/docs/components/properties/#public-properties-and-internal-state).
-
-{% endaside %}
 
 You can use standard JavaScript in Lit expressions to create conditional or repeating templates. In this step, you'll use `map()` to turn an array of data into a repeating template.
 

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
@@ -1,5 +1,11 @@
 Now that you've got some of the basics, we'll introduce a more complicated element. In the remainder of this tutorial, you'll build a to-do list component. Here we've provided some of the boilerplate for your to-do-list.
 
+{% aside "info" %}
+
+Since the list items are private to the component, the `_listItems` property is defined as _internal reactive state_. It works just like a reactive property, but it isn't exposed as an attribute, and shouldn't be accessed from outside the component. For more information, see [Public properties and internal state](/docs/components/properties/#public-properties-and-internal-state).
+
+{% endaside %}
+
 You can use standard JavaScript in Lit expressions to create conditional or repeating templates. In this step, you'll use `map()` to turn an array of data into a repeating template.
 
 *   **Render list items.**
@@ -7,7 +13,7 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
     Add the following expression between the start and end tags for the unordered list (`<ul>`).
 
     ```html
-      ${this.listItems.map((item) =>
+      ${this._listItems.map((item) =>
         html`<li>${item.text}</li>`
       )}
     ```
@@ -26,7 +32,7 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
     input!: HTMLInputElement;
 
     addToDo() {
-      this.listItems = [...this.listItems,
+      this._listItems = [...this._listItems,
           {text: this.input.value, completed: false}];
       this.input.value = '';
     }
@@ -38,7 +44,7 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
     }
 
     addToDo() {
-      this.listItems = [...this.listItems,
+      this._listItems = [...this._listItems,
           {text: this.input.value, completed: false}];
       this.input.value = '';
     }
@@ -60,7 +66,7 @@ Try entering a new item and clicking **Add**.
 
 Mutating objects and arrays.
 
-Note that instead of mutating the `listItems` array, `addToDo()` creates a new array that includes the new item. Using this immutable data pattern ensures that the components see the new data. For more information, see [Mutating objects and arrays](/docs/components/properties/#mutating-properties).
+Note that instead of mutating the `_listItems` array, `addToDo()` creates a new array that includes the new item. Using this immutable data pattern ensures that the components see the new data. For more information, see [Mutating objects and arrays](/docs/components/properties/#mutating-properties).
 
 {% endaside %}
 

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
@@ -46,14 +46,6 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
 
     {% endswitchable-sample %}
 
-    {% aside "info" %}
-
-    Mutating objects and arrays.
-
-    Note that instead of mutating the `listItems` array, `addToDo()` creates a new array that includes the new item. Using this immutable data pattern ensures that the components see the new data. For more information, see [Mutating objects and arrays](/docs/components/properties/#mutating-properties).
-
-    {% endaside %}
-
     The `@query` decorator (used in the TypeScript version of the code) is a handy way of getting a reference to a node in your component's internal DOM. It's  equivalent to this code in the JavaScript version:
 
     ```js
@@ -63,4 +55,15 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
     ```
 
 Try entering a new item and clicking **Add**.
+
+{% aside "info" %}
+
+Mutating objects and arrays.
+
+Note that instead of mutating the `listItems` array, `addToDo()` creates a new array that includes the new item. Using this immutable data pattern ensures that the components see the new data. For more information, see [Mutating objects and arrays](/docs/components/properties/#mutating-properties).
+
+{% endaside %}
+
+
+
 

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/05.md
@@ -26,9 +26,9 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
     input!: HTMLInputElement;
 
     addToDo() {
-      this.listItems.push({text: this.input.value, completed: false});
+      this.listItems = [...this.listItems,
+          {text: this.input.value, completed: false}];
       this.input.value = '';
-      this.requestUpdate();
     }
     ```
 
@@ -38,20 +38,28 @@ You can use standard JavaScript in Lit expressions to create conditional or repe
     }
 
     addToDo() {
-      this.listItems.push({text: this.input.value, completed: false});
+      this.listItems = [...this.listItems,
+          {text: this.input.value, completed: false}];
       this.input.value = '';
-      this.requestUpdate();
     }
     ```
 
     {% endswitchable-sample %}
 
-    As the name suggests, `requestUpdate()` triggers the component to update. Setting a reactive property calls this automatically. Since you're not setting `listItems` here, but only mutating the array, you need to call `requestUpdate()` yourself.
+    {% aside "info" %}
 
-    The `@query` decorator is a handy way of getting a reference to a node in your component's internal DOM. It's basically equivalent to calling code like this in your constructor:
+    Mutating objects and arrays.
+
+    Note that instead of mutating the `listItems` array, `addToDo()` creates a new array that includes the new item. Using this immutable data pattern ensures that the components see the new data. For more information, see [Mutating objects and arrays](/docs/components/properties/#mutating-properties).
+
+    {% endaside %}
+
+    The `@query` decorator (used in the TypeScript version of the code) is a handy way of getting a reference to a node in your component's internal DOM. It's  equivalent to this code in the JavaScript version:
 
     ```js
-    this.input = this.shadowRoot.querySelector('#newitem');
+    get input() {
+      return this.renderRoot?.querySelector('#newitem') ?? null;
+    }
     ```
 
 Try entering a new item and clicking **Add**.

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/07.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/07.md
@@ -47,6 +47,13 @@ Your mission: refactor the template to hide the completed items when **Hide comp
       ...
     ```
 
-Try clicking **hideCompleted** and make sure your code worked. Go ahead and cross off **Complete Lit tutorial.** (If anything's not working, check your work or click **Solve** to see the finished code.)
+Try clicking **Hide completed** and make sure your code worked. Go ahead and cross off **Complete Lit tutorial.** (If anything's not working, check your work or click **Solve** to see the finished code.)
 
-If you'd like to keep experimenting with Lit online, you can head over to the [Playground](/playground/). Or if you're ready to try something real, you might want to check out our component [Starter kits](/docs/tools/starter-kits/) or [add Lit to an existing project](/docs/tools/adding-lit/).
+### Next steps
+
+To keep exploring Lit, try one of these tutorials:
+
+-   [Working with lists](/tutorials/working-with-lists/) explores repeating templates in more detail.
+-   [Reactivity](/tutorials/reactivity/) takes a deeper dive into reactive properties and how Lit components update.
+
+If you'd like to see more interactive samples and keep experimenting with Lit online, you can head over to the [Playground](/playground/). Or if you're ready to try something real, you might want to check out our component [Starter kits](/docs/tools/starter-kits/) or [add Lit to an existing project](/docs/tools/adding-lit/).

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/07.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/07.md
@@ -1,6 +1,6 @@
 As templates get big and complicated, it can help to break them down into smaller pieces. Here we've added a **Hide completed** checkbox to the to-do list. We've also pulled the main todo list template out into a separate local constant, `todos`. You can think of this as a partial template.
 
-You'll notice the `todos` partial is *almost* identical to the `<ul>` element in the previous step, except that it's using the new `items` local constant instead of `this.listItems`.
+You'll notice the `todos` partial is *almost* identical to the `<ul>` element in the previous step, except that it's using the new `items` local constant instead of `this._listItems`.
 
 Your mission: refactor the template to hide the completed items when **Hide completed** is checked and show a message when no uncompleted items are displayed.
 
@@ -10,8 +10,8 @@ Your mission: refactor the template to hide the completed items when **Hide comp
 
     ```ts
     const items = this.hideCompleted
-      ? this.listItems.filter((item) => !item.completed)
-      : this.listItems;
+      ? this._listItems.filter((item) => !item.completed)
+      : this._listItems;
     ```
 
 *   **Define some partial templates.**


### PR DESCRIPTION
Fixes several reported issues and a couple of unreported issues in the intro tutorial. 

- Removes `requestUpdate()` call and favors immutable data pattern instead.
- Adds missing export statements and other inconsistencies noted in #703.
- Fixes a confusingly-written note reported in #753.
- Fixes two errors in JS starting files that I noticed while making the other changes.