### PR TITLE
Warn on exiting the playground w/ unsaved changes

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-playground-page.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-page.ts
@@ -33,6 +33,8 @@ import type {LitDevDrawer} from './litdev-drawer.js';
 import type {LitDevExampleControls} from './litdev-example-controls.js';
 import type {PlaygroundProject} from 'playground-elements/playground-project.js';
 import type {PlaygroundPreview} from 'playground-elements/playground-preview.js';
+import type {PlaygroundFileEditor} from 'playground-elements/playground-file-editor.js';
+import type {PlaygroundCodeEditor} from 'playground-elements/playground-code-editor.js';
 
 interface CompactProjectFile {
   name: string;
@@ -56,11 +58,14 @@ export class LitDevPlaygroundPage extends LitElement {
 
   private _playgroundProject!: PlaygroundProject;
   private _playgroundPreview!: PlaygroundPreview;
+  private _fileEditor!: PlaygroundFileEditor;
+  private _codeEditor!: PlaygroundCodeEditor;
   private _shareButton!: LitDevPlaygroundShareButton;
   private _downloadButton!: LitDevPlaygroundDownloadButton;
   private _examplesDrawer!: LitDevDrawer;
   private _examplesDrawerScroller!: HTMLElement;
   private _exampleControls!: LitDevExampleControls;
+  private _hasUnsavedChanges = false;
 
   /**
    * Base URL for the GitHub API.
@@ -68,21 +73,73 @@ export class LitDevPlaygroundPage extends LitElement {
   @property()
   githubApiUrl!: string;
 
-  connectedCallback() {
+  async connectedCallback() {
     super.connectedCallback();
     this._checkRequiredParameters();
-    this._discoverChildElements();
+    await this._discoverChildElements();
     this._activateChildElements();
     this._syncStateFromUrlHash();
     window.addEventListener('hashchange', () => this._syncStateFromUrlHash());
     window.addEventListener(CODE_LANGUAGE_CHANGE, () =>
       this._syncStateFromUrlHash()
     );
+    this._codeEditor.addEventListener('change', this._onCodeEditorChange);
+    this._shareButton.addEventListener('save', this._onSaveEvent);
+    window.addEventListener('beforeunload', this._beforeUnload);
   }
 
   render() {
     return html`<slot></slot>`;
   }
+
+  /**
+   * When the code editor is changed, store that there are unsaved changes.
+   */
+  private _onCodeEditorChange = () => {
+    this._hasUnsavedChanges = true;
+  };
+
+  /**
+   * When the user saves, reset the unsaved changes flag.
+   */
+  private _onSaveEvent = () => {
+    this._hasUnsavedChanges = false;
+  };
+
+  /**
+   * Shows a confirmation dialog if the user has unsaved changes and is using a
+   * Gist or has not saved at all.
+   *
+   * If the user has already saved with longurl, then just save again and push
+   * the new URL to the browser history.
+   */
+  private _beforeUnload = (e: BeforeUnloadEvent): string | void => {
+    // Deterime whien to show unsaved changes dialog.
+    if (this._hasUnsavedChanges) {
+      // We want to show a confirmation dialog if the user has saved via Gist
+      // because we don't want to deal with beforeUnload and a fetch to github
+      // possibly failing. We also want to show a confirmation dialog if the
+      // user has changes but not consented to saving anything to url or gist.
+      if (
+        this._shareButton.mostRecentSaveType === 'gist' ||
+        this._shareButton.mostRecentSaveType === undefined
+      ) {
+        // Show a confirmations popup before exit. The method seems to be
+        // different per browser.
+        (e || window.event).returnValue = 'non-void value';
+        e.preventDefault();
+        return 'non-void value';
+      }
+
+      // If there are changes, but the user has already consented to save via
+      // longurl, then just push the new URL to the browser history.
+      if (this._shareButton.mostRecentSaveType === 'longurl') {
+        this._shareButton.longUrlSave({skipClipboard: true});
+      }
+    }
+
+    // If there are no unsaved changes, then don't show the dialog or save URL.
+  };
 
   private _checkRequiredParameters() {
     if (!this.githubApiUrl) {
@@ -90,7 +147,7 @@ export class LitDevPlaygroundPage extends LitElement {
     }
   }
 
-  private _discoverChildElements() {
+  private async _discoverChildElements() {
     // TODO(aomarks) This is very unconventional. We should be rendering these
     // elements ourselves, or slotting them in with names.
     const mustFindChild: typeof this['querySelector'] = (
@@ -104,12 +161,19 @@ export class LitDevPlaygroundPage extends LitElement {
     };
     this._playgroundProject = mustFindChild('playground-project')!;
     this._playgroundPreview = mustFindChild('playground-preview')!;
+    this._fileEditor = mustFindChild('playground-file-editor')!;
     this._shareButton = mustFindChild('litdev-playground-share-button')!;
     this._downloadButton = mustFindChild('litdev-playground-download-button')!;
     this._examplesDrawer = mustFindChild('litdev-drawer')!;
     this._exampleControls = mustFindChild('litdev-example-controls')!;
     this._examplesDrawerScroller = mustFindChild(
       'litdev-drawer .minimalScroller'
+    )!;
+    // Unforuntately, the file editor does not emit a change event, so we reach
+    // into the shadow root and find the code editor that does.
+    await this._fileEditor.updateComplete;
+    this._codeEditor = this._fileEditor.shadowRoot?.querySelector(
+      'playground-code-editor'
     )!;
   }
 

--- a/packages/lit-dev-content/src/components/litdev-playground-page.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-page.ts
@@ -111,7 +111,7 @@ export class LitDevPlaygroundPage extends LitElement {
    */
   private _beforeUnload = (e: BeforeUnloadEvent): string | void => {
     if (this._hasUnsavedChanges) {
-      // Show a confirmations popup before exit. The method seems to be
+      // Show a confirmation popup before exit. The method seems to be
       // different per browser.
       (e || window.event).returnValue = 'non-void value';
       e.preventDefault();

--- a/packages/lit-dev-content/src/components/litdev-playground-page.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-page.ts
@@ -83,7 +83,7 @@ export class LitDevPlaygroundPage extends LitElement {
     window.addEventListener(CODE_LANGUAGE_CHANGE, () =>
       this._syncStateFromUrlHash()
     );
-    this._codeEditor.addEventListener('change', this._onCodeEditorChange);
+    this._codeEditor.addEventListener('change', this._onEditorChange);
     this._shareButton.addEventListener('save', this._onSaveEvent);
     window.addEventListener('beforeunload', this._beforeUnload);
   }
@@ -95,7 +95,7 @@ export class LitDevPlaygroundPage extends LitElement {
   /**
    * When the code editor is changed, store that there are unsaved changes.
    */
-  private _onCodeEditorChange = () => {
+  private _onEditorChange = () => {
     this._hasUnsavedChanges = true;
   };
 
@@ -107,38 +107,18 @@ export class LitDevPlaygroundPage extends LitElement {
   };
 
   /**
-   * Shows a confirmation dialog if the user has unsaved changes and is using a
-   * Gist or has not saved at all.
-   *
-   * If the user has already saved with longurl, then just save again and push
-   * the new URL to the browser history.
+   * Shows a confirmation dialog if the user has unsaved changes
    */
   private _beforeUnload = (e: BeforeUnloadEvent): string | void => {
-    // Deterime whien to show unsaved changes dialog.
     if (this._hasUnsavedChanges) {
-      // We want to show a confirmation dialog if the user has saved via Gist
-      // because we don't want to deal with beforeUnload and a fetch to github
-      // possibly failing. We also want to show a confirmation dialog if the
-      // user has changes but not consented to saving anything to url or gist.
-      if (
-        this._shareButton.mostRecentSaveType === 'gist' ||
-        this._shareButton.mostRecentSaveType === undefined
-      ) {
-        // Show a confirmations popup before exit. The method seems to be
-        // different per browser.
-        (e || window.event).returnValue = 'non-void value';
-        e.preventDefault();
-        return 'non-void value';
-      }
-
-      // If there are changes, but the user has already consented to save via
-      // longurl, then just push the new URL to the browser history.
-      if (this._shareButton.mostRecentSaveType === 'longurl') {
-        this._shareButton.longUrlSave({skipClipboard: true});
-      }
+      // Show a confirmations popup before exit. The method seems to be
+      // different per browser.
+      (e || window.event).returnValue = 'non-void value';
+      e.preventDefault();
+      return 'non-void value';
     }
 
-    // If there are no unsaved changes, then don't show the dialog or save URL.
+    // If there are no unsaved changes, then don't show the dialog.
   };
 
   private _checkRequiredParameters() {

--- a/packages/lit-dev-content/src/components/litdev-playground-page.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-page.ts
@@ -152,7 +152,7 @@ export class LitDevPlaygroundPage extends LitElement {
     // Unforuntately, the file editor does not emit a change event, so we reach
     // into the shadow root and find the code editor that does.
     await this._fileEditor.updateComplete;
-    this._codeEditor = this._fileEditor.shadowRoot?.querySelector(
+    this._codeEditor = this._fileEditor.shadowRoot!.querySelector(
       'playground-code-editor'
     )!;
   }

--- a/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
@@ -94,7 +94,7 @@ export class LitDevPlaygroundShareButton extends LitElement {
    * How the user most recently saved, or undefined if they haven't saved this
    * pageload.
    */
-  mostRecentSaveType: SaveMethod | undefined = undefined;
+  private _mostRecentSaveType: SaveMethod | undefined = undefined;
 
   /**
    * When true, clicking on this button will not open the flyout.
@@ -222,15 +222,16 @@ export class LitDevPlaygroundShareButton extends LitElement {
   }
 
   private _onLongUrlSaved() {
+    this._dispatchSaveEvent();
     this._close();
-    this.mostRecentSaveType = 'longurl';
+    this._mostRecentSaveType = 'longurl';
     this.activeGist = undefined;
   }
 
   private _onGistSaved() {
     this._dispatchSaveEvent();
     this._close();
-    this.mostRecentSaveType = 'gist';
+    this._mostRecentSaveType = 'gist';
   }
 
   private readonly _onWindowKeydown = (event: KeyboardEvent) => {
@@ -244,12 +245,12 @@ export class LitDevPlaygroundShareButton extends LitElement {
       !event.repeat
     ) {
       event.preventDefault(); // Don't trigger "Save page as"
-      if (this.mostRecentSaveType === 'longurl') {
+      if (this._mostRecentSaveType === 'longurl') {
         this._longUrl?.generateUrl();
         this._longUrl?.save();
         this._dispatchSaveEvent();
       } else if (
-        this.mostRecentSaveType === 'gist' &&
+        this._mostRecentSaveType === 'gist' &&
         this._gist?.canUpdateGist
       ) {
         this._gist?.updateGist();
@@ -261,21 +262,10 @@ export class LitDevPlaygroundShareButton extends LitElement {
   };
 
   /**
-   * Fires a 'save' event to denote that the project has been saved via
+   * Fires a 'save' event to denote that the project has been saved.
    */
   private _dispatchSaveEvent() {
     this.dispatchEvent(new Event('save', {bubbles: false}));
-  }
-
-  /**
-   * Force a save via the long URL method and pushes to history.
-   *
-   * @params options Options for the save, e.g. skip copy to clipboard.
-   */
-  async longUrlSave(options = {skipClipboard: false}) {
-    this._longUrl?.generateUrl();
-    await this._longUrl?.save(options);
-    this._dispatchSaveEvent();
   }
 }
 

--- a/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
@@ -20,9 +20,13 @@ import type {SampleFile} from 'playground-elements/shared/worker-api.js';
 import type {Snackbar} from '@material/mwc-snackbar';
 import type {Gist} from '../github/github-gists.js';
 
+export type SaveMethod = 'gist' | 'longurl';
+
 /**
  * The Playground "Share" button. Opens a menu with options for sharing as a
  * long base64 URL, or signing into GitHub and sharing as a Gist.
+ *
+ * @event save - Fired when the user performs a save action.
  */
 @customElement('litdev-playground-share-button')
 export class LitDevPlaygroundShareButton extends LitElement {
@@ -90,7 +94,7 @@ export class LitDevPlaygroundShareButton extends LitElement {
    * How the user most recently saved, or undefined if they haven't saved this
    * pageload.
    */
-  private _mostRecentSaveType: 'longurl' | 'gist' | undefined = undefined;
+  mostRecentSaveType: SaveMethod | undefined = undefined;
 
   /**
    * When true, clicking on this button will not open the flyout.
@@ -219,13 +223,14 @@ export class LitDevPlaygroundShareButton extends LitElement {
 
   private _onLongUrlSaved() {
     this._close();
-    this._mostRecentSaveType = 'longurl';
+    this.mostRecentSaveType = 'longurl';
     this.activeGist = undefined;
   }
 
   private _onGistSaved() {
+    this._dispatchSaveEvent();
     this._close();
-    this._mostRecentSaveType = 'gist';
+    this.mostRecentSaveType = 'gist';
   }
 
   private readonly _onWindowKeydown = (event: KeyboardEvent) => {
@@ -239,19 +244,39 @@ export class LitDevPlaygroundShareButton extends LitElement {
       !event.repeat
     ) {
       event.preventDefault(); // Don't trigger "Save page as"
-      if (this._mostRecentSaveType === 'longurl') {
+      if (this.mostRecentSaveType === 'longurl') {
         this._longUrl?.generateUrl();
         this._longUrl?.save();
+        this._dispatchSaveEvent();
       } else if (
-        this._mostRecentSaveType === 'gist' &&
+        this.mostRecentSaveType === 'gist' &&
         this._gist?.canUpdateGist
       ) {
         this._gist?.updateGist();
+        this._dispatchSaveEvent();
       } else {
         this._open = true;
       }
     }
   };
+
+  /**
+   * Fires a 'save' event to denote that the project has been saved via
+   */
+  private _dispatchSaveEvent() {
+    this.dispatchEvent(new Event('save', {bubbles: false}));
+  }
+
+  /**
+   * Force a save via the long URL method and pushes to history.
+   *
+   * @params options Options for the save, e.g. skip copy to clipboard.
+   */
+  async longUrlSave(options = {skipClipboard: false}) {
+    this._longUrl?.generateUrl();
+    await this._longUrl?.save(options);
+    this._dispatchSaveEvent();
+  }
 }
 
 declare global {

--- a/packages/lit-dev-content/src/components/litdev-playground-share-long-url.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-long-url.ts
@@ -86,14 +86,12 @@ export class LitDevPlaygroundShareLongUrl extends LitElement {
    *
    * @param options Options to skip saving to the clipboard.
    */
-  async save(options = {skipClipboard: false}) {
+  async save() {
     history.pushState({}, '', this._url);
     let statusText;
     try {
-      if (!options.skipClipboard) {
-        await navigator.clipboard.writeText(window.location.toString());
-        statusText = 'URL copied to clipboard';
-      }
+      await navigator.clipboard.writeText(window.location.toString());
+      statusText = 'URL copied to clipboard';
     } catch {
       // The browser isn't allowing us to copy. This could happen because it's
       // disabled in settings, or because we're in a browser like Safari that

--- a/packages/lit-dev-content/src/components/litdev-playground-share-long-url.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-long-url.ts
@@ -93,7 +93,7 @@ export class LitDevPlaygroundShareLongUrl extends LitElement {
       if (!options.skipClipboard) {
         await navigator.clipboard.writeText(window.location.toString());
         statusText = 'URL copied to clipboard';
-      };
+      }
     } catch {
       // The browser isn't allowing us to copy. This could happen because it's
       // disabled in settings, or because we're in a browser like Safari that

--- a/packages/lit-dev-content/src/components/litdev-playground-share-long-url.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-long-url.ts
@@ -80,12 +80,20 @@ export class LitDevPlaygroundShareLongUrl extends LitElement {
     `;
   }
 
-  async save() {
+  /**
+   * Pushes the current long url onto the history, attempts to save it to the
+   * clipboard, and notifies with the copied and status events.
+   *
+   * @param options Options to skip saving to the clipboard.
+   */
+  async save(options = {skipClipboard: false}) {
     history.pushState({}, '', this._url);
     let statusText;
     try {
-      await navigator.clipboard.writeText(window.location.toString());
-      statusText = 'URL copied to clipboard';
+      if (!options.skipClipboard) {
+        await navigator.clipboard.writeText(window.location.toString());
+        statusText = 'URL copied to clipboard';
+      };
     } catch {
       // The browser isn't allowing us to copy. This could happen because it's
       // disabled in settings, or because we're in a browser like Safari that


### PR DESCRIPTION
Summary of changes:

- litdev-playground-share-button
  - Dispatches a non-bubbling `save` event whenever a save is performed
- litdev-playground-page
  - looks into shadow root of `playground-file-editor` to get the `playground-code-editor` 🫣
    - needed to listen to the `change` event
  - keeps track whether there are unsaved changes
  - displays a dialog if there are unsaved changes
    
Try it out!

https://pr918-bc9a510---lit-dev-5ftespv5na-uc.a.run.app/playground/