### PR TITLE
implement articles MVP

### DIFF
--- a/packages/lit-dev-content/site/_includes/article.html
+++ b/packages/lit-dev-content/site/_includes/article.html
@@ -1,0 +1,49 @@
+{% extends 'articles.html' %}
+
+{% block articleHeader %}
+  <div class="date">
+    <time datetime="{{ publishDate }}">{{ publishDate | readableDate }}</time>
+    {% if lastUpdated %}
+     — Updated <time datetime="{{ lastUpdated }}">{{ lastUpdated | readableDate }}</time>
+    {% endif %}
+  </div>
+  <div class="tags">
+    {% for tag in tags %}
+      {% if tag != 'articles-nav' %}
+        <a href="{{ site.baseurl }}/articles/tags/{{ tag }}/" aria-label="{{ tag }} tag">{{ tag }}</a>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <div class="authors">
+    {% for authorId in author or defaultAuthor %}
+      {% set authorData = authors[authorId] %}
+      <figure class="author">
+        <img src="{{ site.baseurl }}/images/{{ authorData.image.url }}"
+            width="80" height="80"
+            {% if authorData.image.class %}class="{{ authorData.image.class }}"{% endif %}
+            alt="{% if authorData.image.alt !== undefined %}{{ authorData.image.alt }}{% else %}Photo of {{ authorData.name }}{% endif %}">
+          <div>
+            <figcaption>{{ authorData.name }}</figcaption>
+            {% if authorData.links %}
+              <div class="links">
+                {% if authorData.links.twitter %}
+                  <a href="https://twitter.com/{{ authorData.links.twitter }}" target="_blank">
+                    <svg aria-label="{{ authorData.name}}'s Twitter Account">
+                      <use href="{{ site.baseurl }}/images/social/twitter.svg#twitter"></use>
+                    </svg>
+                  </a>
+                {% endif %}
+                {% if authorData.links.github %}
+                  <a href="https://github.com/{{ authorData.links.twitter }}" target="_blank">
+                    <svg aria-label="{{ authorData.name}}'s Github Account">
+                      <use href="{{ site.baseurl }}/images/social/github.svg#github"></use>
+                    </svg>
+                  </a>
+                {% endif %}
+              </div>
+            {% endif %}
+          </div>
+      </figure>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/packages/lit-dev-content/site/_includes/articles-feed.html
+++ b/packages/lit-dev-content/site/_includes/articles-feed.html
@@ -1,0 +1,54 @@
+{% extends 'articles.html' %}
+
+{% set sectionName = eleventyNavigation.key %}
+{% set children = collections[childrenTag] %}
+
+
+<!-- This is the main articles feed that must list all sections -->
+{% if sectionName == "Tags" %}
+  {% set children = collections.article %}
+{% endif %}
+
+{% set children = children %}
+
+{% block articleContent %}
+
+<ol class="articleFeedList" tabindex="0">
+{% for child in children %}
+  <li class="feedItem">
+    <a href="{{ child.url | url }}">
+      <h2 class="date">
+        {% if child.data.lastUpdated %}
+          <time datetime="{{ child.data.lastUpdated }}">{{ child.data.lastUpdated | readableDate }}</time>
+        {% else %}
+          <time datetime="{{ child.data.publishDate }}">{{ child.data.publishDate | readableDate }}</time>
+        {% endif %}
+      </h2>
+      <div class="details">
+        <h2 class="title">
+          {{ child.data.title }}
+        </h2>
+        <p class="summary">
+          {{ child.data.summary }}
+        </p>
+        <div class="authors">
+          {% for authorId in child.data.author or child.data.defaultAuthor %}
+            {% set authorData = authors[authorId] %}
+            <figure class="author">
+              <img src="{{ site.baseurl }}/images/{{ authorData.image.url }}"
+                  width="80" height="80"
+                  {% if authorData.image.class %}class="{{ authorData.image.class }}"{% endif %}
+                  alt="{% if authorData.image.alt !== undefined %}{{ authorData.image.alt }}{% else %}Photo of {{ authorData.name }}{% endif %}">
+                <figcaption>{{ authorData.name }}</figcaption>
+            </figure>
+          {% endfor %}
+        </div>
+      </div>
+    </a>
+  </li>
+{% endfor %}
+</ol>
+
+{{ content | safe }}
+
+{% endblock %}

