### PR TITLE
Update getting-started.md

### DIFF
--- a/packages/lit-dev-content/site/docs/getting-started.md
+++ b/packages/lit-dev-content/site/docs/getting-started.md
@@ -51,7 +51,11 @@ Lit is also available as pre-built, single-file bundles. These are provided for
 more flexibility around development workflows: for example, if you would prefer
 to download a single file rather than use npm and build tools. The bundles are
 standard JavaScript modules with no dependencies - any modern browser should be
-able to import and run the bundles from within a `<script type="module">`.
+able to import and run the bundles from within a `<script type="module">` like this:
+
+```js
+import {LitElement, html} from 'https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js';
+```
 
 <div class="alert alert-warning">
 


### PR DESCRIPTION
Exactly *how* to directly import (without a build step) is not at all clear in this documentation, a serious hindrance to developers wanting as easy as possible a way to test the waters.  Proposing this explicit line to make things much clearer, since the remaining documentation here all assumes you'll do a build step.