### PR TITLE
Add YouTube video channel to community.md

### DIFF
--- a/packages/lit-dev-content/site/docs/resources/community.md
+++ b/packages/lit-dev-content/site/docs/resources/community.md
@@ -29,5 +29,7 @@ excellent to each other!
     tags like [`web-component`](https://stackoverflow.com/tags/web-component),
     and try your hand at answering other people’s queries.
 
+*   **Watch Lit videos on [YouTube](/youtube/).** The Lit team has a dedicated YouTube channel with tutorials and update streams.
+
 
 


### PR DESCRIPTION
Without the banner, there are no links from lit.dev to our YouTube channel.

This change adds the Lit YouTube channel to our community page.