### PR TITLE
[Playground] warn before hash navigation

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-button.ts
@@ -247,14 +247,14 @@ export class LitDevPlaygroundShareButton extends LitElement {
       event.preventDefault(); // Don't trigger "Save page as"
       if (this._mostRecentSaveType === 'longurl') {
         this._longUrl?.generateUrl();
-        this._longUrl?.save();
         this._dispatchSaveEvent();
+        this._longUrl?.save();
       } else if (
         this._mostRecentSaveType === 'gist' &&
         this._gist?.canUpdateGist
       ) {
-        this._gist?.updateGist();
         this._dispatchSaveEvent();
+        this._gist?.updateGist();
       } else {
         this._open = true;
       }

--- a/packages/lit-dev-content/src/components/litdev-playground-share-gist.ts
+++ b/packages/lit-dev-content/src/components/litdev-playground-share-gist.ts
@@ -288,6 +288,9 @@ export class LitDevPlaygroundShareGist extends LitElement {
         token,
       });
 
+      this.dispatchEvent(
+        new Event('will-hashchange', {bubbles: true, composed: true})
+      );
       window.location.hash = '#gist=' + gist.id;
       let statusText = 'Gist created';
       try {
@@ -358,6 +361,9 @@ export class LitDevPlaygroundShareGist extends LitElement {
         token,
       });
 
+      this.dispatchEvent(
+        new Event('will-hashchange', {bubbles: true, composed: true})
+      );
       window.location.hash = '#gist=' + gist.id;
       let statusText = 'Gist updated';
       try {


### PR DESCRIPTION
Warns before hashchange event. This means that we can warn if someone hits save on the playground then makes edits then hits the back button