### PR TITLE
[infra] Cloud Build/Run artifact cleanup

### DIFF
--- a/cloudbuild-cleanup.yaml
+++ b/cloudbuild-cleanup.yaml
@@ -8,6 +8,7 @@ steps:
     script: |
       cd packages/lit-dev-cloudbuild-cleanup
       npm ci
+      npm run build
       npm start
 
 tags:

--- a/cloudbuild-cleanup.yaml
+++ b/cloudbuild-cleanup.yaml
@@ -10,6 +10,10 @@ steps:
       npm ci
       npm run build
       npm start
+    env:
+      - 'PROJECT_ID=$PROJECT_ID'
+      - 'REPO_NAME=$REPO_NAME'
+      - '_DEPLOY_REGION=$_DEPLOY_REGION'
 
 tags:
   - lit-dev

--- a/cloudbuild-cleanup.yaml
+++ b/cloudbuild-cleanup.yaml
@@ -1,0 +1,20 @@
+# lit.dev Cloud Build config for cleanup of build artifacts
+#
+# https://cloud.google.com/cloud-build/docs/build-config
+
+steps:
+  - id: cleanup
+    name: node:16
+    script: |
+      cd packages/lit-dev-cloudbuild-cleanup
+      npm ci
+      npm start
+
+tags:
+  - lit-dev
+  - cloudbuild-cleanup
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+
+timeout: 45m

--- a/cloudbuild-main.yaml
+++ b/cloudbuild-main.yaml
@@ -119,8 +119,8 @@ steps:
       - beta
       - run
       - services
-      - update-traffic # Service name
-      - lit-dev-playground
+      - update-traffic
+      - lit-dev-playground # Service name
       - '--region=$_DEPLOY_REGION'
       - '--platform=managed'
       - '--quiet'

--- a/cloudbuild-main.yaml
+++ b/cloudbuild-main.yaml
@@ -37,6 +37,8 @@ steps:
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA'
       - '--quiet'
       - '--no-traffic'
+      # If this tag format changes, also update route-traffic- steps below and
+      # the cleanup script in packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
       - '--tag=main-$SHORT_SHA'
       # IMPORTANT: If you change --memory, be sure to also change
       # --max-old-space-size in ./Dockerfile, and this same flag in
@@ -70,6 +72,8 @@ steps:
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA'
       - '--quiet'
       - '--no-traffic'
+      # If this tag format changes, also update route-traffic- steps below and
+      # the cleanup script in packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
       - '--tag=main-$SHORT_SHA'
       # IMPORTANT: If you change --memory, be sure to also change
       # --max-old-space-size in ./Dockerfile, and this same flag in

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -22,6 +22,8 @@ steps:
       - --cache=true
       - --cache-ttl=168h # 1 week
       - --build-arg=LITDEV_ENV=pr
+      # If this tag format changes, also update the cleanup script in
+      # packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
       - --build-arg=REVISION_TAG=pr$_PR_NUMBER-$SHORT_SHA
       - --build-arg=SHORT_SHA=$SHORT_SHA
 
@@ -42,6 +44,8 @@ steps:
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA'
       - '--quiet'
       - '--no-traffic'
+      # If this tag format changes, also update the cleanup script in
+      # packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
       - '--tag=pr$_PR_NUMBER-$SHORT_SHA'
       # IMPORTANT: If you change --memory, be sure to also change
       # --max-old-space-size in ./Dockerfile, and this same flag in
@@ -75,6 +79,8 @@ steps:
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA'
       - '--quiet'
       - '--no-traffic'
+      # If this tag format changes, also update the cleanup script in
+      # packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
       - '--tag=pr$_PR_NUMBER-$SHORT_SHA'
       # IMPORTANT: If you change --memory, be sure to also change
       # --max-old-space-size in ./Dockerfile, and this same flag in

--- a/packages/lit-dev-cloudbuild-cleanup/package-lock.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "gaxios": "^5.0.0",
         "googleapis": "^100.0.0",
-        "octokit": "^1.7.1"
+        "octokit": "^1.7.1",
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@octokit/app": {
@@ -946,6 +947,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/universal-github-app-jwt": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
@@ -1758,6 +1771,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
     },
     "universal-github-app-jwt": {
       "version": "1.1.0",

--- a/packages/lit-dev-cloudbuild-cleanup/package-lock.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package-lock.json
@@ -12,6 +12,7 @@
         "gaxios": "^5.0.0",
         "googleapis": "^100.0.0",
         "octokit": "^1.7.1",
+        "tslib": "^2.4.0",
         "typescript": "^4.6.4"
       }
     },
