### PR TITLE
Decrease algolia response size

### DIFF
--- a/packages/lit-dev-content/src/components/algolia-search-controller.ts
+++ b/packages/lit-dev-content/src/components/algolia-search-controller.ts
@@ -18,12 +18,8 @@ const agloliaSearchControllerDefaultOptions = {
   appId: publicVars.algolia.appId,
   searchOnlyKey: publicVars.algolia.searchOnlyKey,
   index: publicVars.algolia.index,
-  attributesToHighlight: undefined as string[] | undefined,
-  attributesToRetrieve: undefined as string[] | undefined,
-};
-
-type Writeable<T extends {[x: string]: any}, K extends string | number> = {
-  [P in K]: T[P];
+  attributesToHighlight: ['*'],
+  attributesToRetrieve: ['*'],
 };
 
 export type AlgoliaSearchControllerOptions =
@@ -75,25 +71,13 @@ export class AgloliaSearchController<T extends {}> {
     if (trimmedQuery.length < 2) {
       return [];
     }
-    type SearchOptionsReadonly = NonNullable<
-      Parameters<typeof this._index.search>[1]
-    >;
-    type SearchOptions = Writeable<
-      SearchOptionsReadonly,
-      keyof SearchOptionsReadonly
-    >;
+    type SearchOptions = Parameters<typeof this._index.search>[1];
     const searchOpts: SearchOptions = {
       page: 0,
       hitsPerPage: 10,
+      attributesToHighlight: this._attributesToHighlight,
+      attributesToRetrieve: this._attributesToRetrieve,
     };
-
-    if (this._attributesToHighlight) {
-      searchOpts.attributesToHighlight = this._attributesToHighlight;
-    }
-
-    if (this._attributesToRetrieve) {
-      searchOpts.attributesToRetrieve = this._attributesToRetrieve;
-    }
 
     const results = await this._index.search<T>(trimmedQuery, searchOpts);
     return results.hits;

--- a/packages/lit-dev-content/src/components/algolia-search-controller.ts
+++ b/packages/lit-dev-content/src/components/algolia-search-controller.ts
@@ -96,7 +96,6 @@ export class AgloliaSearchController<T extends {}> {
     }
 
     const results = await this._index.search<T>(trimmedQuery, searchOpts);
-    console.log(results);
     return results.hits;
   }
 }

--- a/packages/lit-dev-content/src/components/algolia-search-controller.ts
+++ b/packages/lit-dev-content/src/components/algolia-search-controller.ts
@@ -31,9 +31,9 @@ export class AgloliaSearchController<T extends {}> {
   private _index: SearchIndex;
   private _lastValue: Hit<T>[] = [];
   // https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/
-  private _attributesToHighlight: string[] | undefined;
+  private _attributesToHighlight: string[];
   // https://www.algolia.com/doc/api-reference/api-parameters/attributesToRetrieve/
-  private _attributesToRetrieve: string[] | undefined;
+  private _attributesToRetrieve: string[];
 
   public get value() {
     if (this._task.status !== TaskStatus.COMPLETE) {

--- a/packages/lit-dev-content/src/components/algolia-search-controller.ts
+++ b/packages/lit-dev-content/src/components/algolia-search-controller.ts
@@ -34,7 +34,7 @@ export class AgloliaSearchController<T extends {}> {
   private _client: SearchClient;
   private _index: SearchIndex;
   private _lastValue: Hit<T>[] = [];
-  // https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/#the-response-object
+  // https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/
   private _attributesToHighlight: string[] | undefined;
   // https://www.algolia.com/doc/api-reference/api-parameters/attributesToRetrieve/
   private _attributesToRetrieve: string[] | undefined;

--- a/packages/lit-dev-content/src/components/litdev-search.ts
+++ b/packages/lit-dev-content/src/components/litdev-search.ts
@@ -240,7 +240,13 @@ export class LitDevSearch extends LitElement {
 
   private _searchController = new AgloliaSearchController<Suggestion>(
     this,
-    () => this._searchText
+    () => this._searchText,
+    {
+      // Algolia _highlightResult adds a lot to response size
+      attributesToHighlight: [],
+      // We don't need to return the full text of result so don't request it
+      attributesToRetrieve: ['*', '-text'],
+    }
   );
 
   private get _isExpanded() {


### PR DESCRIPTION
Expose some features from algolia search to narrow our response attributes. This decreases the algolia response size from 15.7kb (3.4kb compressed) to 1.9kb (1.1kb)

| before | after |
| - | - |
| ![image](https://user-images.githubusercontent.com/5981958/189766328-a19cbe3c-ac65-4918-8363-3723caa719c4.png) | ![image](https://user-images.githubusercontent.com/5981958/189766384-18d55dcf-f285-426b-a633-bd33e36a28a9.png) |