--- a/packages/lit-dev-content/site/_includes/articles-nav.html
+++ b/packages/lit-dev-content/site/_includes/articles-nav.html
@@ -1,0 +1,31 @@
+{% set navSection = eleventyNavigation.parent or eleventyNavigation.key %}
+{%- set navSections = collections[collection] | eleventyNavigation -%}
+
+{%- for section in navSections %}
+
+  {% if section.hidden != true %}
+    {# Are any children in this section active? #}
+    {% set sectionActive = false %}
+    {%- for child in section.children %}
+      {% if child.url == page.url %}
+        {% set sectionActive = true %}
+      {% endif %}
+    {%- endfor %}
+
+    <li{% if sectionActive %} class="activeSection"{% endif %}>
+      {%- if section.children | length %}
+        <span class="sectionHead{% if section.url == page.url %} active{% endif %}">
+          {{ section.title }}</span>
+        <ol>
+        {%- for child in section.children %}
+          <li{% if child.url == page.url %} class="active"{% endif %}>
+            <a href="{{ child.url | url }}">{{ child.title }}</a>
+          </li>
+        {%- endfor %}
+        </ol>
+      {%- else %}
+        <a href="{{ section.url | url }}">{{ section.title }}</a>
+      {%- endif %}
+    </li>
+  {% endif %}
+{%- endfor %}

--- a/packages/lit-dev-content/site/_includes/articles.html
+++ b/packages/lit-dev-content/site/_includes/articles.html
@@ -1,0 +1,105 @@
+{% extends 'default.html' %}
+
+<!-- When we're rendering API docs, our "versionLinks" data doesn't come from
+     markdown frontmatter, instead it comes from the API JSON data.
+     TODO(aomarks) There must be some way to assign "versionLinks" to
+     "data.otherVersions" from api.html, but I haven't figure out how! -->
+{% if not versionLinks %}
+  {% set versionLinks = data.versionLinks %}
+{% endif %}
+
+{% block head %}
+  {% inlinecss "docs.css" %}
+  {% inlinecss "articles.css" %}
+  {% inlinejs "pages/docs.js" %}
+  <script type="module" src="{{ site.baseurl }}/js/components/playground-elements.js"></script>
+  <script type="module" src="{{ site.baseurl }}/js/components/litdev-example.js"></script>
+  <script type="module" src="{{ site.baseurl }}/js/components/litdev-switchable-sample.js"></script>
+{% endblock %}
+
+{% block content %}
+  {% set toc = content | toc %}
+
+  <div id="docsNavWrapper" class="minimalScroller">
+    <nav id="docsNav">
+      <ol>{% include 'articles-nav.html' %}</ol>
+    </nav>
+  </div>
+
+  <div id="rhsTocWrapper">
+    {% if toc | tocHasEntries %}
+      <nav id="rhsToc">
+        <h2><a href="#content">Contents: {{ title }}</a></h2>
+        <div id="rhsTocInner">
+          {{ toc | safe }}
+        </div>
+      </nav>
+    {% endif %}
+  </div>
+
+  <div id="articleWrapper">
+    <article id="content">
+      <header class="articleHeader">
+        <h1>{{ title }}</h1>
+        {% block articleHeader %}{% endblock %}
+        {% if toc | tocHasEntries %}
+          <nav id="inlineToc">
+            <details>
+              <summary><h2>Contents</h2></summary>
+              {{ toc | safe }}
+            </details>
+          </nav>
+        {% endif %}
+      </header>
+
+
+      {% block articleContent %}{{ content | safe }}{% endblock %}
+
+      {% set navItems = collections[collection] | eleventyNavigation | flattenNavigationAndAddNextPrev %}
+      {% for item in navItems %}
+        {% if item.url === page.url and item.parent %}
+          {% set prev = item.prev %}
+          {% set prevTitle = prev.url | documentUrlTitle %}
+          {% if not prev.parent %}
+            {% set prev = prev.prev %}
+          {% endif %}
+          {% set next = item.next %}
+          {% set nextTitle = next.url | documentUrlTitle %}
+          {% if not next.parent %}
+            {% set next = next.next %}
+          {% endif %}
+
+          <div id="prevAndNextLinks">
+            <span>
+              {% if prev and isTagPage != true and prevTitle %}
+                <a id="prevLink" href="{{ prev.url }}">
+                  <!-- Source: https://material.io/resources/icons/?icon=arrow_back -->
+                  <svg class="arrow" width="24" height="24" viewBox="0 0 24 24" fill="currentcolor">
+                    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+                  </svg>
+                  <span class="direction">Previous</span>
+                  <span class="title">{{ prevTitle }}</span>
+                </a>
+              {% endif %}
+            </span>
+
+            <span>
+              {% if next and isTagPage != true and nextTitle %}
+                <a id="nextLink" href="{{ next.url }}">
+                  <span class="direction">Next</span>
+                  <span class="title">{{ nextTitle }}</span>
+                  <!-- Source: https://material.io/resources/icons/?icon=arrow_forward -->
+                  <svg class="arrow" width="24" height="24" viewBox="0 0 24 24" fill="currentcolor">
+                    <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
+                  </svg>
+                </a>
+              {% endif %}
+            </span>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </article>
+  </div>
+
+
+{% endblock %}

--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -77,7 +77,8 @@
     {% endif %}
 
     <main {% if not page.url.includes('/docs/')
-            and not page.url.includes('/playground/') %}
+            and not page.url.includes('/playground/')
+            and not page.url.includes('/articles/') %}
               id="content" {% endif %}>
       {% block content %}{{ content | safe }}{% endblock %}
     </main>