@@ -947,6 +948,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -1771,6 +1777,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "typescript": {
       "version": "4.6.4",

--- a/packages/lit-dev-cloudbuild-cleanup/package-lock.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package-lock.json
@@ -1,0 +1,1811 @@
+{
+  "name": "lit-dev-cloudbuild-cleanup",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lit-dev-cloudbuild-cleanup",
+      "version": "0.0.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "googleapis": "^100.0.0",
+        "octokit": "^1.7.1"
+      }
+    },
+    "node_modules/@octokit/app": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-12.0.5.tgz",
+      "integrity": "sha512-lM3pIfx2h+UbvsXHFVs1ApJ9Rmp8LO4ciFSr5q/9MdHmhsH6WtwayieUn875xwB77IoR9r8czxxxASu2WCtdeA==",
+      "dependencies": {
+        "@octokit/auth-app": "^3.3.0",
+        "@octokit/auth-unauthenticated": "^2.0.4",
+        "@octokit/core": "^3.4.0",
+        "@octokit/oauth-app": "^3.3.2",
+        "@octokit/plugin-paginate-rest": "^2.13.3",
+        "@octokit/types": "^6.27.1",
+        "@octokit/webhooks": "^9.0.1"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.6.1.tgz",
+      "integrity": "sha512-6oa6CFphIYI7NxxHrdVOzhG7hkcKyGyYocg7lNDSJVauVOLtylg8hNJzoUyPAYKKK0yUeoZamE/lMs2tG+S+JA==",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^4.3.0",
+        "@octokit/auth-oauth-user": "^1.2.3",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.0.3",
+        "@types/lru-cache": "^5.1.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "^6.0.0",
+        "universal-github-app-jwt": "^1.0.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.1.tgz",
+      "integrity": "sha512-FXkKcGtTXS2987rp11mSuhMOXDw8Iy/ED9aXs83T29VeMEWjv40q4ytC0voUDxkBC/of1QYOPQUAdI2tv/dwNg==",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/auth-oauth-user": "^1.2.1",
+        "@octokit/request": "^5.6.3",
+        "@octokit/types": "^6.0.3",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.2.tgz",
+      "integrity": "sha512-w7Po4Ck6N2aAn2VQyKLuojruiyKROTBv4qs6IwE5rbwF7HhBXXp4A/NKmkpoFIZkiXQtM+N8QtkSck4ApYWdGg==",
+      "dependencies": {
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^5.4.14",
+        "@octokit/types": "^6.10.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-1.3.0.tgz",
+      "integrity": "sha512-3QC/TAdk7onnxfyZ24BnJRfZv8TRzQK7SEFUS9vLng4Vv6Hv6I64ujdk/CUkREec8lhrwU764SZ/d+yrjjqhaQ==",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^5.4.14",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.1.0.tgz",
+      "integrity": "sha512-+baofLfSL0CAv3CfGQ9rxiZZQEX8VNJMGuuS4PgrMRBUL52Ho5+hQYb63UJQshw7EXYMPDZxbXznc0y33cbPqw==",
+      "dependencies": {
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.6.0.tgz",
+      "integrity": "sha512-OxPw4ItQXaC2GuEXyZB7EmZ2rHvNFX4y3yAsqdFIRW7qg2HyoEPxacxza6c8wqbEEvu84b98AJ5BXm+IjPWrww==",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^4.0.0",
+        "@octokit/auth-oauth-user": "^1.3.0",
+        "@octokit/auth-unauthenticated": "^2.0.0",
+        "@octokit/core": "^3.3.2",
+        "@octokit/oauth-authorization-url": "^4.2.1",
+        "@octokit/oauth-methods": "^1.2.2",
+        "@types/aws-lambda": "^8.10.83",
+        "fromentries": "^1.3.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-4.3.3.tgz",
+      "integrity": "sha512-lhP/t0i8EwTmayHG4dqLXgU+uPVys4WD/qUNvC+HfB1S1dyqULm5Yx9uKc1x79aP66U1Cb4OZeW8QU/RA9A4XA=="
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-1.2.6.tgz",
+      "integrity": "sha512-nImHQoOtKnSNn05uk2o76om1tJWiAo4lOu2xMAHYsNr0fwopP+Dv+2MlGvaMMlFjoqVd3fF3X5ZDTKCsqgmUaQ==",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^4.3.1",
+        "@octokit/request": "^5.4.14",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "dependencies": {
+        "@octokit/types": "^6.34.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "dependencies": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.6.2.tgz",
+      "integrity": "sha512-0az5fxgVlhFfFtiKLKVXTpmCG2tK3BG0fYI8SO4pmGlN1kyJktJVQA+6KKaFxtxMIWsuHmSEAkR6zSgtk86g2A==",
+      "dependencies": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^3.5.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.24.0.tgz",
+      "integrity": "sha512-s1nqplA+j4sP7Cz40jn/Q2ipkKRKJ7Gi+NzZiSnwNfisYNduLHEwMUJVBEKc5I0r6GMcZZRJOe6PJ2rJXYW66g==",
+      "dependencies": {
+        "@octokit/request-error": "^2.0.2",
+        "@octokit/webhooks-methods": "^2.0.0",
+        "@octokit/webhooks-types": "5.6.0",
+        "aggregate-error": "^3.1.0"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-2.0.0.tgz",
+      "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
+    },
+    "node_modules/@octokit/webhooks-types": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.6.0.tgz",
+      "integrity": "sha512-y3MqE6N6Ksg1+YV0sXVpW2WP7Y24h7rUp2hDJuzoqWdKGr7owmRDyHC72INwfCYNzura/vsNPXvc6Xbfp4wGGw=="
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.97",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.97.tgz",
+      "integrity": "sha512-BZk3qO4R2KN8Ts3eR6CW1n8LI46UOgv1KoDZjo8J9vOQvDeX/rsrv1H0BpEAMcSqZ1mLwTEyAMtlua5tlSn0kw=="
+    },
+    "node_modules/@types/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg=="
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
+    "node_modules/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/gaxios": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.0.tgz",
+      "integrity": "sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "dependencies": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-100.0.0.tgz",
+      "integrity": "sha512-RToFQGY54B756IDbjdyjb1vWFmn03bYpXHB2lIf0eq2UBYsIbYOLZ0kqSomfJnpclEukwEmMF7Jn6Wsev871ew==",
+      "dependencies": {
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.1.0.tgz",
+      "integrity": "sha512-RXrif+Gzhq1QAzfjxulbGvAY3FPj8zq/CYcvgjzDbaBNCD6bUl+86I7mUs4DKWHGruuK26ijjR/eDpWIDgNROA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.14.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+      "dependencies": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/octokit": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-1.7.1.tgz",
+      "integrity": "sha512-1b7eRgU8uWetHOWr8f9ptnVo2EKbrkOfocMeQdpgCt7tl/LK67HptFsy2Xg4fMjsJ/+onoBJW0hy/fO0In3/uA==",
+      "dependencies": {
+        "@octokit/app": "^12.0.4",
+        "@octokit/core": "^3.5.1",
+        "@octokit/oauth-app": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0",
+        "@octokit/plugin-retry": "^3.0.9",
+        "@octokit/plugin-throttling": "^3.5.1",
+        "@octokit/types": "^6.26.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
+      "integrity": "sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==",
+      "dependencies": {
+        "@types/jsonwebtoken": "^8.3.3",
+        "jsonwebtoken": "^8.5.1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  },
+  "dependencies": {
+    "@octokit/app": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-12.0.5.tgz",
+      "integrity": "sha512-lM3pIfx2h+UbvsXHFVs1ApJ9Rmp8LO4ciFSr5q/9MdHmhsH6WtwayieUn875xwB77IoR9r8czxxxASu2WCtdeA==",
+      "requires": {
+        "@octokit/auth-app": "^3.3.0",
+        "@octokit/auth-unauthenticated": "^2.0.4",
+        "@octokit/core": "^3.4.0",
+        "@octokit/oauth-app": "^3.3.2",
+        "@octokit/plugin-paginate-rest": "^2.13.3",
+        "@octokit/types": "^6.27.1",
+        "@octokit/webhooks": "^9.0.1"
+      }
+    },
+    "@octokit/auth-app": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.6.1.tgz",
+      "integrity": "sha512-6oa6CFphIYI7NxxHrdVOzhG7hkcKyGyYocg7lNDSJVauVOLtylg8hNJzoUyPAYKKK0yUeoZamE/lMs2tG+S+JA==",
+      "requires": {
+        "@octokit/auth-oauth-app": "^4.3.0",
+        "@octokit/auth-oauth-user": "^1.2.3",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.0.3",
+        "@types/lru-cache": "^5.1.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "^6.0.0",
+        "universal-github-app-jwt": "^1.0.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-app": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.1.tgz",
+      "integrity": "sha512-FXkKcGtTXS2987rp11mSuhMOXDw8Iy/ED9aXs83T29VeMEWjv40q4ytC0voUDxkBC/of1QYOPQUAdI2tv/dwNg==",
+      "requires": {
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/auth-oauth-user": "^1.2.1",
+        "@octokit/request": "^5.6.3",
+        "@octokit/types": "^6.0.3",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-device": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.2.tgz",
+      "integrity": "sha512-w7Po4Ck6N2aAn2VQyKLuojruiyKROTBv4qs6IwE5rbwF7HhBXXp4A/NKmkpoFIZkiXQtM+N8QtkSck4ApYWdGg==",
+      "requires": {
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^5.4.14",
+        "@octokit/types": "^6.10.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-user": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-1.3.0.tgz",
+      "integrity": "sha512-3QC/TAdk7onnxfyZ24BnJRfZv8TRzQK7SEFUS9vLng4Vv6Hv6I64ujdk/CUkREec8lhrwU764SZ/d+yrjjqhaQ==",
+      "requires": {
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^5.4.14",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/auth-unauthenticated": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.1.0.tgz",
+      "integrity": "sha512-+baofLfSL0CAv3CfGQ9rxiZZQEX8VNJMGuuS4PgrMRBUL52Ho5+hQYb63UJQshw7EXYMPDZxbXznc0y33cbPqw==",
+      "requires": {
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/oauth-app": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.6.0.tgz",
+      "integrity": "sha512-OxPw4ItQXaC2GuEXyZB7EmZ2rHvNFX4y3yAsqdFIRW7qg2HyoEPxacxza6c8wqbEEvu84b98AJ5BXm+IjPWrww==",
+      "requires": {
+        "@octokit/auth-oauth-app": "^4.0.0",
+        "@octokit/auth-oauth-user": "^1.3.0",
+        "@octokit/auth-unauthenticated": "^2.0.0",
+        "@octokit/core": "^3.3.2",
+        "@octokit/oauth-authorization-url": "^4.2.1",
+        "@octokit/oauth-methods": "^1.2.2",
+        "@types/aws-lambda": "^8.10.83",
+        "fromentries": "^1.3.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/oauth-authorization-url": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-4.3.3.tgz",
+      "integrity": "sha512-lhP/t0i8EwTmayHG4dqLXgU+uPVys4WD/qUNvC+HfB1S1dyqULm5Yx9uKc1x79aP66U1Cb4OZeW8QU/RA9A4XA=="
+    },
+    "@octokit/oauth-methods": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-1.2.6.tgz",
+      "integrity": "sha512-nImHQoOtKnSNn05uk2o76om1tJWiAo4lOu2xMAHYsNr0fwopP+Dv+2MlGvaMMlFjoqVd3fF3X5ZDTKCsqgmUaQ==",
+      "requires": {
+        "@octokit/oauth-authorization-url": "^4.3.1",
+        "@octokit/request": "^5.4.14",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "requires": {
+        "@octokit/types": "^6.34.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "requires": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.6.2.tgz",
+      "integrity": "sha512-0az5fxgVlhFfFtiKLKVXTpmCG2tK3BG0fYI8SO4pmGlN1kyJktJVQA+6KKaFxtxMIWsuHmSEAkR6zSgtk86g2A==",
+      "requires": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "requires": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
+    "@octokit/webhooks": {
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.24.0.tgz",
+      "integrity": "sha512-s1nqplA+j4sP7Cz40jn/Q2ipkKRKJ7Gi+NzZiSnwNfisYNduLHEwMUJVBEKc5I0r6GMcZZRJOe6PJ2rJXYW66g==",
+      "requires": {
+        "@octokit/request-error": "^2.0.2",
+        "@octokit/webhooks-methods": "^2.0.0",
+        "@octokit/webhooks-types": "5.6.0",
+        "aggregate-error": "^3.1.0"
+      }
+    },
+    "@octokit/webhooks-methods": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-2.0.0.tgz",
+      "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
+    },
+    "@octokit/webhooks-types": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.6.0.tgz",
+      "integrity": "sha512-y3MqE6N6Ksg1+YV0sXVpW2WP7Y24h7rUp2hDJuzoqWdKGr7owmRDyHC72INwfCYNzura/vsNPXvc6Xbfp4wGGw=="
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.97",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.97.tgz",
+      "integrity": "sha512-BZk3qO4R2KN8Ts3eR6CW1n8LI46UOgv1KoDZjo8J9vOQvDeX/rsrv1H0BpEAMcSqZ1mLwTEyAMtlua5tlSn0kw=="
+    },
+    "@types/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg=="
+    },
+    "@types/jsonwebtoken": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+    },
+    "@types/node": {
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+    },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "gaxios": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.0.tgz",
+      "integrity": "sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        }
+      }
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "google-auth-library": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+      "requires": {
+        "node-forge": "^1.3.1"
+      }
+    },
+    "googleapis": {
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-100.0.0.tgz",
+      "integrity": "sha512-RToFQGY54B756IDbjdyjb1vWFmn03bYpXHB2lIf0eq2UBYsIbYOLZ0kqSomfJnpclEukwEmMF7Jn6Wsev871ew==",
+      "requires": {
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.2"
+      }
+    },
+    "googleapis-common": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.1.0.tgz",
+      "integrity": "sha512-RXrif+Gzhq1QAzfjxulbGvAY3FPj8zq/CYcvgjzDbaBNCD6bUl+86I7mUs4DKWHGruuK26ijjR/eDpWIDgNROA==",
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.14.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        }
+      }
+    },
+    "gtoken": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.1.3",
+        "jws": "^4.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        }
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+    },
+    "octokit": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-1.7.1.tgz",
+      "integrity": "sha512-1b7eRgU8uWetHOWr8f9ptnVo2EKbrkOfocMeQdpgCt7tl/LK67HptFsy2Xg4fMjsJ/+onoBJW0hy/fO0In3/uA==",
+      "requires": {
+        "@octokit/app": "^12.0.4",
+        "@octokit/core": "^3.5.1",
+        "@octokit/oauth-app": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0",
+        "@octokit/plugin-retry": "^3.0.9",
+        "@octokit/plugin-throttling": "^3.5.1",
+        "@octokit/types": "^6.26.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "universal-github-app-jwt": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
+      "integrity": "sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==",
+      "requires": {
+        "@types/jsonwebtoken": "^8.3.3",
+        "jsonwebtoken": "^8.5.1"
+      }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/packages/lit-dev-cloudbuild-cleanup/package.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package.json
@@ -14,6 +14,7 @@
     "gaxios": "^5.0.0",
     "googleapis": "^100.0.0",
     "octokit": "^1.7.1",
+    "tslib": "^2.4.0",
     "typescript": "^4.6.4"
   }
 }

--- a/packages/lit-dev-cloudbuild-cleanup/package.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "lit-dev-cloudbuild-cleanup",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Tool to cleanup cloudrun artifacts for lit.dev",
+  "author": "Google LLC",
+  "license": "BSD-3-Clause",
+  "type": "module",
+  "scripts": {
+    "build": "wireit",
+    "build:ts": "wireit",
+    "start": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:ts"
+      ]
+    },
+    "build:ts": {
+      "files": [
+        "src/**",
+        "tsconfig.json",
+        "../../tsconfig.base.json"
+      ],
+      "output": [
+        "lib"
+      ],
+      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "clean": "if-file-deleted"
+    },
+    "start": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "node ./lib/cleanup.js"
+    }
+  },
+  "dependencies": {
+    "gaxios": "^5.0.0",
+    "googleapis": "^100.0.0",
+    "octokit": "^1.7.1"
+  }
+}

