### PR TITLE
docs: anchor for renderable

### DIFF
--- a/packages/lit-dev-content/site/docs/components/rendering.md
+++ b/packages/lit-dev-content/site/docs/components/rendering.md
@@ -18,14 +18,7 @@ Write your template in HTML inside a JavaScript [tagged template literal](https:
 
 Lit templates can include JavaScript _expressions_. You can use expressions to set text content, attributes, properties, and event listeners. The `render()` method can also include any JavaScript—for example, you can create local variables for use in expressions.
 
-### Renderable
-
-Typically, the component's `render()` method returns a single `TemplateResult` object (the same type returned by the `html` tag function). However, it can return anything that Lit can render:
-
-*   Primitive values like string, number, or boolean.
-*   `TemplateResult` objects created by the `html` function.
-*   DOM Nodes.
-*   Arrays or iterables of any of the supported types.
+Typically, the component's `render()` method returns a single `TemplateResult` object (the same type returned by the `html` tag function). However, it can return [anything that Lit can render](/docs/templates/overview/#renderable).
 
 For more information about writing templates, see [Templates](/docs/templates/overview/).
 

--- a/packages/lit-dev-content/site/docs/components/rendering.md
+++ b/packages/lit-dev-content/site/docs/components/rendering.md
@@ -18,6 +18,8 @@ Write your template in HTML inside a JavaScript [tagged template literal](https:
 
 Lit templates can include JavaScript _expressions_. You can use expressions to set text content, attributes, properties, and event listeners. The `render()` method can also include any JavaScript—for example, you can create local variables for use in expressions.
 
+### Renderable
+
 Typically, the component's `render()` method returns a single `TemplateResult` object (the same type returned by the `html` tag function). However, it can return anything that Lit can render:
 
 *   Primitive values like string, number, or boolean.

--- a/packages/lit-dev-content/site/docs/templates/overview.md
+++ b/packages/lit-dev-content/site/docs/templates/overview.md
@@ -30,6 +30,14 @@ Lit templates are extremely expressive and allow you to render dynamic content i
  - [Built-in directives](/docs/templates/directives/): Directives are functions that can extend Lit's templating functionality. The library includes a set of built-in directives to help with a variety of rendering needs.
  - [Custom directives](/docs/templates/custom-directives/): You can also write your own directives to customize Lit's rendering as needed.
 
+## Renderable
+Lit can render more than just templates, 
+
+*  Primitive values like `string`, `number`, or `boolean`.
+*   `TemplateResult` objects created by the `html` function.
+*   DOM Nodes.
+*   Arrays or iterables of any of the supported types.
+
 ## Standalone templating
 
 You can also use Lit's templating library for standalone templating, outside of a Lit component. For details, see [Standalone lit-html templates](/docs/libraries/standalone-templates).


### PR DESCRIPTION
Makes https://lit.dev/docs/components/rendering/#:~:text=typically%2C%20the%20component's the canonical docs location for `renderable`

Alternatively, A new section on rendering, or a heading on the [templates](https://lit.dev/docs/templates/overview/) page could be appropriate

## Y THO?

So I'm writing the sentence fragment "Icons are JavaScript modules which export a lit renderable" in my docs. Is there a canonical docs URL for "lit renderable" asides from the list mentioned off-hand at https://lit.dev/docs/components/rendering/

Renderable feels a bit opaque at times, with its `unknown` type. I'd like to be able to provide some more comprehensive and focused guidance.

So this issue is about **docs** and explicitly not about **types.** I'm fine with `unknown` if it's strictly true, but I believe that in the absence of clear type info, "thou shalt fully document thine API's intentions"