### PR TITLE
Fix typo in 00.md

### DIFF
--- a/packages/lit-dev-content/site/tutorials/content/carousel/00.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/00.md
@@ -1,5 +1,5 @@
 In this tutorial, you'll build a simple carousel element animated with the
-`@lib-labs/motion` package's `animate` directive.
+`@lit-labs/motion` package's `animate` directive.
 
 #### Background
 Carousels are a great way to show a large amount of related content in a


### PR DESCRIPTION
Fixed a typo on the first page of the carousel tutorial
lib-labs -> lit-labs