### PR TITLE
Add articles to site search

### DIFF
--- a/packages/lit-dev-content/site/_includes/articles.html
+++ b/packages/lit-dev-content/site/_includes/articles.html
@@ -39,8 +39,8 @@
 
   <div id="articleWrapper">
     <article id="content">
+      <h1>{{ title }}</h1>
       <header class="articleHeader">
-        <h1>{{ title }}</h1>
         {% block articleHeader %}{% endblock %}
         {% if toc | tocHasEntries %}
           <nav id="inlineToc">

--- a/packages/lit-dev-content/site/css/articles.css
+++ b/packages/lit-dev-content/site/css/articles.css
@@ -11,6 +11,11 @@ main {
  * Header Section
  * ------------------------------------ */
 
+ article h1 {
+  margin-block: 1rem;
+  margin-block-start: 0;
+ }
+
 .articleHeader {
   margin-block-end: 1.3rem;
   border-block-end: 1px solid var(--docs-rule-color);

--- a/packages/lit-dev-tools-cjs/src/search/PageSearchChunker.spec.ts
+++ b/packages/lit-dev-tools-cjs/src/search/PageSearchChunker.spec.ts
@@ -17,6 +17,30 @@ const h2 = (text: string, fragment: string) => `<div class="heading h2">
 
 const INLINE_TOC = `<nav id="inlineToc"></nav>`;
 
+const ARTICLE_HEADER = `<h1>What is Lit?</h1>
+<header class="articleHeader">
+  <div class="date">some time</div>
+  <div class="tags"><a href="asdf">Some tag</a></div>
+  <div class="authors"><figure>A figure of an author</figure></div>
+  ${INLINE_TOC}
+</header>`;
+
+const ARTICLE_CONTENTS = `${ARTICLE_HEADER}
+<p>
+  <img src="/images/logo.svg" alt="Lit Logo" class="logo" width="425" height="200">
+</p>
+<p>
+  Lit is a simple library for building fast, lightweight web components.
+</p>
+<p>
+  At Lit's core is a boilerplate-killing component base class that...
+</p>
+<p>
+  Naïve test.
+</p>
+${h2('What can I build with Lit?', 'what-can-i-build-with-lit')}
+`;
+
 const DOC_CONTENTS = `<h1>What is Lit?</h1>
   ${INLINE_TOC}
 <p>
@@ -128,6 +152,24 @@ const ARTICLE_CHANGED_ID_PAGE = `<!DOCTYPE html>
 
 test('chunk simple docs page', () => {
   const page = new PageSearchChunker(simplePageLayout(DOC_CONTENTS));
+  assert.equal(page.pageSearchChunks(), [
+    {
+      title: 'What is Lit? – Lit',
+      heading: 'What is Lit?',
+      fragment: '',
+      text: 'Lit is a simple library for building fast lightweight web components At Lits core is a boilerplatekilling component base class that Naïve test',
+    },
+    {
+      title: 'What is Lit? – Lit',
+      heading: 'What can I build with Lit?',
+      fragment: '#what-can-i-build-with-lit',
+      text: '',
+    },
+  ]);
+});
+
+test('chunk simple article page', () => {
+  const page = new PageSearchChunker(simplePageLayout(ARTICLE_CONTENTS));
   assert.equal(page.pageSearchChunks(), [
     {
       title: 'What is Lit? – Lit',

--- a/packages/lit-dev-tools-cjs/src/search/PageSearchChunker.ts
+++ b/packages/lit-dev-tools-cjs/src/search/PageSearchChunker.ts
@@ -105,14 +105,10 @@ export class PageSearchChunker {
         `Expect every lit.dev page to have an article#content element.`
       );
     }
-    const toc = article.querySelector('nav#inlineToc');
-    if (toc) {
-      toc.remove();
-    }
-    const articleHeaderSections = article.querySelectorAll(
-      'header.articleHeader .date, header.tags .date, header.articleHeader .authors'
+    const removedSections = article.querySelectorAll(
+      'nav#inlineToc, header.articleHeader'
     );
-    [...articleHeaderSections].forEach((section) => section.remove());
+    [...removedSections].forEach((section) => section.remove());
     return article;
   }
 