--- a/packages/lit-dev-content/site/articles/article.md
+++ b/packages/lit-dev-content/site/articles/article.md
@@ -1,0 +1,7 @@
+---
+tags:
+  - articles-nav
+eleventyNavigation:
+  key: Articles
+  order: 1
+---

--- a/packages/lit-dev-content/site/articles/article/article.11tydata.js
+++ b/packages/lit-dev-content/site/articles/article/article.11tydata.js
@@ -1,0 +1,6 @@
+module.exports = {
+  eleventyComputed: {
+    layout: "article",
+    permalink: data => `/articles/${data.page.fileSlug}/`,
+  }
+}

--- a/packages/lit-dev-content/site/articles/article/light-dom.md
+++ b/packages/lit-dev-content/site/articles/article/light-dom.md
@@ -1,0 +1,50 @@
+---
+title: Using Light DOM
+publishDate: 2020-07-19
+lastUpdated: 2020-07-22
+summary: This article is about composition stuff.
+tags:
+  - composition
+eleventyNavigation:
+  parent: Articles
+  key: Using Light DOM
+  order: 0
+author:
+  - arthur-evans
+---
+
+This is an example article to show how to hook up an article.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque elit eget gravida cum sociis. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper. Blandit aliquam etiam erat velit scelerisque in dictum. Lectus arcu bibendum at varius vel pharetra. Massa placerat duis ultricies lacus sed turpis tincidunt id aliquet. Netus et malesuada fames ac. Pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus. Aenean sed adipiscing diam donec adipiscing. A arcu cursus vitae congue mauris rhoncus. Vel facilisis volutpat est velit egestas dui id. Ultrices in iaculis nunc sed. Dui accumsan sit amet nulla.
+
+## Title 1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque elit eget gravida cum sociis. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper. Blandit aliquam etiam erat velit scelerisque in dictum. Lectus arcu bibendum at varius vel pharetra. Massa placerat duis ultricies lacus sed turpis tincidunt id aliquet. Netus et malesuada fames ac. Pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus. Aenean sed adipiscing diam donec adipiscing. A arcu cursus vitae congue mauris rhoncus. Vel facilisis volutpat est velit egestas dui id. Ultrices in iaculis nunc sed. Dui accumsan sit amet nulla.
+
+Sit amet tellus cras adipiscing enim eu turpis egestas. Varius morbi enim nunc faucibus a pellentesque sit amet porttitor. Et molestie ac feugiat sed lectus. Sodales ut eu sem integer vitae. Aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi. Nunc sed id semper risus in hendrerit gravida. Tincidunt dui ut ornare lectus. Lacus vel facilisis volutpat est velit egestas dui id ornare. Nisi est sit amet facilisis. Tempor orci dapibus ultrices in iaculis nunc. Aliquam eleifend mi in nulla posuere. At varius vel pharetra vel turpis nunc. Quis blandit turpis cursus in hac habitasse platea. Ultrices tincidunt arcu non sodales neque sodales. Nec nam aliquam sem et tortor. Tincidunt arcu non sodales neque.
+
+Enim blandit volutpat maecenas volutpat blandit aliquam. Tortor at auctor urna nunc. Lectus quam id leo in vitae turpis massa. Viverra nibh cras pulvinar mattis nunc sed. Netus et malesuada fames ac turpis egestas sed tempus. Amet mauris commodo quis imperdiet massa tincidunt nunc. Ipsum consequat nisl vel pretium lectus quam. Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Ultrices tincidunt arcu non sodales neque sodales ut etiam sit. Posuere lorem ipsum dolor sit amet. Diam quam nulla porttitor massa.
+
+### Subtitle
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque elit eget gravida cum sociis. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper. Blandit aliquam etiam erat velit scelerisque in dictum. Lectus arcu bibendum at varius vel pharetra. Massa placerat duis ultricies lacus sed turpis tincidunt id aliquet. Netus et malesuada fames ac. Pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus. Aenean sed adipiscing diam donec adipiscing. A arcu cursus vitae congue mauris rhoncus. Vel facilisis volutpat est velit egestas dui id. Ultrices in iaculis nunc sed. Dui accumsan sit amet nulla.
+
+### Subtitle 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque elit eget gravida cum sociis. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper. Blandit aliquam etiam erat velit scelerisque in dictum. Lectus arcu bibendum at varius vel pharetra. Massa placerat duis ultricies lacus sed turpis tincidunt id aliquet. Netus et malesuada fames ac. Pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus. Aenean sed adipiscing diam donec adipiscing. A arcu cursus vitae congue mauris rhoncus. Vel facilisis volutpat est velit egestas dui id. Ultrices in iaculis nunc sed. Dui accumsan sit amet nulla.
+
+Sit amet tellus cras adipiscing enim eu turpis egestas. Varius morbi enim nunc faucibus a pellentesque sit amet porttitor. Et molestie ac feugiat sed lectus. Sodales ut eu sem integer vitae. Aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi. Nunc sed id semper risus in hendrerit gravida. Tincidunt dui ut ornare lectus. Lacus vel facilisis volutpat est velit egestas dui id ornare. Nisi est sit amet facilisis. Tempor orci dapibus ultrices in iaculis nunc. Aliquam eleifend mi in nulla posuere. At varius vel pharetra vel turpis nunc. Quis blandit turpis cursus in hac habitasse platea. Ultrices tincidunt arcu non sodales neque sodales. Nec nam aliquam sem et tortor. Tincidunt arcu non sodales neque.
+
+## Title 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque elit eget gravida cum sociis. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper. Blandit aliquam etiam erat velit scelerisque in dictum. Lectus arcu bibendum at varius vel pharetra. Massa placerat duis ultricies lacus sed turpis tincidunt id aliquet. Netus et malesuada fames ac. Pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus. Aenean sed adipiscing diam donec adipiscing. A arcu cursus vitae congue mauris rhoncus. Vel facilisis volutpat est velit egestas dui id. Ultrices in iaculis nunc sed. Dui accumsan sit amet nulla.
+
+Sit amet tellus cras adipiscing enim eu turpis egestas. Varius morbi enim nunc faucibus a pellentesque sit amet porttitor. Et molestie ac feugiat sed lectus. Sodales ut eu sem integer vitae. Aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi. Nunc sed id semper risus in hendrerit gravida. Tincidunt dui ut ornare lectus. Lacus vel facilisis volutpat est velit egestas dui id ornare. Nisi est sit amet facilisis. Tempor orci dapibus ultrices in iaculis nunc. Aliquam eleifend mi in nulla posuere. At varius vel pharetra vel turpis nunc. Quis blandit turpis cursus in hac habitasse platea. Ultrices tincidunt arcu non sodales neque sodales. Nec nam aliquam sem et tortor. Tincidunt arcu non sodales neque.
+
+Enim blandit volutpat maecenas volutpat blandit aliquam. Tortor at auctor urna nunc. Lectus quam id leo in vitae turpis massa. Viverra nibh cras pulvinar mattis nunc sed. Netus et malesuada fames ac turpis egestas sed tempus. Amet mauris commodo quis imperdiet massa tincidunt nunc. Ipsum consequat nisl vel pretium lectus quam. Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Ultrices tincidunt arcu non sodales neque sodales ut etiam sit. Posuere lorem ipsum dolor sit amet. Diam quam nulla porttitor massa.
+
+## Title 3
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque elit eget gravida cum sociis. Posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper. Blandit aliquam etiam erat velit scelerisque in dictum. Lectus arcu bibendum at varius vel pharetra. Massa placerat duis ultricies lacus sed turpis tincidunt id aliquet. Netus et malesuada fames ac. Pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus. Aenean sed adipiscing diam donec adipiscing. A arcu cursus vitae congue mauris rhoncus. Vel facilisis volutpat est velit egestas dui id. Ultrices in iaculis nunc sed. Dui accumsan sit amet nulla.
+
+Sit amet tellus cras adipiscing enim eu turpis egestas. Varius morbi enim nunc faucibus a pellentesque sit amet porttitor. Et molestie ac feugiat sed lectus. Sodales ut eu sem integer vitae. Aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi. Nunc sed id semper risus in hendrerit gravida. Tincidunt dui ut ornare lectus. Lacus vel facilisis volutpat est velit egestas dui id ornare. Nisi est sit amet facilisis. Tempor orci dapibus ultrices in iaculis nunc. Aliquam eleifend mi in nulla posuere. At varius vel pharetra vel turpis nunc. Quis blandit turpis cursus in hac habitasse platea. Ultrices tincidunt arcu non sodales neque sodales. Nec nam aliquam sem et tortor. Tincidunt arcu non sodales neque.

