### PR TITLE
Reference superclass explicitly in the mixin demo

### DIFF
--- a/packages/lit-dev-content/samples/docs/mixins/highlightable/element-two.ts
+++ b/packages/lit-dev-content/samples/docs/mixins/highlightable/element-two.ts
@@ -5,7 +5,7 @@ import {Highlightable} from './highlightable.js'
 @customElement('element-two')
 export class ElementTwo extends Highlightable(LitElement) {
   static styles = [
-    super.styles || [],
+    Highlightable(LitElement).styles || [],
     css`:host { display: block; }`
   ];
   render(){

--- a/packages/lit-dev-content/samples/docs/mixins/highlightable/element-two.ts
+++ b/packages/lit-dev-content/samples/docs/mixins/highlightable/element-two.ts
@@ -2,10 +2,12 @@ import {LitElement, html, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {Highlightable} from './highlightable.js'
 
+const HighlightableLitElement = Highlightable(LitElement);
+
 @customElement('element-two')
-export class ElementTwo extends Highlightable(LitElement) {
+export class ElementTwo extends HighlightableLitElement {
   static styles = [
-    Highlightable(LitElement).styles || [],
+    HighlightableLitElement.styles || [],
     css`:host { display: block; }`
   ];
   render(){

--- a/packages/lit-dev-content/samples/docs/mixins/highlightable/highlightable.ts
+++ b/packages/lit-dev-content/samples/docs/mixins/highlightable/highlightable.ts
@@ -15,7 +15,10 @@ export const Highlightable =
   <T extends Constructor<LitElement>>(superClass: T) => {
     class HighlightableElement extends superClass {
       // Adds some styles...
-      static styles = css`.highlight { background: yellow; }`
+      static styles = [
+        (superClass as unknown as typeof LitElement).styles ?? [],
+        css`.highlight { background: yellow; }`
+      ];
 
       // ...a public `highlight` property/attribute...
       @property({type: Boolean}) highlight = false;


### PR DESCRIPTION
Hey Lit team,

The playground [example](https://lit.dev/playground/#sample=docs/mixins/highlightable) on the live site is not working, the second element is not rendered correctly because `super.styles` does not work here. So I implemented a quick fix to replace `super.styles` with `Highlightable(LitElement).styles`.

Actually the Lit documentation also mentions about explicitly referencing the superclass instead of using `super`: https://lit.dev/docs/components/styles/#inheriting-styles-from-a-superclass

Thanks,