### PR TITLE
Cloud build for discord bot deploy

### DIFF
--- a/Dockerfile-discord-bot
+++ b/Dockerfile-discord-bot
@@ -1,0 +1,41 @@
+# Official lightweight Node.js image
+# https://hub.docker.com/_/node
+FROM node:18-slim
+
+# Arbitrary but conventional working directory
+WORKDIR /usr/src/app
+
+# Note we isolate work across sub-packages below, organized from least to most
+# likely to change, to maximize Docker filesystem layer cache hits. For
+# example, organized this way a site content only change will usually only need
+# to execute the final Eleventy build step.
+
+# External dependencies
+COPY package*.json tsconfig.base.json ./
+COPY packages/lit-dev-tools-cjs/package*.json ./packages/lit-dev-tools-cjs/
+COPY packages/lit-dev-tools-esm/package*.json ./packages/lit-dev-tools-esm/
+COPY packages/lit-dev-server/package*.json ./packages/lit-dev-server/
+COPY packages/lit-dev-discord-bot/package*.json ./packages/lit-dev-discord-bot/
+RUN npm ci
+
+# Tooling code
+COPY packages/lit-dev-tools-cjs/ ./packages/lit-dev-tools-cjs/
+COPY packages/lit-dev-tools-esm/ ./packages/lit-dev-tools-esm/
+COPY packages/lit-dev-server/ ./packages/lit-dev-server/
+COPY packages/lit-dev-discord-bot/ ./packages/lit-dev-discord-bot/
+RUN npm run build:ts -w packages/lit-dev-tools-cjs -w packages/lit-dev-tools-esm -w packages/lit-dev-server -w packages/lit-dev-discord-bot
+
+# Run the web service on container startup.
+#
+# IMPORTANT: Keep --max-old-space-size in sync with the --memory flag in
+# ./cloudbuild-main.yaml. The flag here should be set a little lower than
+# --memory (e.g. 75%) to give headroom for other uses [0].
+#
+# (Node isn't aware of Docker memory limits, so if we don't set this flag we're
+# at higher risk for termination and restart. This value determines when V8
+# decides to perform garbage collection. Node uses sysinfo totalram as the
+# default limit [1], which will be higher than our Docker memory limit.)
+#
+# [0] https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
+# [1] https://github.com/nodejs/node/pull/25576
+CMD [ "node", "--max-old-space-size=768", "packages/lit-dev-discord-bot/lib/index.js" ]

--- a/cloudbuild-discord-bot.yaml
+++ b/cloudbuild-discord-bot.yaml
@@ -45,6 +45,8 @@ steps:
       - '--max-instances=1'
       - '--set-secrets=BOT_CLIENT_SECRET=lit-dev-discord-bot-token:1'
 
+# TODO(augustjk) Consider adding a step here to delete the old revision
+
 tags:
   - lit-dev
   - discord-bot

--- a/cloudbuild-discord-bot.yaml
+++ b/cloudbuild-discord-bot.yaml
@@ -1,0 +1,55 @@
+# lit.dev Cloud Build config for discord bot deployment.
+# This is triggered manually.
+#
+# https://cloud.google.com/cloud-build/docs/build-config
+
+steps:
+  # Build Docker image.
+  #
+  # https://docs.docker.com/engine/reference/commandline/build/
+  # https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/docker
+  # https://cloud.google.com/build/docs/kaniko-cache
+  - id: build
+    # Kaniko pinned to earlier version due to
+    # https://github.com/GoogleContainerTools/kaniko/issues/1786
+    name: gcr.io/kaniko-project/executor:v1.6.0
+    args:
+      - --dockerfile=./Dockerfile-discord-bot
+      - --destination=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev-discord-bot:$COMMIT_SHA
+      - --cache=true
+      - --cache-ttl=168h # 1 week
+
+  # Create a new Cloud Run revision for the discord bot.
+  #
+  # https://cloud.google.com/sdk/gcloud/reference/beta/run/deploy
+  # https://github.com/GoogleCloudPlatform/cloud-sdk-docker
+  - id: deploy-discord-bot
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - lit-dev-discord-bot # Service name
+      - '--region=$_DEPLOY_REGION'
+      - '--platform=managed'
+      - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev-discord-bot:$COMMIT_SHA'
+      - '--quiet'
+      - '--tag=main-$SHORT_SHA'
+      # IMPORTANT: If you change --memory, be sure to also change
+      # --max-old-space-size in ./Dockerfile-discord-bot, and this same flag in
+      - '--memory=1Gi'
+      - '--cpu=1'
+      - '--concurrency=default' # unlimited
+      - '--min-instances=1'
+      - '--max-instances=1'
+      - '--set-secrets=BOT_CLIENT_SECRET=lit-dev-discord-bot-token:1'
+
+tags:
+  - lit-dev
+  - discord-bot
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+
+timeout: 45m

