### PR TITLE
update to playground-elements 0.16.2

### DIFF
--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -203,7 +203,7 @@
     "@material/mwc-textfield": "^0.25.1",
     "lit": "^2.1.0",
     "minisearch": "^3.0.4",
-    "playground-elements": "^0.16.0",
+    "playground-elements": "^0.16.2",
     "postdoc-lib": "^1.0.3",
     "tarts": "^1.0.0",
     "timeago.js": "^4.0.2",

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -47,7 +47,7 @@
     "jsdom": "^17.0.0",
     "minisearch": "^3.0.4",
     "outdent": "^0.8.0",
-    "playground-elements": "^0.16.0",
+    "playground-elements": "^0.16.2",
     "playwright": "^1.8.0",
     "source-map": "^0.8.0-beta.0",
     "strip-comments": "^2.0.1",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -43,7 +43,7 @@
     "fast-glob": "^3.2.9",
     "lit-dev-server": "^0.0.0",
     "lit-dev-tools-cjs": "^0.0.0",
-    "playground-elements": "^0.16.0",
+    "playground-elements": "^0.16.2",
     "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
Bump the `playground-element` dependency up a knotch!

This update supports `jsx` and `tsx` files.