--- a/packages/lit-dev-content/site/articles/articles.json
+++ b/packages/lit-dev-content/site/articles/articles.json
@@ -1,0 +1,7 @@
+{
+  "defaultAuthor": ["lit-team"],
+  "collection": "articles-nav",
+  "tags": [
+    "articles-nav"
+  ]
+}

--- a/packages/lit-dev-content/site/articles/index.md
+++ b/packages/lit-dev-content/site/articles/index.md
@@ -1,0 +1,12 @@
+---
+layout: 'articles-feed'
+title: Articles
+tags:
+  - articles-nav
+eleventyNavigation:
+  key: Tags
+  order: 0
+---
+
+<!-- This file exists only to create a section heading.
+     Its output is deleted by the Eleventy build process. -->

--- a/packages/lit-dev-content/site/articles/tags/composition.md
+++ b/packages/lit-dev-content/site/articles/tags/composition.md
@@ -1,0 +1,10 @@
+---
+title: Composition
+childrenTag: composition
+eleventyNavigation:
+  parent: Tags
+  key: Composition
+  order: 2
+---
+
+<!-- This is an example tag for composition to show how to set up a tag. -->

--- a/packages/lit-dev-content/site/articles/tags/tags.json
+++ b/packages/lit-dev-content/site/articles/tags/tags.json
@@ -1,0 +1,4 @@
+{
+  "layout": "articles-feed",
+  "isTagPage": true
+}

