### PR TITLE
Fix snippet in Events docs

### DIFF
--- a/packages/lit-dev-content/site/docs/components/events.md
+++ b/packages/lit-dev-content/site/docs/components/events.md
@@ -51,7 +51,7 @@ The component constructor is a good place to add event listeners on the componen
 ```js
 constructor() {
   super();
-  this.addEventListener('click', (e) => console.log(e.type, e.target.localName)));
+  this.addEventListener('click', (e) => console.log(e.type, e.target.localName));
 }
 ```
 


### PR DESCRIPTION
Removed redundant bracket in section [Adding event listeners to the component or its shadow root](https://lit.dev/docs/components/events/#adding-event-listeners-to-the-component-or-its-shadow-root)