### PR TITLE
Misc fixes to tooltip tutorial

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/tooltip/00/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/00/before/index.html
@@ -7,6 +7,7 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <script src="./process.js"></script>
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/00/before/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/00/before/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/00/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/00/before/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"hidden":true},
     "my-content.ts": {"selected": true},
-    "index.html": {"hidden": true}
+    "index.html": {"hidden": true},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/00/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/00/before/project.json
@@ -1,9 +1,9 @@
 {
   "extends": "/samples/base.json",
   "files": {
+    "simple-tooltip.ts": {"hidden":true},
     "my-content.ts": {"selected": true},
-    "index.html": {},
-    "simple-tooltip.ts": {}
+    "index.html": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/00/before/simple-tooltip.ts
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/00/before/simple-tooltip.ts
@@ -16,16 +16,17 @@ export class SimpleTooltip extends LitElement {
 
   // Lazy creation
   static lazy(target: Element, callback: (target: SimpleTooltip) => void) {
-    let called = false;
-    enterEvents.forEach(name => target.addEventListener(name, () => {
-      if (!called) {
-        called = true;
-        const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
-        callback(tooltip);
-        target.parentNode!.insertBefore(tooltip, target.nextSibling);
-        tooltip.show();
-      }
-    }, {once: true}));
+    const createTooltip = () => {
+      const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
+      callback(tooltip);
+      target.parentNode!.insertBefore(tooltip, target.nextSibling);
+      tooltip.show();
+      // We only need to create the tooltip once, so ignore all future events.
+      enterEvents.forEach(
+        (eventName) => target.removeEventListener(eventName, createTooltip));
+    };
+    enterEvents.forEach(
+      (eventName) => target.addEventListener(eventName, createTooltip));
   }
 
   static styles = css`

--- a/packages/lit-dev-content/samples/tutorials/tooltip/05/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/05/before/index.html
@@ -7,6 +7,10 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/05/before/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/05/before/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/05/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/05/before/project.json
@@ -3,6 +3,7 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   }
 }

--- a/packages/lit-dev-content/samples/tutorials/tooltip/06/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/06/before/index.html
@@ -7,6 +7,10 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/06/before/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/06/before/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/06/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/06/before/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/after/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/after/index.html
@@ -7,6 +7,10 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/after/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/after/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/after/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/after/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/after/simple-tooltip.ts
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/after/simple-tooltip.ts
@@ -11,16 +11,17 @@ export class SimpleTooltip extends LitElement {
 
   // Lazy creation
   static lazy(target: Element, callback: (target: SimpleTooltip) => void) {
-    let called = false;
-    enterEvents.forEach(name => target.addEventListener(name, () => {
-      if (!called) {
-        called = true;
-        const tooltip = document.createElement('simple-tooltip');
-        callback(tooltip);
-        target.parentNode!.insertBefore(tooltip, target.nextSibling);
-        tooltip.show();
-      }
-    }, {once: true}));
+    const createTooltip = () => {
+      const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
+      callback(tooltip);
+      target.parentNode!.insertBefore(tooltip, target.nextSibling);
+      tooltip.show();
+      // We only need to create the tooltip once, so ignore all future events.
+      enterEvents.forEach(
+        (eventName) => target.removeEventListener(eventName, createTooltip));
+    };
+    enterEvents.forEach(
+      (eventName) => target.addEventListener(eventName, createTooltip));
   }
 
   static styles = css`

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/before/index.html
@@ -7,6 +7,10 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/before/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/before/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/07/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/07/before/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/after/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/after/index.html
@@ -7,6 +7,11 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/after/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/after/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/after/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/after/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/after/simple-tooltip.ts
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/after/simple-tooltip.ts
@@ -13,16 +13,17 @@ export class SimpleTooltip extends LitElement {
 
   // Lazy creation
   static lazy(target: Element, callback: (target: SimpleTooltip) => void) {
-    let called = false;
-    enterEvents.forEach(name => target.addEventListener(name, () => {
-      if (!called) {
-        called = true;
-        const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
-        callback(tooltip);
-        target.parentNode!.insertBefore(tooltip, target.nextSibling);
-        tooltip.show();
-      }
-    }, {once: true}));
+    const createTooltip = () => {
+      const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
+      callback(tooltip);
+      target.parentNode!.insertBefore(tooltip, target.nextSibling);
+      tooltip.show();
+      // We only need to create the tooltip once, so ignore all future events.
+      enterEvents.forEach(
+        (eventName) => target.removeEventListener(eventName, createTooltip));
+    };
+    enterEvents.forEach(
+      (eventName) => target.addEventListener(eventName, createTooltip));
   }
 
   static styles = css`

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/before/index.html
@@ -7,6 +7,10 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/before/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/before/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/before/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/08/before/simple-tooltip.ts
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/08/before/simple-tooltip.ts
@@ -13,16 +13,17 @@ export class SimpleTooltip extends LitElement {
 
   // Lazy creation
   static lazy(target: Element, callback: (target: SimpleTooltip) => void) {
-    let called = false;
-    enterEvents.forEach(name => target.addEventListener(name, () => {
-      if (!called) {
-        called = true;
-        const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
-        callback(tooltip);
-        target.parentNode!.insertBefore(tooltip, target.nextSibling);
-        tooltip.show();
-      }
-    }, {once: true}));
+    const createTooltip = () => {
+      const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
+      callback(tooltip);
+      target.parentNode!.insertBefore(tooltip, target.nextSibling);
+      tooltip.show();
+      // We only need to create the tooltip once, so ignore all future events.
+      enterEvents.forEach(
+        (eventName) => target.removeEventListener(eventName, createTooltip));
+    };
+    enterEvents.forEach(
+      (eventName) => target.addEventListener(eventName, createTooltip));
   }
 
   static styles = css`

--- a/packages/lit-dev-content/samples/tutorials/tooltip/09/before/index.html
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/09/before/index.html
@@ -7,6 +7,10 @@
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet">
+  <!-- playground-fold -->
+  <script src="./process.js"></script>
+  <!-- playground-fold-end -->
+
   <script type="module" src="./my-content.js"></script>
 </head>
 <body>

--- a/packages/lit-dev-content/samples/tutorials/tooltip/09/before/process.js
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/09/before/process.js
@@ -1,0 +1,3 @@
+window.process = {
+  env: {NODE_ENV: ''}
+};

--- a/packages/lit-dev-content/samples/tutorials/tooltip/09/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/09/before/project.json
@@ -1,9 +1,9 @@
 {
   "extends": "/samples/base.json",
   "files": {
-    "my-content.ts": {"selected": true},
-    "index.html": {},
-    "simple-tooltip.ts": {}
+    "simple-tooltip.ts": {"selected": true},
+    "my-content.ts": {},
+    "index.html": {}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/09/before/project.json
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/09/before/project.json
@@ -3,7 +3,8 @@
   "files": {
     "simple-tooltip.ts": {"selected": true},
     "my-content.ts": {},
-    "index.html": {}
+    "index.html": {},
+    "process.js": {"hidden": true}
   },
   "dependencies": {
     "@floating-ui/dom": "^0.4.1"

--- a/packages/lit-dev-content/samples/tutorials/tooltip/09/before/simple-tooltip.ts
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/09/before/simple-tooltip.ts
@@ -1,4 +1,3 @@
-/* playground-fold */
 import {html, css, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {Directive, DirectiveParameters, directive} from 'lit/directive.js';
@@ -154,5 +153,3 @@ class TooltipDirective extends Directive {
 }
 
 export const tooltip = directive(TooltipDirective);
-
-/* playground-fold-end */

--- a/packages/lit-dev-content/samples/tutorials/tooltip/09/before/simple-tooltip.ts
+++ b/packages/lit-dev-content/samples/tutorials/tooltip/09/before/simple-tooltip.ts
@@ -15,16 +15,17 @@ export class SimpleTooltip extends LitElement {
 
   // Lazy creation
   static lazy(target: Element, callback: (target: SimpleTooltip) => void) {
-    let called = false;
-    enterEvents.forEach(name => target.addEventListener(name, () => {
-      if (!called) {
-        called = true;
-        const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
-        callback(tooltip);
-        target.parentNode!.insertBefore(tooltip, target.nextSibling);
-        tooltip.show();
-      }
-    }, {once: true}));
+    const createTooltip = () => {
+      const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
+      callback(tooltip);
+      target.parentNode!.insertBefore(tooltip, target.nextSibling);
+      tooltip.show();
+      // We only need to create the tooltip once, so ignore all future events.
+      enterEvents.forEach(
+        (eventName) => target.removeEventListener(eventName, createTooltip));
+    };
+    enterEvents.forEach(
+      (eventName) => target.addEventListener(eventName, createTooltip));
   }
 
   static styles = css`

--- a/packages/lit-dev-content/site/docs/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/templates/directives.md
@@ -409,7 +409,7 @@ customElements.define('my-element', MyElement);
 
 {% endswitchable-sample %}
 
-For CSS properties that contain dashes, you can either use the camel-case equivalent, or put the property name in quotes. For example, you can write the the CSS property `font-family` as either `fontFamily` or `'font-family'`:
+For CSS properties that contain dashes, you can either use the camel-case equivalent, or put the property name in quotes. For example, you can write the CSS property `font-family` as either `fontFamily` or `'font-family'`:
 
 ```js
 { fontFamily: 'roboto' }

--- a/packages/lit-dev-content/site/tutorials/content/carousel/06.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/06.md
@@ -35,13 +35,13 @@ get previousSlot() {
 <span slot="ts">
 
 The `@query` decorator provides convenient access to the `slot` elements. This
-will be used to to see their currently `assignedElements`.
+will be used to see their currently `assignedElements`.
 
 </span>
 <span slot="js">
 
 `querySelector` provides convenient access to the `slot` elements. This
-will be used to to see their currently `assignedElements`.
+will be used to see their currently `assignedElements`.
 
 </span>
 </ts-js>

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/00.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/00.md
@@ -15,12 +15,14 @@ as fast as possible.
 
 ## Preview
 
-Here's a preview of the `simple-tooltip` element. Take a look at the
+Here's a preview of the `simple-tooltip` element. Take a look at
 <code>my-content.<ts-js></ts-js></code> in the code editor. This shows one way
 to use `simple-tooltip`. Look at the preview output and move your pointer over
 the interface to see how the tooltip is displayed.
 
 ## Tasks
+
+Here's what you'll do in the upcoming steps:
 
 * Focus on the basics: triggering the tooltip and positioning it.
 * Animate the tooltip when it's shown and hidden.

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/01.md
@@ -30,4 +30,4 @@ add the following properties to the `:host` selector of `simple-tooltip`.
 The tooltip should be shown on top of the content it's hinting. Using `position: fixed`
 creates a new
 [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
-which should work fine for the vast majority of cases.
+which should work fine for the majority of cases.

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/02.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/02.md
@@ -1,7 +1,7 @@
 The tooltip should be initially hidden and displayed only when the user
 interacts with the element it's hinting. Add the `show` and `hide` methods so
 they can be called to manage the display of the tooltip. The best way to
-enforce the hidden styling is to use an inline style since this has the
+enforce the hidden styling is to use an inline style, because that has the
 highest precedence in css.
 
 ```ts
@@ -19,7 +19,7 @@ hide = () => {
 The `show` and `hide` methods are defined using
 [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
-This binds the the functions to the element and makes it simpler to use them
+This binds the functions to the element and makes it simpler to use them
 with `add/removeEventListener` which you'll do next.
 
 {% endaside %}

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/04.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/04.md
@@ -24,7 +24,7 @@ constructor() {
 {% endswitchable-sample %}
 
 Since the target element's position may change, position the tooltip
-each time its shown. Again, to do this simply and robustly, use inline styling.
+each time it's shown. Again, to do this simply and robustly, use inline styling.
 
 {% switchable-sample %}
 

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/05.md
@@ -70,6 +70,3 @@ show = () => {
 Now move your pointer over the boxes when they are near the bottom of
 the preview window. Its tooltip should be displayed above the box if there's
 more room for it there.
-
-<!-- TODO The Box 3 tooltip goes back to the wrong place after using floating-ui,
-     and there is an error in the console: "process is not defined". -->

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/05.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/05.md
@@ -70,3 +70,6 @@ show = () => {
 Now move your pointer over the boxes when they are near the bottom of
 the preview window. Its tooltip should be displayed above the box if there's
 more room for it there.
+
+<!-- TODO The Box 3 tooltip goes back to the wrong place after using floating-ui,
+     and there is an error in the console: "process is not defined". -->

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/07.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/07.md
@@ -58,6 +58,8 @@ The `once` option is used to automatically remove the event listener after it fi
 Since the callback should be called only once, and there are multiple triggering
 events, a flag is used to manage the state.
 
+<!-- TODO Slightly confused by the "a flag is used" sentence above. -->
+
 {% endaside %}
 
 Now open the <code>my-content.<ts-js></ts-js></code> module and change the

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/07.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/07.md
@@ -20,47 +20,40 @@ showing it. Near the top of the class definition, add:
 {% switchable-sample %}
 
 ```ts
+// Lazy creation
 static lazy(target: Element, callback: (target: SimpleTooltip) => void) {
-  let called = false;
-  enterEvents.forEach(name => target.addEventListener(name, () => {
-    if (!called) {
-      called = true;
-      const tooltip = document.createElement('simple-tooltip');
-      callback(tooltip);
-      target.parentNode!.insertBefore(tooltip, target.nextSibling);
-      tooltip.show();
-    }
-  }, {once: true}));
+  const createTooltip = () => {
+    const tooltip = document.createElement('simple-tooltip') as SimpleTooltip;
+    callback(tooltip);
+    target.parentNode!.insertBefore(tooltip, target.nextSibling);
+    tooltip.show();
+    // We only need to create the tooltip once, so ignore all future events.
+    enterEvents.forEach(
+      (eventName) => target.removeEventListener(eventName, createTooltip));
+  };
+  enterEvents.forEach(
+    (eventName) => target.addEventListener(eventName, createTooltip));
 }
 ```
 
 ```js
+// Lazy creation
 static lazy(target, callback) {
-  let called = false;
-  enterEvents.forEach((name) => target.addEventListener(name, () => {
-    if (!called) {
-      called = true;
-      const tooltip = document.createElement('simple-tooltip');
-      callback(tooltip);
-      target.parentNode.insertBefore(tooltip, target.nextSibling);
-      tooltip.show();
-    }
-  }, {once: true}));
+  const createTooltip = () => {
+    const tooltip = document.createElement('simple-tooltip');
+    callback(tooltip);
+    target.parentNode!.insertBefore(tooltip, target.nextSibling);
+    tooltip.show();
+    // We only need to create the tooltip once, so ignore all future events.
+    enterEvents.forEach(
+      (eventName) => target.removeEventListener(eventName, createTooltip));
+  };
+  enterEvents.forEach(
+    (eventName) => target.addEventListener(eventName, createTooltip));
 }
 ```
 
 {% endswitchable-sample %}
-
-{% aside  "info" %}
-
-The `once` option is used to automatically remove the event listener after it fires once.
-
-Since the callback should be called only once, and there are multiple triggering
-events, a flag is used to manage the state.
-
-<!-- TODO Slightly confused by the "a flag is used" sentence above. -->
-
-{% endaside %}
 
 Now open the <code>my-content.<ts-js></ts-js></code> module and change the
 `greeting` tooltip to use the `lazy` method. To do so, first remove the inline

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/08.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/08.md
@@ -9,9 +9,9 @@ on the target element and provide a
 [TemplateResult](https://lit.dev/docs/libraries/standalone-templates/#rendering-lit-html-templates)
 containing the tooltip content.
 
-A scaffold for the directive is setup for you with the `update`
-method already completed. It stores directive `part` and the `tooltipContent`
-passed in so you can use them in the methods you'll add: `setupLazy` and
+A scaffold for the directive is set up for you with the `update` method already
+completed. It stores the directive `part` and the `tooltipContent` passed in so
+you can use them in the methods you'll add: `setupLazy` and
 `renderTooltipContent`.
 
 Implement the `setupLazy` method. It should set `didSetupLazy`

--- a/packages/lit-dev-content/site/tutorials/content/tooltip/09.md
+++ b/packages/lit-dev-content/site/tutorials/content/tooltip/09.md
@@ -13,5 +13,5 @@ element. Great job, you're a tooltip expert!
 ### Extra Credit
 * Add additional ways to specify the tooltip target. Hint: try an `id` reference.
 * Add options for where to position the tooltip relative to the target. Hint: check out the [floating-ui](https://floating-ui.com/) docs.
-* Hide the tooltip when the page scrolls. Hint add a "leave" event listener for `scroll` on the document.
-* Remove the tooltip from the DOM completely when it's hidden and add it again when shown.
+* Hide the tooltip when the page scrolls. Hint: add a "leave" event listener for `scroll` on the document.
+* Remove the tooltip from the DOM completely when it's hidden, and add it again when shown.


### PR DESCRIPTION
- Hid some files on the first step.
- Made file order consistent.
- Fixed some typos and minor grammar things (also found a couple repeated words in some random other pages on the site).
- Added "Here's what you'll do in the upcoming steps:" to the first page, because it seemed like a user could think they were supposed to complete the task list right away.
- Softened language about `fixed` solving stacking context. I think it might actually be a problem fairly often, so "vast majority" seemed a bit strong.
- Removed folding from the last step. It was showing nothing, but seems like we should show the whole final product?

### Open issues

- In step 6, the box 3 tooltip goes back to the wrong place after setting up `floating-ui`, and there is an error in the console: `process is not defined`.

- In step 8, I was slightly confused by the "a flag is used" sentence. Can you clarify what this is supposed to mean? Does "flag" refer to the "once" option?