--- a/packages/lit-dev-discord-bot/README.md
+++ b/packages/lit-dev-discord-bot/README.md
@@ -1,0 +1,9 @@
+# lit-dev-discord-bot
+
+This package contains the code for Lit Bot discord bot that responds to `/docs` command which searches the lit.dev site index for provided query and returns a list of matches. It posts the url to the doc in the chat when an option is selected.
+
+## Deployment
+
+The bot is deployed by Google Cloud Build as a Cloud Run service. The Cloud Build configuration is stored in the root of the monorepo `cloudbuild-discord-bot.yaml`.
+
+The Cloud Build job must be triggered _manually_ to deploy a new version of the bot. Run the trigger from the Google Cloud console after the new code is merged to deploy a new version of the bot. After successful deployment, remove the old revision to prevent multiple bots from trying to handle the same request.

--- a/packages/lit-dev-discord-bot/package.json
+++ b/packages/lit-dev-discord-bot/package.json
@@ -9,11 +9,11 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "scripts": {
-    "build": "wireit",
+    "build:ts": "wireit",
     "start": "wireit"
   },
   "wireit": {
-    "build": {
+    "build:ts": {
       "command": "tsc --build --pretty",
       "files": [
         "src/**/*.ts",
@@ -31,7 +31,7 @@
     "start": {
       "command": "node ./lib/index.js",
       "dependencies": [
-        "build"
+        "build:ts"
       ]
     }
   },

--- a/packages/lit-dev-discord-bot/package.json
+++ b/packages/lit-dev-discord-bot/package.json
@@ -9,10 +9,16 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "scripts": {
+    "build": "wireit",
     "build:ts": "wireit",
     "start": "wireit"
   },
   "wireit": {
+    "build": {
+      "dependencies": [
+        "build:ts"
+      ]
+    },
     "build:ts": {
       "command": "tsc --build --pretty",
       "files": [
@@ -31,7 +37,7 @@
     "start": {
       "command": "node ./lib/index.js",
       "dependencies": [
-        "build:ts"
+        "build"
       ]
     }
   },

--- a/packages/lit-dev-discord-bot/src/index.ts
+++ b/packages/lit-dev-discord-bot/src/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import http from 'node:http';
 import {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
@@ -178,3 +179,12 @@ const startClientWebsocketServer = async () => {
 
 publishDiscordCommands([docsSlashCommand]);
 startClientWebsocketServer();
+
+/**
+ * HTTP server for Cloud Run liveness
+ */
+http
+  .createServer((_, response) => {
+    response.end('OK');
+  })
+  .listen(process.env.PORT ?? 8080);

--- a/packages/lit-dev-discord-bot/src/index.ts
+++ b/packages/lit-dev-discord-bot/src/index.ts
@@ -139,7 +139,7 @@ const handleDocsSubmissionInteraction = async (
     // If the response is not a lit.dev url, then bot responds with an
     // ephemeral message that is only visible to the user. This happens when
     // there are no results, or if the user hits enter before results show up.
-    interaction.reply({
+    await interaction.reply({
       ephemeral: true,
       content: `value: "${value}" is not a valid lit.dev url. Please select from the autocomplete list.`,
     });
@@ -150,25 +150,29 @@ const handleDocsSubmissionInteraction = async (
  * Creates a discord bot client, registers the event handlers, and starts the
  * client websocket server that listens for events.
  */
-const startClientWebsocketServer = async () => {
+const startClientWebsocketServer = () => {
   const client = new Client({intents: [GatewayIntentBits.Guilds]});
 
   client.on('ready', () => {
     console.log(`Logged in as ${client.user?.tag}!`);
   });
 
-  client.on('interactionCreate', async (interaction) => {
+  client.on('interactionCreate', (interaction) => {
     // handle only the /docs slash command.
     if ((interaction as ChatInputCommandInteraction).commandName === 'docs') {
       // This happens as the user is typing. Enabled by the
       // SlashCommandBuilder's .setAutocomplete(true) option.
       if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
-        handleDocsAutocompleteInteraction(interaction);
+        handleDocsAutocompleteInteraction(interaction).catch((error) =>
+          console.error(error)
+        );
       }
 
       // This is true when the user finally returns a command. (a lit.dev url)
       if (interaction.isChatInputCommand()) {
-        handleDocsSubmissionInteraction(interaction);
+        handleDocsSubmissionInteraction(interaction).catch((error) =>
+          console.error(error)
+        );
       }
     }
   });


### PR DESCRIPTION
Adds Dockerfile and cloud build config yaml file for deploying the discord bot.
Also adds some catches so there won't be any unhandled promise rejections that cause the container to restart.

This still has a couple of things to address before merging.

Potential things to address:
- Cloud build is currently set to trigger manually.
  - This is probably okay for now since we don't need the bot to re-deploy every time a merge to main happens. We could add some rules to watch for changes in select files for re-deploy.
- A new build will trigger a new cloud run revision but we should only ever have 1 revision running so that we just have 1 bot handling interactions.
  - I've been manually deleting the old revisions but need to codify that. Perhaps deleting existing revision right before deploying a new one? There should be minimal down time for the bot, if any. Or find the revision id to delete, and delete immediately after deploying the new one.