### PR TITLE
Aside applies the indentation of content

### DIFF
--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -321,7 +321,7 @@ export const playgroundPlugin = (
 
       // Matches the first line's leading whitespace and applies it to the other
       // HTML nodes to preserve the same indentaiton.
-      const contentIndent =  (content.match(/^\s*/)?? [''])[0];
+      const contentIndent = (content.match(/^\s*/) ?? [''])[0];
 
       // htmlmin:ignore will prevent minifier from formatting the contents.
       // otherwise, in the prod build, there will not be a space between the

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -320,7 +320,7 @@ export const playgroundPlugin = (
       const noHeaderAttribute = noHeader === 'no-header' ? ' no-header' : '';
 
       // Matches the first line's leading whitespace and applies it to the other
-      // HTML nodes to preserve the same indentaiton.
+      // HTML nodes to preserve the same indentation.
       const contentIndent = (content.match(/^\s*/) ?? [''])[0];
 
       // htmlmin:ignore will prevent minifier from formatting the contents.

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -327,9 +327,7 @@ export const playgroundPlugin = (
       // otherwise, in the prod build, there will not be a space between the
       // bolded header and the second line.
       return (
-        // Indent not required for the first line, because shortcode preserves
-        // the indentation of the shortcode's location.
-        `<litdev-aside type="${variant}"${noHeaderAttribute}>` +
+        `${contentIndent}<litdev-aside type="${variant}"${noHeaderAttribute}>` +
         `\n${contentIndent}<!-- htmlmin:ignore -->\n\n` +
         content +
         `\n\n${contentIndent}<!-- htmlmin:ignore -->` +

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -318,15 +318,22 @@ export const playgroundPlugin = (
       }
 
       const noHeaderAttribute = noHeader === 'no-header' ? ' no-header' : '';
+
+      // Matches the first line's leading whitespace and applies it to the other
+      // HTML nodes to preserve the same indentaiton.
+      const contentIndent =  (content.match(/^\s*/)?? [''])[0];
+
       // htmlmin:ignore will prevent minifier from formatting the contents.
       // otherwise, in the prod build, there will not be a space between the
       // bolded header and the second line.
       return (
+        // Indent not required for the first line, because shortcode preserves
+        // the indentation of the shortcode's location.
         `<litdev-aside type="${variant}"${noHeaderAttribute}>` +
-        '\n<!-- htmlmin:ignore -->\n\n' +
+        `\n${contentIndent}<!-- htmlmin:ignore -->\n\n` +
         content +
-        '\n\n<!-- htmlmin:ignore -->' +
-        '\n</litdev-aside>'
+        `\n\n${contentIndent}<!-- htmlmin:ignore -->` +
+        `\n${contentIndent}</litdev-aside>`
       );
     }
   );


### PR DESCRIPTION
When aside is currently in an indent. e.g.

```md
*   Here is a bulleted list that has an aside

    {% aside "info" %}
    Here are the contents
    {% endaside %}
```

The shortcode will translate it into markdown as so:

```md
*   Here is a bulleted list that has an aside

<litdev-aside type="info">
<!-- htmlmin:ignore -->

    Here are the contents

<!-- htmlmin:ignore -->
</litdev-aside>
```

Thus throwing off the MD compiler. In this PR we get the leading whitespace in front of the contents, and prepend them to all of our HTML nodes:

```js
// content looks like this:

"    Here are the contents"
```

The regex matches `^\s*` which is the first 4 spaces and applies it to our HTML nodes

```md
*   Here is a bulleted list that has an aside

    <litdev-aside type="info">
    <!-- htmlmin:ignore -->

    Here are the contents

    <!-- htmlmin:ignore -->
    </litdev-aside
```

This is how it looks now at 3 different indentation levels +0, +1, +2

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/5981958/167232617-f499867b-e5d4-4185-86b2-ec0194887ff4.png">
