### PR TITLE
hides the modal if native dialog not supported

### DIFF
--- a/packages/lit-dev-content/site/css/header.css
+++ b/packages/lit-dev-content/site/css/header.css
@@ -51,6 +51,12 @@
   font-size: 0.9em;
 }
 
+@supports not selector(:modal) {
+  litdev-search-modal {
+      display: none !important;
+  }
+}
+
 #desktopNav > .navItem > *:hover,
 #desktopNav > .navItem.active > a {
   color: var(--color-blue);


### PR DESCRIPTION
Fixes #980 

@jrencz Sorry it took so long!

Tested on Safari 14.1
<img width="2792" alt="Screen Shot 2022-10-24 at 4 30 19 PM" src="https://user-images.githubusercontent.com/5981958/197649267-8534786b-eab0-466e-8602-282c7e922330.png">