### PR TITLE
Update slack invite link to "never-expring" link

### DIFF
--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -5,7 +5,7 @@
  */
 
 export const pageRedirects = new Map([
-  ['/slack-invite',                   'https://join.slack.com/t/lit-and-friends/shared_invite/zt-1d6e48e3m-vHSdNti_uGiCJcDcoLYitw'],
+  ['/slack-invite',                   'https://join.slack.com/t/lit-and-friends/shared_invite/zt-1etplu7f6-h1I1D0S16VMOluYyZ_2JUQ'],
   ['/youtube',                        'https://www.youtube.com/channel/UCok4ZKSzM3jY7JQRMlF-DPg'],
   ['/msg/dev-mode',                   '/docs/tools/development/#development-and-production-builds'],
   // TODO(sorvell) https://github.com/lit/lit.dev/issues/455


### PR DESCRIPTION
Slack says this link supposedly never expires but I don't believe it because it always does