### PR TITLE
Minor workspaces followup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "npm-run-all": "^4.1.5",
         "playground-elements": "^0.16.2",
-        "prettier": "^2.1.2",
+        "prettier": "=2.1.2",
         "typescript": "~4.6.2",
         "wireit": "^0.6.1"
       }
@@ -8045,17 +8045,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty": {
@@ -10694,6 +10692,20 @@
         "lit-dev-server": "^0.0.0",
         "lit-dev-tools-cjs": "^0.0.0",
         "prettier": "^2.3.2"
+      }
+    },
+    "packages/lit-dev-tools-esm/node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     }
   },
@@ -16164,6 +16176,13 @@
         "lit-dev-server": "^0.0.0",
         "lit-dev-tools-cjs": "^0.0.0",
         "prettier": "^2.3.2"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+          "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+        }
       }
     },
     "lit-element": {
@@ -17274,9 +17293,10 @@
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
     },
     "pretty": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "devDependencies": {
         "npm-run-all": "^4.1.5",
         "playground-elements": "^0.16.2",
-        "prettier": "=2.1.2",
+        "prettier": "^2.1.2",
         "typescript": "~4.6.2",
-        "wireit": "^0.6.1"
+        "wireit": "^0.7.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2350,9 +2350,9 @@
       "optional": true
     },
     "node_modules/aws-sdk": {
-      "version": "2.1156.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1156.0.tgz",
-      "integrity": "sha512-XLMsSOW6ZyBj6mRgACt1EiUdvd+q0Da5fTjbsEgi1KOENQ0met0CSqgBcpg2EMWgBBV9E2L7uUd98O1uBbGc7g==",
+      "version": "2.1157.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1157.0.tgz",
+      "integrity": "sha512-30t+zhCECib8uaggd0Du8ifab4vtJjgVvNKxHWTpiLa3deTnM+0K7x3pwM99zxw0gLDxAUet/oURaoPJHwk/5Q==",
       "optional": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -8045,15 +8045,17 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
-      "dev": true,
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty": {
@@ -10279,9 +10281,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.6.1.tgz",
-      "integrity": "sha512-UmrAzFd2w6ioyHluPwXr3TxUIo5CIbklTbTTgubN81jQxiPkAHXTjzkfTOjeAdeEzZ5OpsbYCQW5obCrFMlTdw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.0.tgz",
+      "integrity": "sha512-VQAH/ma6ujc9Y+K4zn5U76vH/Q4rFq74zWS+CMrkYhczi6nwKA+Z0zw9hrvIjbMoYs7wswu4ysaXe63Rnv4tlg==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -10692,20 +10694,6 @@
         "lit-dev-server": "^0.0.0",
         "lit-dev-tools-cjs": "^0.0.0",
         "prettier": "^2.3.2"
-      }
-    },
-    "packages/lit-dev-tools-esm/node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     }
   },
@@ -12801,9 +12789,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1156.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1156.0.tgz",
-      "integrity": "sha512-XLMsSOW6ZyBj6mRgACt1EiUdvd+q0Da5fTjbsEgi1KOENQ0met0CSqgBcpg2EMWgBBV9E2L7uUd98O1uBbGc7g==",
+      "version": "2.1157.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1157.0.tgz",
+      "integrity": "sha512-30t+zhCECib8uaggd0Du8ifab4vtJjgVvNKxHWTpiLa3deTnM+0K7x3pwM99zxw0gLDxAUet/oURaoPJHwk/5Q==",
       "optional": true,
       "requires": {
         "buffer": "4.9.2",
@@ -16176,13 +16164,6 @@
         "lit-dev-server": "^0.0.0",
         "lit-dev-tools-cjs": "^0.0.0",
         "prettier": "^2.3.2"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-          "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
-        }
       }
     },
     "lit-element": {
@@ -17293,10 +17274,9 @@
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "prettier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
-      "dev": true
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "pretty": {
       "version": "2.0.0",
@@ -19112,9 +19092,9 @@
       }
     },
     "wireit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.6.1.tgz",
