### PR TITLE
fix Clarity's url

### DIFF
--- a/packages/lit-dev-content/site/home/5-who-is-using.html
+++ b/packages/lit-dev-content/site/home/5-who-is-using.html
@@ -154,7 +154,7 @@
         </div>
       </a>
 
-      <a target="_blank" rel="noopener" href="https://clarity.design/storybook/core/?path=/docs/internal-documentation-imports-and-dependencies--page#:~:text=lit-element">
+      <a target="_blank" rel="noopener" href="https://core.clarity.design/">
         <lazy-svg
           svg-role="img"
           label="VMWare"

--- a/packages/lit-dev-tests/known-good-urls.txt
+++ b/packages/lit-dev-tests/known-good-urls.txt
@@ -5,7 +5,7 @@ https://twitter.com/buildWithLit
 https://shoelace.style/#:~:text=LitElement
 https://stackoverflow.com/questions/tagged/lit+or+lit-html+or+lit-element
 https://spdx.org/licenses/BSD-3-Clause.html
-https://clarity.design/storybook/core/?path=/docs/internal-documentation-imports-and-dependencies--page#:~:text=lit-element
+https://core.clarity.design/
 https://auro.alaskaair.com/#:~:text=Using%20LitElement%20as%20a%20base
 https://spdx.org/licenses/CC-BY-3.0
 https://www.npmjs.com/package/lit


### PR DESCRIPTION
[https://clarity.design/storybook/core/?path=/docs/internal-documentation-imports-and-dependencies--page#:~:text=lit-element](https://clarity.design/storybook/core/?path=/docs/internal-documentation-imports-and-dependencies--page#:~:text=lit-element) is 404. [Clarity](https://github.com/vmware/clarity) was divided into Clarity Angular and Clarity Core. Clarity Core uses Lit. Therefore, This changed to Clarity Core's url.