### PR TITLE
use discord's blurple for the banner

### DIFF
--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #283198;
+  background: #5865F2;
   color: white;
   height: 48px;
 }


### PR DESCRIPTION
https://discord.com/branding

Use discord blurple because the current dark blue is weird and off-palette w/ the rest of the site might as well use their brand color