@@ -191,7 +187,7 @@ export class PageSearchChunker {
         reducedPageChunks.push(maybeNewPageChunk);
       } else {
         const lastChunk = reducedPageChunks[reducedPageChunks.length - 1];
-        if (lastChunk !== null && lastChunk !== undefined) {
+        if (lastChunk !== null) {
           lastChunk.nodeCollection.appendChild(childNode);
         }
       }

--- a/packages/lit-dev-tools-cjs/src/search/PageSearchChunker.ts
+++ b/packages/lit-dev-tools-cjs/src/search/PageSearchChunker.ts
@@ -109,6 +109,10 @@ export class PageSearchChunker {
     if (toc) {
       toc.remove();
     }
+    const articleHeaderSections = article.querySelectorAll(
+      'header.articleHeader .date, header.tags .date, header.articleHeader .authors'
+    );
+    [...articleHeaderSections].forEach((section) => section.remove());
     return article;
   }
 
@@ -187,7 +191,7 @@ export class PageSearchChunker {
         reducedPageChunks.push(maybeNewPageChunk);
       } else {
         const lastChunk = reducedPageChunks[reducedPageChunks.length - 1];
-        if (lastChunk !== null) {
+        if (lastChunk !== null && lastChunk !== undefined) {
           lastChunk.nodeCollection.appendChild(childNode);
         }
       }

--- a/packages/lit-dev-tools-cjs/src/search/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/search/plugin.ts
@@ -41,6 +41,16 @@ export async function createSearchIndex(outputDir: '_dev' | '_site') {
   );
   const relativeDocUrlsToHtmlFile: UrlToFile = walkDir(DOCS_PATH, new Map());
 
+  const ARTICLES_PATH = path.resolve(
+    __dirname,
+    // Load the article content itself not the tags pages.
+    `../../../lit-dev-content/${outputDir}/articles/article`
+  );
+  const relativeLinksToHTMLFile: UrlToFile = walkDir(
+    ARTICLES_PATH,
+    relativeDocUrlsToHtmlFile
+  );
+
   /**
    * NOTE: The minisearch options must exactly match when we create the search
    * index on the client. Any changes here must be reflected in the
@@ -58,7 +68,7 @@ export async function createSearchIndex(outputDir: '_dev' | '_site') {
   });
 
   let id = 0;
-  for (const [relUrl, filePath] of relativeDocUrlsToHtmlFile.entries()) {
+  for (const [relUrl, filePath] of relativeLinksToHTMLFile.entries()) {
     if (filePath.includes('/internal/')) {
       // Skip internal pages.
       continue;

--- a/packages/lit-dev-tools-cjs/src/search/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/search/plugin.ts
@@ -130,7 +130,7 @@ function walkDir(dir: string, results: UrlToFile): UrlToFile {
   const dirContents = fs.readdirSync(dir);
   for (const contents of dirContents) {
     if (path.extname(contents) === '.html') {
-      const relPathBase = dir.match(/\/docs.*/)?.[0];
+      const relPathBase = dir.match(/(\/docs.*)|(\/articles\/article.*)/)?.[0];
       if (!relPathBase) {
         throw new Error(`Failed to match relative path.`);
       }

--- a/packages/lit-dev-tools-cjs/src/search/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/search/plugin.ts
@@ -48,7 +48,7 @@ export async function createSearchIndex(outputDir: '_dev' | '_site') {
   );
 
   const skipFiles = (filepath: string) => {
-    // These pages have are tag feeds and are not structured in a way the
+    // These pages are tag feeds and are not structured in a way the
     // search indexer can understand.
     const badPathParts = [
       ['articles', 'tags'],


### PR DESCRIPTION
Fixes #912

Add articles to site search:

Since there are tags pages and because we wanted the articles URLs to be in `/articles/...` rather than `/articles/article/...`, I had to add a feature to the site crawler that skips indexing those pages.

I also had to move the `<h1>` out of the article header because the indexer was not associating the following content with the h1