--- a/packages/lit-dev-content/site/css/articles.css
+++ b/packages/lit-dev-content/site/css/articles.css
@@ -1,57 +1,15 @@
 main {
-  /* Colors */
-  --docs-h1-underline-color: var(--color-blue);
-  --docs-h2-color: #384861;
-  --docs-h3-color: #5d6c86;
-  --docs-rule-color: #d1d1d1;
-  --docs-table-header-background: #e4e4e4;
-  --docs-table-header-color: rgb(73, 73, 73);
-  --docs-link-color: #005cc5;
-  --docs-nav-color: #242424;
-  --docs-background-color: white;
-  --playground-code-background: var(--color-light-gray);
-  --code-border: 1px solid #ddd;
-
-  /* IMPORTANT: If any of the following variables change, one or both of the
-    @media query thresholds below need to be updated. */
-  --docs-nav-min-width: 14em;
-  --docs-nav-max-width: 1fr;
-  --docs-toc-min-width: 5em;
-  --docs-article-min-width: 30em;
-  --docs-article-max-width: 49em;
-  --docs-article-margin-horizontal: 3em;
-  --docs-margin-top: 32px;
-
-  --chips-background-color: rgba(0, 0, 0, .12);
-  --chips-background-color-hover: rgba(0, 0, 0, .18);
-  --chips-background-color-press: rgba(0, 0, 0, .24);
-  --chips-content-color: rgba(0, 0, 0, .87);
-
-  display: grid;
-  grid-template-columns:
-    minmax(var(--docs-nav-min-width), var(--docs-nav-max-width)) minmax(0, var(--docs-article-max-width)) 1fr;
-  max-width: none;
-  border-bottom: 1px solid var(--color-blue);
-
-  /* Open Sans is more readable than Manrope, so we prefer it for content that
-    users will spend a lot of time reading. */
-  font-family: "Open Sans", sans-serif;
-
   background: var(--docs-background-color);
-  padding-top: var(--docs-margin-top);
-}
-
-@media (max-width: 864px) {
-  main {
-    display: block;
-    padding-top: 0;
-  }
 }
 
 #articleWrapper>article {
   box-shadow: none;
   padding-block-start: 0;
 }
