### PR TITLE
Add + Rename filters & update styles

### DIFF
--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -163,6 +163,12 @@ ${content}
     return url.substring(0, url.length - extension.length);
   });
 
+  // used for debugging and printing out data in the console
+  eleventyConfig.addFilter('debug', function (value) {
+    console.log(value);
+    return value;
+  });
+
   const sortDocs = (a, b) => {
     if (a.fileSlug == 'docs') {
       return -1;
@@ -176,12 +182,12 @@ ${content}
     return 0;
   };
 
-  const docsByUrl = new Map();
+  const documentByUrl = new Map();
 
   eleventyConfig.addCollection('docs-v1', function (collection) {
     const docs = collection.getFilteredByGlob('site/docs/v1/**').sort(sortDocs);
     for (const page of docs) {
-      docsByUrl.set(page.url, page);
+      documentByUrl.set(page.url, page);
     }
     return docs;
   });
@@ -191,7 +197,26 @@ ${content}
       .getFilteredByGlob(['site/docs/*', 'site/docs/!(v1)/**'])
       .sort(sortDocs);
     for (const page of docs) {
-      docsByUrl.set(page.url, page);
+      documentByUrl.set(page.url, page);
+    }
+    return docs;
+  });
+
+  const sortArticles = (a, b) => {
+    const aDate = new Date(a.data.lastUpdated ?? a.data.publishDate);
+    const bDate = new Date(b.data.lastUpdated ?? b.data.publishDate);
+    // note this is reversed because we want the most recent articles first
+    return bDate - aDate;
+  };
+
+  eleventyConfig.addCollection('article', function (collection) {
+    // get the articles and sort them by date. This sort is only used on the
+    // article-feed views
+    const docs = collection
+      .getFilteredByGlob('site/articles/article/**')
+      .sort(sortArticles);
+    for (const page of docs) {
+      documentByUrl.set(page.url, page);
     }
     return docs;
   });
@@ -245,10 +270,10 @@ ${content}
   });
 
   /**
-   * Gets the title given a docs URL.
+   * Gets the title given a document URL.
    */
-  eleventyConfig.addFilter('docsUrlTitle', (url) => {
-    return docsByUrl.get(url)?.data?.title;
+  eleventyConfig.addFilter('documentUrlTitle', (url) => {
+    return documentByUrl.get(url)?.data?.title;
   });
 
   /**

--- a/packages/lit-dev-content/site/_includes/docs.html
+++ b/packages/lit-dev-content/site/_includes/docs.html
@@ -78,7 +78,7 @@
                     <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
                   </svg>
                   <span class="direction">Previous</span>
-                  <span class="title">{{ prev.url | docsUrlTitle }}</span>
+                  <span class="title">{{ prev.url | documentUrlTitle }}</span>
                 </a>
               {% endif %}
             </span>
@@ -87,7 +87,7 @@
               {% if next %}
                 <a id="nextLink" href="{{ next.url }}">
                   <span class="direction">Next</span>
-                  <span class="title">{{ next.url | docsUrlTitle }}</span>
+                  <span class="title">{{ next.url | documentUrlTitle }}</span>
                   <!-- Source: https://material.io/resources/icons/?icon=arrow_forward -->
                   <svg class="arrow" width="24" height="24" viewBox="0 0 24 24" fill="currentcolor">
                     <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />

--- a/packages/lit-dev-content/site/_includes/header.html
+++ b/packages/lit-dev-content/site/_includes/header.html
@@ -1,4 +1,4 @@
-<header>
+<header class="pageHeader">
   <nav>
     <a id="homeLink" href="{{ site.baseurl }}/" aria-label="Home">
       <img id="headerLogo" class="black" src="{{ site.baseurl }}/images/logo.svg" alt="Lit Home" width="425" height="200" />

--- a/packages/lit-dev-content/site/css/docs.css
+++ b/packages/lit-dev-content/site/css/docs.css
@@ -544,11 +544,26 @@ table.directory tr.subheading {
 }
 
 #inlineToc ol {
-  list-style: disc;
+  list-style: none;
+}
+
+/* Top level sections */
+#inlineToc div > ol > li > a {
+  font-weight: bold;
 }
 
 #inlineToc a {
   color: inherit;
+  color: var(--docs-link-color);
+  display: flex;
+}
+
+/* Set mobile touch target */
+@media(pointer: coarse) {
+  #inlineToc a {
+    min-height: 48px;
+    align-items: center;
+  }
 }
 
 /* ------------------------------------

--- a/packages/lit-dev-content/site/css/header.css
+++ b/packages/lit-dev-content/site/css/header.css
@@ -1,4 +1,4 @@
-header {
+.pageHeader {
   position: sticky;
   top: 0;
   height: var(--header-nav-height);
@@ -19,7 +19,7 @@ header {
   padding: 0.1em 0.5em;
 }
 
-header > nav {
+.pageHeader > nav {
   flex: 1;
   display: flex;
   justify-content: space-between;
@@ -79,7 +79,7 @@ header > nav {
     display: flex;
   }
 
-  header {
+  .pageHeader {
     padding: 0 0.5em;
   }
 }


### PR DESCRIPTION
This is a PR in a chain:

| PR 1 | PR 2 | PR 3 |
| -- | -- | --|
| #901 | This one | #891 |
| Move Authors | Filters & Styles | Articles implementation |

This PR:

- adds a `debug` 11ty filter that console.log 11ty data
- renames the `docsUrlTitle` filter to `documentUrlTitle`
  - in the next PR will be used in Docs and Articles
- Sets up the `articles` 11ty collection
- Adds a `pageHeader` class to the site header and updates relevant styles
  - The previous styles just styled `header` which clashes with some changes in the articles impl
- updates the styles of the inline table of contents (mobile / narrow view) in the docs and future articles sections

## Good URLs to test

- https://pr900-0f23ec3---lit-dev-5ftespv5na-uc.a.run.app/docs/components/properties/
  - make the window narrow and expand the inline table of contents