### PR TITLE
Add one hidden example for Labs/observers ReactiveController usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -515,6 +515,14 @@
         "lit": "^2.0.0"
       }
     },
+    "node_modules/@lit-labs/observers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-1.1.0.tgz",
+      "integrity": "sha512-+MbK+OD+Io9MvGIKY8HVB7vQVOpYxruChlw52OzHjAPl+cBPK8i+MKQ2OvH02LakRYloEc6u/Nuvz6+e8+qAbA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.1.0"
+      }
+    },
     "node_modules/@lit-labs/react": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.0.8.tgz",
@@ -10976,6 +10984,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/motion": "^1.0.1",
+        "@lit-labs/observers": "1.1.0",
         "@lit-labs/react": "^1.0.8",
         "@lit-labs/task": "^1.0.0",
         "@lit/localize": "^0.10.0",
@@ -11027,42 +11036,6 @@
       "dependencies": {
         "algoliasearch": "^4.14.2",
         "discord.js": "^14.3.0"
-      },
-      "devDependencies": {
-        "typescript": "^4.8.2",
-        "wireit": "^0.7.1"
-      }
-    },
-    "packages/lit-dev-discord-bot/node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "packages/lit-dev-discord-bot/node_modules/wireit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
-      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "jsonc-parser": "^3.0.0",
-        "proper-lockfile": "^4.1.2"
-      },
-      "bin": {
-        "wireit": "bin/wireit.js"
-      },
-      "engines": {
-        "node": ">=14.14.0"
       }
     },
     "packages/lit-dev-server": {
@@ -11585,6 +11558,14 @@
       "integrity": "sha512-Qv3VKJUllEkIVGFQMMbV68VJDECXutBL+NBM0ZQFFYqEmBFlZQcNxTVlC9dMhDdXeQaX5vfpNdJlP4xKM30ERQ==",
       "requires": {
         "lit": "^2.0.0"
+      }
+    },
+    "@lit-labs/observers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-1.1.0.tgz",
+      "integrity": "sha512-+MbK+OD+Io9MvGIKY8HVB7vQVOpYxruChlw52OzHjAPl+cBPK8i+MKQ2OvH02LakRYloEc6u/Nuvz6+e8+qAbA==",
+      "requires": {
+        "@lit/reactive-element": "^1.1.0"
       }
     },
     "@lit-labs/react": {
@@ -16796,6 +16777,7 @@
         "@11ty/eleventy-plugin-rss": "^1.1.2",
         "@lit-labs/eleventy-plugin-lit": "^0.1.1",
         "@lit-labs/motion": "^1.0.1",
+        "@lit-labs/observers": "1.1.0",
         "@lit-labs/react": "^1.0.8",
         "@lit-labs/task": "^1.0.0",
         "@lit/localize": "^0.10.0",
@@ -16839,30 +16821,7 @@
       "version": "file:packages/lit-dev-discord-bot",
       "requires": {
         "algoliasearch": "^4.14.2",
-        "discord.js": "^14.3.0",
-        "typescript": "^4.8.2",
-        "wireit": "*"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-          "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-          "dev": true
-        },
-        "wireit": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
-          "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "chokidar": "^3.5.3",
-            "fast-glob": "^3.2.11",
-            "jsonc-parser": "^3.0.0",
-            "proper-lockfile": "^4.1.2"
-          }
-        }
+        "discord.js": "^14.3.0"
       }
     },
     "lit-dev-server": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -195,6 +195,7 @@
   },
   "dependencies": {
     "@lit-labs/motion": "^1.0.1",
+    "@lit-labs/observers": "1.1.0",
     "@lit-labs/react": "^1.0.8",
     "@lit-labs/task": "^1.0.0",
     "@lit/localize": "^0.10.0",

--- a/packages/lit-dev-content/samples/examples/observers-resize-controller/index.html
+++ b/packages/lit-dev-content/samples/examples/observers-resize-controller/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script type="module" src="./resize-demo.js"></script>
+<script type="module" src="./mock-drawer.js"></script>
+<style>
+  body {
+    display: flex;
+    font-family: Sans-Serif;
+  }
+</style>
+
+<mock-drawer></mock-drawer>
+<simple-resize-demo></simple-resize-demo>

--- a/packages/lit-dev-content/samples/examples/observers-resize-controller/mock-drawer.ts
+++ b/packages/lit-dev-content/samples/examples/observers-resize-controller/mock-drawer.ts
@@ -1,0 +1,57 @@
+import {LitElement, html, css} from 'lit';
+import {customElement, state} from 'lit/decorators.js';
+import {styleMap} from 'lit/directives/style-map.js';
+
+// Material icon: https://fonts.google.com/icons?selected=Material%20Symbols%20Outlined%3Atouch_app%3AFILL%400%3Bwght%40400%3BGRAD%400%3Bopsz%4048
+const touch_app_svg = html`<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="white"
+  height="48"
+  width="48"
+  viewBox="0 0 48 48"
+>
+  <path
+    d="M23.25 2q4.55 0 7.775 3.175Q34.25 8.35 34.25 12.9q0 2.6-1.125 4.9Q32 20.1 29.95 21.7h-1.7v-2.5q1.45-1.15 2.225-2.8.775-1.65.775-3.5 0-3.3-2.35-5.6T23.25 5q-3.3 0-5.65 2.3-2.35 2.3-2.35 5.6 0 1.85.775 3.5t2.225 2.8v3.6q-2.8-1.45-4.4-4.1-1.6-2.65-1.6-5.8 0-4.55 3.225-7.725T23.25 2Zm-1.9 42q-.85 0-1.6-.325-.75-.325-1.3-.875L8.15 32.5l2.8-2.9q.7-.7 1.575-1.075t1.825-.125l3.9.9V13q0-2.1 1.45-3.55Q21.15 8 23.25 8q2.1 0 3.55 1.45 1.45 1.45 1.45 3.55v8.6h1.3q.25 0 .45.1t.45.2l7.4 3.6q1.2.55 1.775 1.775.575 1.225.325 2.525l-1.8 10.9q-.25 1.45-1.4 2.375t-2.6.925Zm-.4-3H35l2.15-12.45L28 24h-2.75V13q0-.9-.55-1.45-.55-.55-1.45-.55-.9 0-1.45.55-.55.55-.55 1.45v19.95l-7.7-1.65-1.15 1.15ZM35 41H20.95 35Z"
+  />
+</svg>`;
+
+/**
+ * `mock-drawer` imitates a menu drawer on the page. Clicking this drawer
+ * expands and contracts it.
+*/
+@customElement('mock-drawer')
+export class MockDrawer extends LitElement {
+  @state() extended = false;
+
+  toggleExtended() {
+    this.extended = !this.extended;
+  }
+
+  render() {
+    return html`
+      <div
+        style=${styleMap({width: this.extended ? '200px' : '50px'})}
+        @click=${this.toggleExtended}
+      >
+        ${touch_app_svg}
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      height: calc(100vh - 90px);
+    }
+    div {
+      background-color: #324fff;
+      transition: width 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+    }
+    div:hover {
+      background-color: #101ccc;
+    }
+  `;
+}

--- a/packages/lit-dev-content/samples/examples/observers-resize-controller/project.json
+++ b/packages/lit-dev-content/samples/examples/observers-resize-controller/project.json
@@ -1,0 +1,14 @@
+{
+  "extends": "/samples/base.json",
+  "hide": true,
+  "title": "ResizeController",
+  "description": "@lit-labs/observers ResizeController example",
+  "section": "Observers",
+  "files": {
+    "resize-demo.ts": {},
+    "styles.ts": {},
+    "mock-drawer.ts": {},
+    "index.html": {}
+  },
+  "order": 0
+}

--- a/packages/lit-dev-content/samples/examples/observers-resize-controller/resize-demo.ts
+++ b/packages/lit-dev-content/samples/examples/observers-resize-controller/resize-demo.ts
@@ -1,0 +1,31 @@
+import {html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {styles, svgCross} from './styles.js';
+import {ResizeController} from '@lit-labs/observers/resize_controller.js';
+
+/**
+ * This example demonstrates a simple usage of the ResizeController exported
+ * from the `@lit-labs/observers` package. This element uses a resize controller
+ * to render its width and height.
+ *
+ * The controller automatically triggers a reactive update when a resize on the
+ * element is observed.
+ */
+@customElement('simple-resize-demo')
+export class SimpleResizeDemo extends LitElement {
+  static styles = styles;
+
+  private resizeController = new ResizeController(this, {
+    callback([entry]) {
+      return [entry.contentRect.width, entry.contentRect.height];
+    },
+  });
+
+  render() {
+    const [width, height] = this.resizeController.value ?? [0, 0];
+    return html`
+      ${svgCross}
+      <span>${width.toFixed(0)}px by ${height.toFixed(0)}px</span>
+    `;
+  }
+}

--- a/packages/lit-dev-content/samples/examples/observers-resize-controller/styles.ts
+++ b/packages/lit-dev-content/samples/examples/observers-resize-controller/styles.ts
@@ -1,0 +1,57 @@
+import {css, html} from 'lit';
+
+export const styles = css`
+  :host {
+    display: grid;
+    min-height: 100px;
+    width: 100%;
+    height: 100%;
+    font-size: 1.4rem;
+  }
+
+  * {
+    grid-area: 1 / 1 / 1 / 1;
+  }
+
+  span {
+    align-self: center;
+    justify-self: center;
+    color: white;
+    background-color: #324fff;
+  }
+
+  svg {
+    color: #324fff;
+    border: 5px solid #324fff;
+    max-height: calc(100vh - 100px);
+    width: 100%;
+  }
+`;
+
+export const svgCross = html`
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    preserveAspectRatio="none"
+    viewBox="0 0 100 100"
+  >
+    <line
+      x1="0"
+      y1="0"
+      x2="100"
+      y2="100"
+      stroke="currentColor"
+      stroke-width="5px"
+      vector-effect="non-scaling-stroke"
+    />
+    <line
+      x1="0"
+      y1="100"
+      x2="100"
+      y2="0"
+      stroke="currentColor"
+      stroke-width="5px"
+      vector-effect="non-scaling-stroke"
+    />
+  </svg>
+`;


### PR DESCRIPTION
For easier reviews I'm splitting out the labs/observers example playgrounds into isolated PRs. There will be a final PR that un-hides them.

This change adds a simple `ResizeController` example.

Can be viewed by going to the preview URL with relative path: /playground/#sample=examples/observers-resize-controller

I also installed `labs/observers` as it is required for type checking and building lit.dev content, even though it isn't technically required as the examples run client side.