+
+/* ------------------------------------
+ * Header Section
+ * ------------------------------------ */
 
 .articleHeader {
   margin-block-end: 1.3rem;

--- a/packages/lit-dev-content/site/css/articles.css
+++ b/packages/lit-dev-content/site/css/articles.css
@@ -1,0 +1,298 @@
+main {
+  /* Colors */
+  --docs-h1-underline-color: var(--color-blue);
+  --docs-h2-color: #384861;
+  --docs-h3-color: #5d6c86;
+  --docs-rule-color: #d1d1d1;
+  --docs-table-header-background: #e4e4e4;
+  --docs-table-header-color: rgb(73, 73, 73);
+  --docs-link-color: #005cc5;
+  --docs-nav-color: #242424;
+  --docs-background-color: white;
+  --playground-code-background: var(--color-light-gray);
+  --code-border: 1px solid #ddd;
+
+  /* IMPORTANT: If any of the following variables change, one or both of the
+    @media query thresholds below need to be updated. */
+  --docs-nav-min-width: 14em;
+  --docs-nav-max-width: 1fr;
+  --docs-toc-min-width: 5em;
+  --docs-article-min-width: 30em;
+  --docs-article-max-width: 49em;
+  --docs-article-margin-horizontal: 3em;
+  --docs-margin-top: 32px;
+
+  --chips-background-color: rgba(0, 0, 0, .12);
+  --chips-background-color-hover: rgba(0, 0, 0, .18);
+  --chips-background-color-press: rgba(0, 0, 0, .24);
+  --chips-content-color: rgba(0, 0, 0, .87);
+
+  display: grid;
+  grid-template-columns:
+    minmax(var(--docs-nav-min-width), var(--docs-nav-max-width)) minmax(0, var(--docs-article-max-width)) 1fr;
+  max-width: none;
+  border-bottom: 1px solid var(--color-blue);
+
+  /* Open Sans is more readable than Manrope, so we prefer it for content that
+    users will spend a lot of time reading. */
+  font-family: "Open Sans", sans-serif;
+
+  background: var(--docs-background-color);
+  padding-top: var(--docs-margin-top);
+}
+
+@media (max-width: 864px) {
+  main {
+    display: block;
+    padding-top: 0;
+  }
+}
+
+#articleWrapper>article {
+  box-shadow: none;
+  padding-block-start: 0;
+}
+
+.articleHeader {
+  margin-block-end: 1.3rem;
+  border-block-end: 1px solid var(--docs-rule-color);
+}
+
+.articleHeader>* {
+  margin-block: 1rem;
+}
+
+.articleHeader>*:first-child {
+  margin-block-start: 0;
+}
+
+.articleHeader>*:last-child {
+  margin-block-end: 0;
+}
+
+/* ------------------------------------
+ * Bottom Links
+ * ------------------------------------ */
+
+/* TODO(emarquez): remove once we launch articles nav */
+#prevAndNextLinks {
+  display: none;
+}
+
+
+#prevAndNextLinks a {
+  border: 1px solid var(--color-medium-gray);
+  border-radius: .5rem;
+  padding: 1rem;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+#prevAndNextLinks a :is(.direction, .title) {
+  align-self: start;
+}
+
+#prevAndNextLinks a:hover,
+#prevAndNextLinks a:focus {
+  border: 1px solid var(--color-blue);
+  color: var(--color-blue);
+}
+
+#prevAndNextLinks>span>a:focus> :is(.direction, .arrow) {
+  color: var(--color-blue);
+}
+
+#prevAndNextLinks>span>a:first-of-type {
+  margin-right: 0;
+}
+
+/* ------------------------------------
+ * Tags Feed
+ * ------------------------------------ */
+article {
+  font-size: 1rem;
+  font-family: 'Manrope', sans-serif;
+}
+
+.articleFeedList {
+  padding: 0;
+}
+
+.feedItem {
+  list-style-type: none;
+  border-block-start: 1.5px solid #ccc;
+}
+
+.feedItem:first-of-type {
+  border-block-start: none;
+}
+
+.feedItem a {
+  display: flex;
+  cursor: pointer;
+  text-decoration: none;
+  padding: 1.5rem 0;
+  color: inherit;
+}
+
+.feedItem a:hover {
+  text-decoration: none;
+}
+
+.feedItem a .date {
+  color: #666;
+  font-size: 1em;
+  flex-basis: 180px;
+}
+
+.feedItem a .title {
+  font-size: 1.5rem;
+  color: #0043c0;
+  margin-block-start: 0
+}
+
+.feedItem a:hover .title {
+  text-decoration: underline;
+}
+
+.feedItem .date {
+  margin: 0;
+}
+
+/* ------------------------------------
+ * Authors
+ * ------------------------------------ */
+#content :is(.title, .date, .authors) {
+  font-weight: 500;
+}
+
+#content a .authors {
+  color: #555;
+}
+
+#content .authors {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#content .author {
+  display: flex;
+  align-items: center;
+  padding-inline-end: 32px;
+}
+
+#content .author img {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  margin-inline-end: 1rem;
+}
+
+#content .author .links {
+  display: flex;
+  align-items: center;
+}
+
+#content .author .links a {
+  display: flex;
+  margin-inline: .25rem;
+  color: #6f6f6f;
+}
+
+#content .author .links a:hover,
+#content .author .links a:focus,
+#content .author .links a:active {
+  text-decoration: none;
+  margin-inline: .25rem;
+  color: var(--color-blue);
+}
+
+#content .author .links a svg {
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+#content .author .links a:first-of-type,
+.articleHeader .tags a:first-of-type {
+  margin-inline-start: 0;
+}
+
+#content .author .links a:last-of-type,
+.articleHeader .tags a:last-of-type {
+  margin-inline-end: 0;
+}
+
+/* ------------------------------------
+ * article dates
+ * ------------------------------------ */
+
+#content .articleHeader .date {
+  color: var(--color-medium-gray);
+  font-weight: 600;
+}
+
+/* ------------------------------------
+  * article tags
+  * ------------------------------------ */
+
+.articleHeader .tags {
+  display: flex;
+  /* TODO(emarquez): remove once we launch tags */
+  display: none;
+}
+
+.articleHeader .tags a {
+  --_height: 32px;
+  display: block;
+  background-color: var(--chips-background-color);
+  color: var(--chips-content-color);
+  padding-inline: 12px;
+  font-size: 14px;
+  height: var(--_height);
+  border-radius: calc(var(--_height) / 2);
+  cursor: pointer;
+  margin-inline: .25rem;
+  text-decoration: none;
+}
+
+.articleHeader .tags a:hover,
+.articleHeader .tags a:focus {
+  background-color: var(--chips-background-color-hover);
+}
+
+.articleHeader .tags a:active {
+  background-color: var(--chips-background-color-press);
+}
+
+/* ------------------------------------
+ * inline toc
+ * ------------------------------------ */
+
+.articleHeader #inlineToc details {
+  margin-block-end: 0;
+}
+
+/* ------------------------------------
+ * Left Nav
+ * ------------------------------------ */
+
+/* TODO(emarquez): remove once we launch articles nav */
+#docsNav {
+  display: none;
+}
+
+/* TODO(emarquez): remove once we launch articles nav */
+@media (max-width: 1332px) {
+  main {
+    /* Remove grid */
+    display: block;
+  }
+
+  #docsNavWrapper {
+    display: none;
+  }
+
+  article {
+    margin: auto;
+  }
+}


### PR DESCRIPTION
This is a PR in a chain:

| PR 1 | PR 2 | PR 3 |
| -- | -- | --|
| #901 | #900 | This one |
| Move Authors | Filters & Styles | Articles implementation |

This PR implements the following views:

- articles
  - article-nav
  - article-feed
  - article

It also implements a LHS article navigation, and article tag view, but they are currently hidden and not click-navigable until the team decides when or if we will show them to users. (Marked in CSS with TODO comments)

## Good URLs to test

- All articles feed
  - https://pr891-33b4c5d---lit-dev-5ftespv5na-uc.a.run.app/articles/
- tag feed (for now will look the same as all articles feed)
  - https://pr891-33b4c5d---lit-dev-5ftespv5na-uc.a.run.app/articles/tags/composition/
- article view
  - https://pr891-33b4c5d---lit-dev-5ftespv5na-uc.a.run.app/articles/light-dom/