### PR TITLE
Add generic meta tags to home page, docs, tutorials, and playground

### DIFF
--- a/packages/lit-dev-content/site/_includes/docs.html
+++ b/packages/lit-dev-content/site/_includes/docs.html
@@ -9,6 +9,7 @@
 {% endif %}
 
 {% block head %}
+  {% include "social-tags.html" %}
   {% inlinecss "docs.css" %}
   {% inlinejs "pages/docs.js" %}
   {% if '/api/' in page.url %}

--- a/packages/lit-dev-content/site/_includes/social-tags.html
+++ b/packages/lit-dev-content/site/_includes/social-tags.html
@@ -1,0 +1,16 @@
+<!--
+    Generalized from 'blog-post.html' to provide basic open graph and
+    Twitter card metadata.
+  -->
+<meta property="og:url" content="{{ env.MAIN_URL }}{{ page.url }}" />
+<meta property="og:title" content="{% if title %}{{ title }} &ndash;{% endif %} Lit" />
+<meta property="og:description" content="Simple. Fast. Web Components." />
+<meta property="og:site_name" content="lit.dev" />
+<meta
+  property="og:image"
+  content="{{ env.MAIN_URL }}/images/logo-whitebg-padded-1600x800.png"
+/>
+<meta property="og:image:alt" content="Lit Logo" />
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@buildWithLit" />

--- a/packages/lit-dev-content/site/index.html
+++ b/packages/lit-dev-content/site/index.html
@@ -5,6 +5,7 @@ noaside: true
 {% extends 'default.html' %}
 
 {% block head %}
+  {% include "social-tags.html" %}
   {% inlinecss "home.css" %}
   {% inlinejs "pages/home.js" %}
   <script type="module" src="{{ site.baseurl }}/js/pages/home-components.js"></script>

--- a/packages/lit-dev-content/site/playground/index.html
+++ b/packages/lit-dev-content/site/playground/index.html
@@ -5,6 +5,7 @@ title: Playground
 {% extends 'default.html' %}
 
 {% block head %}
+  {% include "social-tags.html" %}
   {% inlinecss "playground.css" %}
   {% inlinejs "pages/playground-inline.js" %}
   <script type="module" src="{{ site.baseurl }}/js/components/litdev-playground-page.js"></script>

--- a/packages/lit-dev-content/site/tutorials/index.html
+++ b/packages/lit-dev-content/site/tutorials/index.html
@@ -6,6 +6,7 @@ noaside: true
 {% extends 'default.html' %}
 
 {% block head %}
+  {% include "social-tags.html" %}
   {% inlinecss "tutorial-catalog.css" %}
 {% endblock %}
 


### PR DESCRIPTION
Issue: https://github.com/lit/lit.dev/issues/335

Adds generalized social meta tags across pages that were missing them.
These only leverage "title" and "url" which are available on each of these pages.

Primarily this change is to add the thumbnail image https://lit.dev/images/logo-whitebg-padded-1600x800.png to social links.

Pages which will now have the Lit logo on them when shared:

 - Home page
 - Playground
 - Tutorial catalog
 - Documentation


Tested by passing the following preview urls into https://developers.facebook.com/tools/debug and https://cards-dev.twitter.com/validator

- https://pr883-8af8840---lit-dev-5ftespv5na-uc.a.run.app/
- https://pr883-8af8840---lit-dev-5ftespv5na-uc.a.run.app/docs/
- https://pr883-8af8840---lit-dev-5ftespv5na-uc.a.run.app/tutorials/
- https://pr883-8af8840---lit-dev-5ftespv5na-uc.a.run.app/playground/

Fixes https://github.com/lit/lit.dev/issues/335