### PR TITLE
[tutorials] Working with lists: encourage immutable data pattern

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/00/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/00/before/my-element.ts
@@ -1,5 +1,5 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement} from 'lit/decorators.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/01/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/01/after/my-element.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {map} from 'lit/directives/map.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   items = new Set(['Apple', 'Banana', 'Grape', 'Orange', 'Lime'])
 
   render() {

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/01/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/01/before/my-element.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 // TODO: import map directive.
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   items = new Set(['Apple', 'Banana', 'Grape', 'Orange', 'Lime'])
 
   render() {

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/02/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/02/after/my-element.ts
@@ -1,9 +1,9 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   names = ['Chandler', 'Phoebe', 'Joey', 'Monica', 'Rachel', 'Ross'];
 
   render() {

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/02/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/02/before/my-element.ts
@@ -1,9 +1,9 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   names = ['Chandler', 'Phoebe', 'Joey', 'Monica', 'Rachel', 'Ross'];
 
   render() {

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/03/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/03/after/my-element.ts
@@ -1,13 +1,13 @@
 import {LitElement, html} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import type {TemplateResult} from 'lit';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   friends = ['Harry', 'Ron', 'Hermione'];
 
-  @property({attribute: false})
+  @state()
   pets = [
     { name: "Hedwig", species: "Owl" },
     { name: "Scabbers", species: "Rat" },

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/03/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/03/before/my-element.ts
@@ -1,13 +1,13 @@
 import {LitElement, html} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import type {TemplateResult} from 'lit';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   friends = ['Harry', 'Ron', 'Hermione'];
 
-  @property({attribute: false})
+  @state()
   pets = [
     { name: "Hedwig", species: "Owl" },
     { name: "Scabbers", species: "Rat" },

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/05/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/05/after/my-element.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {repeat} from 'lit/directives/repeat.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   tasks = [
     { id: 'a', label: 'Learn Lit'},
     { id: 'b', label: 'Feed the cat'},

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/05/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/05/before/my-element.ts
@@ -1,11 +1,11 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {map} from 'lit/directives/map.js'
 // TODO: import repeat directive.
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   tasks = [
     { id: 'a', label: 'Learn Lit'},
     { id: 'b', label: 'Feed the cat'},

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/06/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/06/before/my-element.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {map} from 'lit/directives/map.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   things = [
     "Raindrops on roses",
     "Whiskers on kittens",

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/07/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/07/before/my-element.ts
@@ -1,10 +1,10 @@
 import {LitElement, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {map} from 'lit/directives/map.js';
 
 @customElement('my-element')
 class MyElement extends LitElement {
-  @property({attribute: false})
+  @state()
   things = [
     "Raindrops on roses",
     "Whiskers on kittens",

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/07/before/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/07/before/my-element.ts
@@ -30,7 +30,6 @@ class MyElement extends LitElement {
   }
 
   private _deleteThing(index: number) {
-    this.things.splice(index, 1);
-    this.requestUpdate();
+    this.things = this.things.filter((_, i) => i !== index);
   }
 }

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/01.md
@@ -6,8 +6,8 @@ an iterable. The `map()` directive works with any iterables such as arrays,
 sets, maps, and even generators. It returns an iterable containing the result of
 calling the provided callback function on each item.
 
-In this example, a custom element is presented with a property named `items`
-that contains a set of strings.
+In this example, a custom element is presented with a state property named
+`items` that contains a set of strings.
 
 Render each item in the set as a list item (`<li>`) containing that string.
 Begin by importing the `map()` directive.

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/02.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/02.md
@@ -3,8 +3,8 @@ returns a renderable value as described in the [expressions
 documentation](/docs/templates/expressions/). When working with arrays, their
 prototype methods can be used to generate arrays of renderable values as well.
 
-This example has a component with a `names` property containing an array of
-strings.
+This example has a component with a `names` state property containing an array
+of strings.
 
 Use the `filter()` array method to only keep the names that include the letter
 "e" followed by a `map()` array method call to generate an array of template

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/03.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/03.md
@@ -2,7 +2,7 @@ The methods used in the previous steps are great when working with a single
 iterable as a source of data but sometimes the situation might call for a more
 imperative approach.
 
-In this example, the component has the following properties:
+In this example, the component has the following state properties:
 * `friends` - an array of strings.
 * `pets` - an array of objects.
 * `includePets` - a boolean controlled by a button.

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/06.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/06.md
@@ -2,9 +2,9 @@ There are several ways of adding event listeners to list items getting rendered,
 but care must be taken to ensure the correct information is made available to
 the event handler. This step shows one way of achieving this.
 
-The example currently has an array of strings in the `things` property that are
-being rendered as list items with a "Delete" button which does not do anything
-yet.
+The example currently has an array of strings in the `things` state property
+that are being rendered as list items with a "Delete" button which does not do
+anything yet.
 
 First, create a method that will be called when the button is clicked that will
 remove the item from the `things` array. It will take the item's index.

--- a/packages/lit-dev-content/site/tutorials/content/working-with-lists/06.md
+++ b/packages/lit-dev-content/site/tutorials/content/working-with-lists/06.md
@@ -16,8 +16,7 @@ remove the item from the `things` array. It will take the item's index.
 class MyElement extends LitElement {
   ⋮
   private _deleteThing(index: number) {
-    this.things.splice(index, 1);
-    this.requestUpdate();
+    this.things = this.things.filter((_, i) => i !== index);
   }
 }
 ```
@@ -27,8 +26,7 @@ class MyElement extends LitElement {
 class MyElement extends LitElement {
   ⋮
   _deleteThing(index) {
-    this.things.splice(index, 1);
-    this.requestUpdate();
+    this.things = this.things.filter((_, i) => i !== index);
   }
 }
 ```
@@ -37,12 +35,14 @@ class MyElement extends LitElement {
 
 {% aside "warn" %}
 
-Call `this.requestUpdate()` to render array mutations.
+Use immutable data patterns to trigger an update.
 
-Since the `splice()` array method mutates the array without changing the
-reference stored in `this.things`, Lit will not know that its content has
-changed. Calling `requestUpdate()` triggers the component to update using the
-new contents of the array.
+The `filter()` array method returns a new array which is assigned to
+`this.things`. Since the reference stored in `this.things` changes, Lit will
+know to update the component when `_deleteThing()` is called. If the array is
+mutated instead with something like the `splice()` array method, an update must
+be manually requested. See [Mutating objects and array
+properties](/docs/components/properties/#mutating-properties) for details.
 
 {% endaside %}
 


### PR DESCRIPTION
Updates step 7 to encourage immutable data pattern by creating a new array rather than mutating and calling `requestUpdate()`. Adds link to that section of the doc.

Also updates all property usages to use `@state` decorator instead for consistency with Intro to Lit tutorial.