-      "integrity": "sha512-UmrAzFd2w6ioyHluPwXr3TxUIo5CIbklTbTTgubN81jQxiPkAHXTjzkfTOjeAdeEzZ5OpsbYCQW5obCrFMlTdw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.0.tgz",
+      "integrity": "sha512-VQAH/ma6ujc9Y+K4zn5U76vH/Q4rFq74zWS+CMrkYhczi6nwKA+Z0zw9hrvIjbMoYs7wswu4ysaXe63Rnv4tlg==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "dev": "cd packages/lit-dev-server && npm run build && cd ../lit-dev-content && (npm run dev:build:assets --watch & npm run dev:build:eleventy:watch & node ../lit-dev-tools-esm/lib/dev-server.js --open)",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "nuke": "rm -rf node_modules packages/*/node_modules && npm ci",
     "upgrade": "rm -rf node_modules package-lock.json packages/*/node_modules && npm i",
     "test:unit": "npm run test -w lit-dev-tools-cjs",
     "test:integration": "npm run test:integration -w lit-dev-tests",
@@ -46,7 +45,7 @@
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "playground-elements": "^0.16.2",
-    "prettier": "^2.1.2",
+    "prettier": "=2.1.2",
     "typescript": "~4.6.2",
     "wireit": "^0.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "playground-elements": "^0.16.2",
-    "prettier": "=2.1.2",
+    "prettier": "^2.1.2",
     "typescript": "~4.6.2",
-    "wireit": "^0.6.1"
+    "wireit": "^0.7.0"
   }
 }

--- a/packages/lit-dev-server/src/server.ts
+++ b/packages/lit-dev-server/src/server.ts
@@ -18,6 +18,8 @@ import {contentSecurityPolicyMiddleware} from './middleware/content-security-pol
 import {createGitHubTokenExchangeMiddleware} from './middleware/github-token-exchange-middleware.js';
 import {notFoundMiddleware} from './middleware/notfound-middleware.js';
 import {getEnvironment} from 'lit-dev-tools-cjs/lib/lit-dev-environments.js';
+import {createRequire} from 'node:module';
+const require = createRequire(import.meta.url);
 
 const ENV = getEnvironment();
 
@@ -34,7 +36,7 @@ const repoRoot = path.resolve(__dirname, '..', '..', '..');
 const contentPackage = path.resolve(repoRoot, 'packages', 'lit-dev-content');
 const staticRoot =
   mode === 'playground'
-    ? path.join(repoRoot, 'node_modules', 'playground-elements')
+    ? require.resolve('playground-elements')
     : path.join(contentPackage, ENV.eleventyOutDir);
 
 console.log(`mode: ${mode}`);

--- a/packages/lit-dev-tools-esm/src/dev-server.ts
+++ b/packages/lit-dev-tools-esm/src/dev-server.ts
@@ -14,6 +14,8 @@ import {contentSecurityPolicyMiddleware} from 'lit-dev-server/lib/middleware/con
 import {fakeGitHubMiddleware} from './fake-github-middleware.js';
 import {createGitHubTokenExchangeMiddleware} from 'lit-dev-server/lib/middleware/github-token-exchange-middleware.js';
 import {dev as ENV} from 'lit-dev-tools-cjs/lib/lit-dev-environments.js';
+import {createRequire} from 'node:module';
+const require = createRequire(import.meta.url);
 
 const THIS_DIR = pathlib.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = pathlib.resolve(THIS_DIR, '..', '..', '..');
@@ -107,7 +109,7 @@ startDevServer({
 startDevServer({
   config: {
     port: ENV.playgroundPort,
-    rootDir: pathlib.resolve(REPO_ROOT, 'node_modules', 'playground-elements'),
+    rootDir: require.resolve('playground-elements'),
     middleware: [playgroundMiddleware()],
   },
   // Ignore any CLI flags. In particular we only want --open to apply to the


### PR DESCRIPTION
- Remove `nuke` script because it's now equivalent to just `npm ci`
- Use `require.resolve` in a couple spots instead of hard-coding the path to `node_modules/playground-elements`
- Update wireit to bring in https://github.com/google/wireit/pull/310