### PR TITLE
[svg-tutorial] update demo height, based on view height

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/svg-templates/00/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/00/before/index.html
@@ -2,18 +2,22 @@
 <html>
   <head>
     <style>
-      html, body {
-         height: 100%;
-         padding: 0;
-         margin: 0;
-      }
-      :root {
+      body {
         --background-color: #7acbf1;
         --font-color: #fff;
         --font-size: 56px;
         --stroke-width: 3.5px;
         --stroke-color: #e3a7b2;
+
+        height: 100vh;
+        margin: 0;
       }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
+      }
+
       .knobs {
         background: #efefef;
         border-bottom-right-radius: 4px;

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/00/before/repeat-pattern.ts
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/00/before/repeat-pattern.ts
@@ -18,6 +18,10 @@ const themeCSS = css`
 `;
 
 const svgCSS = css`
+  :host {
+    display: block;
+  }
+
   svg, rect {
     height: 100%;
     width: 100%;

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/01/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/01/before/index.html
@@ -3,10 +3,14 @@
   <head>
     <script type="module" src="repeat-pattern.js"></script>
     <style>
-      html, body {
-         height: 100%;
-         padding: 0;
-         margin: 0;
+      body {
+        height: 100vh;
+        margin: 0;
+      }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
       }
     </style>
   </head>

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/02/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/02/before/index.html
@@ -3,10 +3,14 @@
   <head>
     <script type="module" src="repeat-pattern.js"></script>
     <style>
-      html, body {
-         height: 100%;
-         padding: 0;
-         margin: 0;
+      body {
+        height: 100vh;
+        margin: 0;
+      }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
       }
     </style>
   </head>

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/03/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/03/before/index.html
@@ -3,10 +3,14 @@
   <head>
     <script type="module" src="repeat-pattern.js"></script>
     <style>
-      html, body {
-         height: 100%;
-         padding: 0;
-         margin: 0;
+      body {
+        height: 100vh;
+        margin: 0;
+      }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
       }
     </style>
   </head>

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/04/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/04/before/index.html
@@ -3,10 +3,14 @@
   <head>
     <script type="module" src="repeat-pattern.js"></script>
     <style>
-      html, body {
-         height: 100%;
-         padding: 0;
-         margin: 0;
+      body {
+        height: 100vh;
+        margin: 0;
+      }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
       }
     </style>
   </head>

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/05/after/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/05/after/index.html
@@ -2,11 +2,16 @@
 <html>
   <head>
     <style>
-      html, body {
-        height: 100%;
-        padding: 0;
+      body {
+        height: 100vh;
         margin: 0;
       }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
+      }
+      
       :root {
         --background-color: #000;
         --font-color: #fff;

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/05/after/repeat-pattern.ts
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/05/after/repeat-pattern.ts
@@ -18,6 +18,10 @@ const themeCSS = css`
 `;
 
 const svgCSS = css`
+  :host {
+    display: block;
+  }
+
   svg, rect {
     height: 100%;
     width: 100%;

--- a/packages/lit-dev-content/samples/tutorials/svg-templates/06/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/svg-templates/06/before/index.html
@@ -2,18 +2,22 @@
 <html>
   <head>
     <style>
-      html, body {
-         height: 100%;
-         padding: 0;
-         margin: 0;
-      }
-      :root {
+      body {
         --background-color: #000;
         --font-color: #fff;
         --font-size: 26px;
         --stroke-width: 1.1px;
         --stroke-color: #7acbf1;
+
+        height: 100vh;
+        margin: 0;
       }
+
+      repeat-pattern {
+        height: 100vh;
+        width: 100vw;
+      }
+
       .knobs {
         background: #efefef;
         border-bottom-right-radius: 4px;


### PR DESCRIPTION
Update `repeat-pattern` to use view height instead of parent height.
This prevents the occasional `0` height issue when a demo is initially rendered.