### PR TITLE
Fix markdown link for "primitive values"

### DIFF
--- a/packages/lit-dev-content/site/docs/templates/expressions.md
+++ b/packages/lit-dev-content/site/docs/templates/expressions.md
@@ -145,7 +145,7 @@ Expressions in the child position can take many kinds of values:
 
 ### Primitive values
 
-Lit can render almost all (primitive values)[https://developer.mozilla.org/en-US/docs/Glossary/Primitive] and converts them to strings when interpolated into text content.
+Lit can render almost all [primitive values](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) and converts them to strings when interpolated into text content.
 
 Numbers values like `5` will render the string `'5'`. Bigints are treated similarly.
 


### PR DESCRIPTION
This fixes a markdown link, which used the wrong brackets and was therefore not displaying correctly.

<img width="751" alt="Screenshot 2022-09-18 at 13 47 17" src="https://user-images.githubusercontent.com/1055819/190900497-2156e73d-2db7-4114-aea9-f61cf103e46a.png">
