### PR TITLE
Fix typo in docs/components/properties.md

### DIFF
--- a/packages/lit-dev-content/site/docs/components/properties.md
+++ b/packages/lit-dev-content/site/docs/components/properties.md
@@ -56,7 +56,7 @@ static properties = {
   _counter: {state: true};
 };
 
-constructor()
+constructor() {
   super();
   this._counter = 0;
 }


### PR DESCRIPTION
There is syntax error. This fixed it.