--- a/packages/lit-dev-cloudbuild-cleanup/package.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package.json
@@ -7,12 +7,13 @@
   "license": "BSD-3-Clause",
   "type": "module",
   "scripts": {
-    "build": "npx tsc --build",
+    "build": "tsc --build",
     "start": "node lib/cleanup.js"
   },
   "dependencies": {
     "gaxios": "^5.0.0",
     "googleapis": "^100.0.0",
-    "octokit": "^1.7.1"
+    "octokit": "^1.7.1",
+    "typescript": "^4.6.4"
   }
 }

--- a/packages/lit-dev-cloudbuild-cleanup/package.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "build": "npx tsc --build",
-    "start": "node lib/index.js"
+    "start": "node lib/cleanup.js"
   },
   "dependencies": {
     "gaxios": "^5.0.0",

--- a/packages/lit-dev-cloudbuild-cleanup/package.json
+++ b/packages/lit-dev-cloudbuild-cleanup/package.json
@@ -7,34 +7,8 @@
   "license": "BSD-3-Clause",
   "type": "module",
   "scripts": {
-    "build": "wireit",
-    "build:ts": "wireit",
-    "start": "wireit"
-  },
-  "wireit": {
-    "build": {
-      "dependencies": [
-        "build:ts"
-      ]
-    },
-    "build:ts": {
-      "files": [
-        "src/**",
-        "tsconfig.json",
-        "../../tsconfig.base.json"
-      ],
-      "output": [
-        "lib"
-      ],
-      "command": "../../node_modules/.bin/tsc --build --pretty",
-      "clean": "if-file-deleted"
-    },
-    "start": {
-      "dependencies": [
-        "build"
-      ],
-      "command": "node ./lib/cleanup.js"
-    }
+    "build": "npx tsc --build",
+    "start": "node lib/index.js"
   },
   "dependencies": {
     "gaxios": "^5.0.0",

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -186,6 +186,8 @@ async function main() {
       tags: string[];
     };
 
+    console.log('image tag count', data.tags.length);
+
     for (const [digest, manifest] of Object.entries(data.manifest)) {
       if (
         !imageDigestsToKeep.has(digest) &&
@@ -216,6 +218,7 @@ async function main() {
 
   // clean up gcr lit-dev/cache images created by kaniko
   {
+    console.log('fetching cache images from gcr');
     const resp = await request({
       url: `https://us.gcr.io/v2/${PROJECT_ID}/${REPO_NAME}/lit-dev/cache/tags/list`,
       method: 'GET',
@@ -229,12 +232,14 @@ async function main() {
       tags: string[];
     };
 
+    console.log('cache image tag count', data.tags.length);
+
     for (const [digest, manifest] of Object.entries(data.manifest)) {
       if (new Date(Number(manifest.timeCreatedMs)) < ONE_WEEK_AGO) {
         for (const tag of manifest.tag) {
           console.log(`deleting tag ${tag}`);
           await request({
-            url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/cache/manifests/${digest}`,
+            url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/cache/manifests/${tag}`,
             method: 'DELETE',
             headers: {
               authorization: 'Bearer ' + token,

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -8,6 +8,7 @@ const ONE_WEEK_AGO = new Date(Date.now() - ONE_WEEK_IN_MS);
 const {PROJECT_ID, REPO_NAME, _DEPLOY_REGION} = process.env;
 
 if ([PROJECT_ID, REPO_NAME, _DEPLOY_REGION].some((env) => env === undefined)) {
+  console.log({PROJECT_ID, REPO_NAME, _DEPLOY_REGION});
   throw new Error(
     'missing one or more required environment variables: PROJECT_ID, REPO_NAME, _DEPLOY_REGION'
   );

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -80,7 +80,7 @@ async function main() {
     parent: `projects/${PROJECT_ID}/locations/${_DEPLOY_REGION}`,
   });
 
-  let revisions = data;
+  const revisions = data;
 
   if (!revisions.items) {
     // We should never reach this since there should always be running revisions

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {google} from 'googleapis';
 import {Octokit} from 'octokit';
 import {request} from 'gaxios';

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -95,7 +95,7 @@ async function main() {
 
       const trafficToKeep = data.spec.traffic.filter((t) => {
         return (
-          // precence of percent indicates traffic is being routed here (i.e. prod)
+          // presence of percent indicates traffic is being routed here (i.e. prod)
           Boolean(t.percent) ||
           revisionsToKeepByRecency.has(t.revisionName!) ||
           openPrs.has(parseInt(t.tag!.slice(2), 10))
@@ -203,7 +203,7 @@ async function main() {
         new Date(manifest.timeCreatedMs) < ONE_WEEK_AGO
       ) {
         for (const tag of manifest.tag) {
-          console.log(`deleting tag ${tag}`);
+          console.log(`deleting container registry tag ${tag}`);
           await request({
             url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/manifests/${tag}`,
             method: 'DELETE',
@@ -245,7 +245,7 @@ async function main() {
     for (const [digest, manifest] of Object.entries(data.manifest)) {
       if (new Date(Number(manifest.timeCreatedMs)) < ONE_WEEK_AGO) {
         for (const tag of manifest.tag) {
-          console.log(`deleting tag ${tag}`);
+          console.log(`deleting container registry tag ${tag}`);
           await request({
             url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/cache/manifests/${tag}`,
             method: 'DELETE',

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -1,0 +1,258 @@
+import {google} from 'googleapis';
+import {Octokit} from 'octokit';
+import {request} from 'gaxios';
+
+const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+const ONE_WEEK_AGO = new Date(Date.now() - ONE_WEEK_IN_MS);
+
+const {PROJECT_ID, REPO_NAME, _DEPLOY_REGION} = process.env;
+
+if ([PROJECT_ID, REPO_NAME, _DEPLOY_REGION].some((env) => env === undefined)) {
+  throw new Error(
+    'missing one or more required environment variables: PROJECT_ID, REPO_NAME, _DEPLOY_REGION'
+  );
+}
+
+const sleep = (time: number) =>
+  new Promise((resolve) => setTimeout(resolve, time));
+
+async function main() {
+  const octokit = new Octokit();
+
+  const openPrs = new Set<number>();
+
+  console.log('fetching open PRs from github');
+  const openPrsIterator = octokit.paginate.iterator(octokit.rest.pulls.list, {
+    owner: 'lit',
+    repo: `${REPO_NAME}`,
+    state: 'open',
+    per_page: 100,
+  });
+
+  for await (const {data: prs} of openPrsIterator) {
+    for (const pr of prs) {
+      openPrs.add(pr.number);
+    }
+  }
+
+  console.log('found open prs', openPrs);
+
+  const run = google.run('v1');
+
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+  });
+
+  const authClient = await auth.getClient();
+  google.options({auth: authClient});
+
+  // fetch list of revisions across both services
+  console.log('fetching list of revisions');
+  const {data: revisions} = await run.projects.locations.revisions.list({
+    parent: `projects/${PROJECT_ID}/locations/${_DEPLOY_REGION}`,
+  });
+
+  if (!revisions.items) {
+    throw new Error('found no revision items');
+  }
+
+  console.log('total revisions count', revisions.items.length);
+
+  const revisionsToKeepByRecency = new Set<string>();
+  for (const rev of revisions.items) {
+    if (!rev.metadata) {
+      throw new Error('found no metadata');
+    }
+
+    if (new Date(rev.metadata.creationTimestamp!) > ONE_WEEK_AGO) {
+      revisionsToKeepByRecency.add(rev.metadata.name!);
+    }
+  }
+
+  console.log(
+    'revisions younger than a week count',
+    revisionsToKeepByRecency.size
+  );
+
+  // traffic tags must be cleaned up before a revision can be deleted
+  const services = ['lit-dev', 'lit-dev-playground'];
+  await Promise.all(
+    services.map(async (serviceName) => {
+      console.log(`fetching ${serviceName} service`);
+      const {data} = await run.projects.locations.services.get({
+        name: `projects/${PROJECT_ID}/locations/${_DEPLOY_REGION}/services/${serviceName}`,
+      });
+
+      if (!data.spec || !data.spec.traffic) {
+        throw new Error(`found no traffic for ${serviceName} service`);
+      }
+
+      console.log(`${serviceName} traffic count`, data.spec.traffic.length);
+
+      const trafficToKeep = data.spec.traffic.filter((t) => {
+        return (
+          Boolean(t.percent) || // there's traffic being routed here (i.e. prod)
+          revisionsToKeepByRecency.has(t.revisionName!) ||
+          openPrs.has(parseInt(t.tag!.slice(2), 10))
+        );
+      });
+
+      console.log(`${serviceName} traffic to keep count`, trafficToKeep.length);
+
+      if (trafficToKeep.length === 0) {
+        throw new Error('found no ${service} traffic to keep');
+      }
+
+      if (data.spec.traffic.length !== trafficToKeep.length) {
+        console.log(`updating ${serviceName} service`);
+        data.spec.traffic = trafficToKeep;
+        await run.projects.locations.services.replaceService({
+          name: `projects/${PROJECT_ID}/locations/${_DEPLOY_REGION}/services/${serviceName}`,
+          requestBody: data,
+        });
+      }
+    })
+  );
+
+  // revision status takes some time to update
+  console.log('waiting 30 seconds for traffic tags to update');
+  await sleep(30_000);
+
+  // fetching new list of revisions to get the now untagged (inactive) ones
+  console.log('fetching new revisions list');
+  const {data: newRevisions} = await run.projects.locations.revisions.list({
+    parent: `projects/${PROJECT_ID}/locations/${_DEPLOY_REGION}`,
+  });
+
+  if (!newRevisions.items) {
+    throw new Error('found no new revision items');
+  }
+
+  console.log('looking for inactive revisions to delete');
+  const imageDigestsToKeep = new Set<string>();
+  for (const rev of newRevisions.items) {
+    if (!rev.metadata) {
+      throw new Error('revision has no metadata');
+    }
+
+    if (!rev.status || !rev.status.conditions) {
+      throw new Error('revision has no status conditions');
+    }
+
+    if (!rev.spec || !rev.spec.containers) {
+      throw new Error('revision has no containers');
+    }
+
+    if (
+      rev.status.conditions.find((cond) => cond.type === 'Active')!.status !==
+        'True' &&
+      // extra timestamp check in case the revision was just created and not active because of that
+      new Date(rev.metadata.creationTimestamp!) < ONE_WEEK_AGO
+    ) {
+      console.log(`deleting revision ${rev.metadata.name}`);
+      await run.projects.locations.revisions.delete({
+        name: `projects/${PROJECT_ID}/locations/${_DEPLOY_REGION}/revisions/${rev.metadata.name}`,
+      });
+      // wait 1 second to not hit api limit
+      await sleep(1_000);
+    } else {
+      // the part after "@" is the image digest
+      const digest = rev.spec.containers[0].image?.match(/(?<=@)[^\/]+$/)?.[0];
+      if (!digest) {
+        throw new Error('found no image digest for revision');
+      }
+      imageDigestsToKeep.add(digest);
+    }
+  }
+
+  console.log('count of images in use', imageDigestsToKeep.size);
+
+  const {token} = await authClient.getAccessToken();
+
+  // clean up gcr lit-dev images that are no longer used
+  {
+    console.log('fetching images from gcr');
+    const resp = await request({
+      url: `https://us.gcr.io/v2/${PROJECT_ID}/${REPO_NAME}/lit-dev/tags/list`,
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer ' + token,
+      },
+    });
+
+    const data = resp.data as {
+      manifest: Record<string, {tag: string[]; timeCreatedMs: string}>;
+      tags: string[];
+    };
+
+    for (const [digest, manifest] of Object.entries(data.manifest)) {
+      if (
+        !imageDigestsToKeep.has(digest) &&
+        // in case image was just created without a revision associated with it
+        new Date(manifest.timeCreatedMs) < ONE_WEEK_AGO
+      ) {
+        for (const tag of manifest.tag) {
+          console.log(`deleting tag ${tag}`);
+          await request({
+            url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/manifests/${tag}`,
+            method: 'DELETE',
+            headers: {
+              authorization: 'Bearer ' + token,
+            },
+          });
+        }
+        console.log(`deleting image ${digest}`);
+        await request({
+          url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/manifests/${digest}`,
+          method: 'DELETE',
+          headers: {
+            authorization: 'Bearer ' + token,
+          },
+        });
+      }
+    }
+  }
+
+  // clean up gcr lit-dev/cache images created by kaniko
+  {
+    const resp = await request({
+      url: `https://us.gcr.io/v2/${PROJECT_ID}/${REPO_NAME}/lit-dev/cache/tags/list`,
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer ' + token,
+      },
+    });
+
+    const data = resp.data as {
+      manifest: Record<string, {tag: string[]; timeCreatedMs: string}>;
+      tags: string[];
+    };
+
+    for (const [digest, manifest] of Object.entries(data.manifest)) {
+      if (new Date(Number(manifest.timeCreatedMs)) < ONE_WEEK_AGO) {
+        for (const tag of manifest.tag) {
+          console.log(`deleting tag ${tag}`);
+          await request({
+            url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/cache/manifests/${digest}`,
+            method: 'DELETE',
+            headers: {
+              authorization: 'Bearer ' + token,
+            },
+          });
+        }
+        console.log(`deleting image ${digest}`);
+        await request({
+          url: `https://us.gcr.io/v2/lit-dev-site/lit.dev/lit-dev/cache/manifests/${digest}`,
+          method: 'DELETE',
+          headers: {
+            authorization: 'Bearer ' + token,
+          },
+        });
+      }
+    }
+  }
+
+  console.log('all done!');
+}
+
+main();

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -245,7 +245,7 @@ async function main() {
       if (
         !imageDigestsToKeep.has(digest) &&
         // in case image was just created without a revision associated with it
-        new Date(manifest.timeCreatedMs) < ONE_WEEK_AGO
+        new Date(Number(manifest.timeCreatedMs)) < ONE_WEEK_AGO
       ) {
         for (const tag of manifest.tag) {
           console.log(`Deleting container registry tag ${tag}`);

--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -146,18 +146,23 @@ async function main() {
         // Tags should look like "pr529-8b0837f" or "main-45ace0e"
         const prMatch = t.tag.match(/^pr(\d+)-/);
         if (prMatch) {
+          // Tags that have PR number require special attention to see if they
+          // should be kept
           const prNumber = Number(prMatch[1]);
           if (openPrs.has(prNumber)) {
             revisionsToKeep.add(t.revisionName);
             return true;
           }
         } else if (!t.tag.startsWith('main')) {
+          // Unrecognized tags are kept just in case
           console.log(
             `Found unrecognized tag "${t.tag}". This will not be deleted.`
           );
           revisionsToKeep.add(t.revisionName);
           return true;
         }
+        // Tags that do begin with "main" require no special attention and can
+        // be filtered out if they passed the recency check above
       }
 
       return false;

--- a/packages/lit-dev-cloudbuild-cleanup/tsconfig.json
+++ b/packages/lit-dev-cloudbuild-cleanup/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "incremental": true,
+    "tsBuildInfoFile": "lib/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Resolves #786 

The Cloud Build and Cloud Run to deploy the lit.dev site for production and PR previews were leaving artifacts like service revisions and docker images that were no longer needed.

This PR adds a `cloudbuild-clean.yaml` that can be manually triggered, or run on schedule, which will do the following:
- Fetch all open PRs for this repo
- Fetch all revisions we have for the main site service and playground service
- Identify revisions that are associated with any open PRs or are younger than 1 week
- Remove any traffic tags for revisions that were not identified in the above step
- Update each service with the trimmed down list of traffic tags
- Delete all revisions that no longer have any traffic tags
- Fetch all docker image tags in GCR and identify ones that are not associated with any active revisions and older than a week
- Delete all tags from image, then delete the image
- Fetch all cache docker images (created by kaniko) and identify ones older than a week
- Delete all tags from image, then delete the image

Run example: https://pantheon.corp.google.com/cloud-build/builds;region=global/b24b1ec5-6947-4e7b-aae9-88ad9505ff18?project=lit-dev-site

Once this is merged, the cloudbuild trigger can be updated to point to `main` branch and scheduled.