### PR TITLE
Fix observers section in Lit 2.1 release blog post

### DIFF
--- a/packages/lit-dev-content/site/blog/2022-01-05-lit-2.1-release.md
+++ b/packages/lit-dev-content/site/blog/2022-01-05-lit-2.1-release.md
@@ -125,9 +125,11 @@ PerformanceObserver. The controllers automatically drive the host element's
 update lifecycle when they observe changes.
 
 ```ts
+import { ResizeController } from '@lit-labs/observers/resize_controller.js';
+
 class MyResizableElement extends LitElement {
 
-  _resizeController = new ResizeController(this);
+  _resizeController = new ResizeController(this, {});
 
   render() {
     return html`Current size is ${this.offsetWidth} x ${this.offsetHeight}`;

--- a/packages/lit-dev-content/site/blog/2022-01-05-lit-2.1-release.md
+++ b/packages/lit-dev-content/site/blog/2022-01-05-lit-2.1-release.md
@@ -116,9 +116,9 @@ alternative to the positional argument API.
 private _icon!: Array<HTMLElement>;
 ```
 
-## Easy to use observers with @lit-labs/observer
+## Easy to use observers with @lit-labs/observers
 
-In Lit Labs we've introduced a new package called `@lit-labs/observer` which
+In Lit Labs we've introduced a new package called `@lit-labs/observers` which
 contains reactive controllers that let you easily use the web platform observer
 APIs: MutationObserver, IntersectionObserver, ResizeObserver, and
 PerformanceObserver. The controllers automatically drive the host element's


### PR DESCRIPTION
Address two minor issues in the labs observers section in the Lit 2.1 blog post:

1. Address https://github.com/lit/lit/issues/2390 by adding a second empty object argument in the code sample. I also added the import so it's clear how to import the ResizeController.
2. Fix two cases where the package was called `observer` (singular) instead of the correct `observers` (plural).

