### PR TITLE
[docs] Fix async task example 

### DIFF
--- a/packages/lit-dev-content/samples/docs/controllers/names/my-element.ts
+++ b/packages/lit-dev-content/samples/docs/controllers/names/my-element.ts
@@ -18,12 +18,12 @@ export class MyElement extends LitElement {
     ${this.names.render({
       complete: (result: Names.Result) => html`
         <p>List of ${this.names.kind}</p>
-        <ul>${result.map(i => html`<li>${i.value}</li>`)}
+        <ul>${result.map(i => html`<li>${i.name}</li>`)}
         </ul>
       `,
       initial: () => html`<p>Select a kind...</p>`,
       pending: () => html`<p>Loading ${this.names.kind}...</p>`,
-      error: (e: any) => html`<p>Error: ${e}</p>`
+      error: (e: any) => html`<p>${e}</p>`
     })}`;
   }
 

--- a/packages/lit-dev-content/samples/docs/controllers/names/names-api.ts
+++ b/packages/lit-dev-content/samples/docs/controllers/names/names-api.ts
@@ -1,18 +1,17 @@
 export interface Error {
   error: string;
 }
-export type Result = Array<{value: string}>;
-export type Kind = keyof typeof kindIdMap;
+export type Result = Array<{name: string}>;
+export type Kind = typeof kinds[number];
 
-export const baseUrl = 'https://next.json-generator.com/api/json/get/';
-export const kindIdMap = {
-  '': '',
-  'cities': 'VyfXnFpH5',
-  'countries': 'Vk0bnY6B9',
-  'states': '4J5N3tTH9',
-  'streets': 'NybqntTr5',
+export const baseUrl = 'https://swapi.dev/api/';
+
+export const kinds = [
+  '',
+  'people',
+  'starships',
+  'species',
+  'planets',
   // Inserted to demo an error state.
-  'error': ''
-}
-
-export const kinds = Object.keys(kindIdMap);
+  'error'
+] as const;

--- a/packages/lit-dev-content/samples/docs/controllers/names/names-controller.ts
+++ b/packages/lit-dev-content/samples/docs/controllers/names/names-controller.ts
@@ -16,13 +16,13 @@ export class NamesController {
         if (!kind?.trim()) {
           return initialState;
         }
-        const response = await fetch(`${Names.baseUrl}${Names.kindIdMap[kind]}`);
-        const result = await response.json();
-        const error = (result as Names.Error).error;
-        if (error !== undefined) {
-          throw new Error(error);
+        try {
+          const response = await fetch(`${Names.baseUrl}${kind}`);
+          const data = await response.json();
+          return data.results as Names.Result;
+        } catch(error) {
+          throw new Error(`Failed to fetch "${kind}"`);
         }
-        return result as Names.Result;
       }, () => [this.kind]
     );
   }


### PR DESCRIPTION
Fixes #559 

### Changes
- Replaced json-generator API with [swapi.dev](https://swapi.dev/)
- There was no more a need for kind to id map since swapi had semantic route names
- Removed the "Error: " in the error rendering as it was causing duplicates since stringifying the error object adds it as well.