### PR TITLE
Adopt wireit services and cascade:false

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ This is an npm workspaces monorepo.
 npm ci
 ```
 
-### Build all
-
-```sh
-npm run build
-```
-
 ### Develop site content
 
 ```sh
@@ -31,16 +25,6 @@ npm run dev
 ```
 
 Serves at [`http://localhost:5415`](http://localhost:5415).
-
-You may also prefer to run each dev script in its own terminal:
-
-```sh
-cd packages/lit-dev-content
-
-npm run build:ts:watch       # TypeScript
-npm run dev:build:eleventy:watch # Eleventy
-npm run dev:serve            # @web/dev-server
-```
 
 Dev mode is different to production in these ways:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3185,130 +3185,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar-cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-2.1.0.tgz",
-      "integrity": "sha512-6n21AVpW6ywuEPoxJcLXMA2p4T+SLjWsXKny/9yTWFz0kKxESI3eUylpeV97LylING/27T/RVTY0f2/0QaWq9Q==",
-      "dependencies": {
-        "chokidar": "^3.2.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "yargs": "^13.3.0"
-      },
-      "bin": {
-        "chokidar": "index.js"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
-    "node_modules/chokidar-cli/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/chokidar-cli/node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      }
-    },
-    "node_modules/chokidar-cli/node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
     "node_modules/clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -3859,14 +3735,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -4763,17 +4631,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
@@ -5066,6 +4923,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -6993,18 +6851,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -7019,11 +6865,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.deburr": {
       "version": "4.1.0",
@@ -7086,11 +6927,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
-    },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/lodash.uniqwith": {
       "version": "4.5.0",
@@ -7912,39 +7748,6 @@
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
       "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -8023,14 +7826,6 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-is-absolute": {
@@ -8833,14 +8628,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -9403,11 +9194,6 @@
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
       "dev": true
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -10667,11 +10453,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
-    },
     "node_modules/wicg-inert": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
@@ -10929,7 +10710,6 @@
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "chokidar-cli": "^2.1.0",
         "lit-dev-tools-cjs": "^0.0.0"
       }
     },
@@ -11133,7 +10913,6 @@
         "@types/prettier": "^2.3.2",
         "@web/dev-server": "^0.1.6",
         "algoliasearch": "^4.14.2",
-        "chokidar": "^3.5.2",
         "co-body": "^6.1.0",
         "fast-glob": "^3.2.9",
         "lit-dev-server": "^0.0.0",
@@ -13936,108 +13715,6 @@
         "readdirp": "~3.6.0"
       }
     },
-    "chokidar-cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-2.1.0.tgz",
-      "integrity": "sha512-6n21AVpW6ywuEPoxJcLXMA2p4T+SLjWsXKny/9yTWFz0kKxESI3eUylpeV97LylING/27T/RVTY0f2/0QaWq9Q==",
-      "requires": {
-        "chokidar": "^3.2.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "yargs": "^13.3.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-        },
-        "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
     "clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -14484,11 +14161,6 @@
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -15159,14 +14831,6 @@
         }
       }
     },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
     "follow-redirects": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
@@ -15377,7 +15041,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.2",
@@ -16728,7 +16393,6 @@
     "lit-dev-api": {
       "version": "file:packages/lit-dev-api",
       "requires": {
-        "chokidar-cli": "^2.1.0",
         "lit-dev-tools-cjs": "^0.0.0"
       }
     },
@@ -16895,7 +16559,6 @@
         "@types/prettier": "^2.3.2",
         "@web/dev-server": "^0.1.6",
         "algoliasearch": "^4.14.2",
-        "chokidar": "^3.5.2",
         "co-body": "^6.1.0",
         "fast-glob": "^3.2.9",
         "lit-dev-server": "^0.0.0",
@@ -16976,15 +16639,6 @@
         }
       }
     },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      }
-    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -16999,11 +16653,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.deburr": {
       "version": "4.1.0",
@@ -17066,11 +16715,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "lodash.uniqwith": {
       "version": "4.5.0",
@@ -17676,27 +17320,6 @@
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
       "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
-    "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "requires": {
-        "p-limit": "^2.0.0"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    },
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -17766,11 +17389,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -18410,12 +18028,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -18863,11 +18477,6 @@
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
       "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -19870,11 +19479,6 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
     },
     "wicg-inert": {
       "version": "3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "playground-elements": "^0.17.0",
         "prettier": "^2.1.2",
         "typescript": "~4.6.2",
-        "wireit": "^0.6.1"
+        "wireit": "^0.7.3-pre.4"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -10689,9 +10689,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.6.1.tgz",
-      "integrity": "sha512-UmrAzFd2w6ioyHluPwXr3TxUIo5CIbklTbTTgubN81jQxiPkAHXTjzkfTOjeAdeEzZ5OpsbYCQW5obCrFMlTdw==",
+      "version": "0.7.3-pre.4",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.3-pre.4.tgz",
+      "integrity": "sha512-dqsWNWMgqSrUDT/PzVsZZcchi/ZF8q3rIZse3nnIOoEi9f36nslehB87PlbtXhRbhz4/vLRJcfVzyQ2CvqBZ2w==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -19890,9 +19890,9 @@
       }
     },
     "wireit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.6.1.tgz",
-      "integrity": "sha512-UmrAzFd2w6ioyHluPwXr3TxUIo5CIbklTbTTgubN81jQxiPkAHXTjzkfTOjeAdeEzZ5OpsbYCQW5obCrFMlTdw==",
+      "version": "0.7.3-pre.4",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.3-pre.4.tgz",
+      "integrity": "sha512-dqsWNWMgqSrUDT/PzVsZZcchi/ZF8q3rIZse3nnIOoEi9f36nslehB87PlbtXhRbhz4/vLRJcfVzyQ2CvqBZ2w==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:main": "LITDEV_ENV=local MODE=main npm run start -w lit-dev-server",
     "start:playground": "LITDEV_ENV=local MODE=playground npm start -w lit-dev-server",
     "start:fake-github": "wireit",
-    "dev": "cd packages/lit-dev-server && npm run build && cd ../lit-dev-content && (npm run dev:build:assets --watch & npm run dev:build:eleventy:watch & node ../lit-dev-tools-esm/lib/dev-server.js --open)",
+    "dev": "npm run dev:serve --workspace lit-dev-content --watch",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "nuke": "rm -rf node_modules packages/*/node_modules && npm ci",
@@ -54,6 +54,6 @@
     "playground-elements": "^0.17.0",
     "prettier": "^2.1.2",
     "typescript": "~4.6.2",
-    "wireit": "^0.6.1"
+    "wireit": "^0.7.3-pre.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
       ]
     },
     "start:fake-github": {
+      "command": "LITDEV_ENV=local node packages/lit-dev-tools-esm/lib/fake-github-server.js",
       "dependencies": [
         "./packages/lit-dev-tools-esm:build"
       ],
-      "command": "LITDEV_ENV=local node packages/lit-dev-tools-esm/lib/fake-github-server.js",
       "output": []
     },
     "publish-search-index": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "dependencies": [
         "./packages/lit-dev-tools-esm:build"
       ],
-      "output": []
+      "files": [],
+      "service": true
     },
     "publish-search-index": {
       "dependencies": [

--- a/packages/lit-dev-api/package.json
+++ b/packages/lit-dev-api/package.json
@@ -22,7 +22,6 @@
     }
   },
   "dependencies": {
-    "chokidar-cli": "^2.1.0",
     "lit-dev-tools-cjs": "^0.0.0"
   }
 }

--- a/packages/lit-dev-api/package.json
+++ b/packages/lit-dev-api/package.json
@@ -10,14 +10,14 @@
   },
   "wireit": {
     "build": {
+      "command": "node ../lit-dev-tools-cjs/lib/api-docs/generate.js",
       "dependencies": [
         "../lit-dev-tools-cjs:build"
       ],
       "files": [
         "lit/packages/*/src/**/*.ts"
       ],
-      "#comment": "We don't declare the api-data directory as output because it's super huge, >1.4GB and 120k files. Maintaining the cache is probably not worth it.",
-      "command": "node ../lit-dev-tools-cjs/lib/api-docs/generate.js"
+      "#comment": "We don't declare the api-data directory as output because it's super huge, >1.4GB and 120k files. Maintaining the cache is probably not worth it."
     }
   },
   "dependencies": {

--- a/packages/lit-dev-api/package.json
+++ b/packages/lit-dev-api/package.json
@@ -6,8 +6,7 @@
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "wireit",
-    "build:watch": "npm run build -- --watch"
+    "build": "wireit"
   },
   "wireit": {
     "build": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -16,7 +16,6 @@
     "build:rollup": "wireit",
     "build:rollup:watch": "npm run build:rollup -- --watch",
     "build:samples": "wireit",
-    "build:samples:watch": "npm run build:samples -- --watch",
     "dev:build": "wireit",
     "dev:build:assets": "wireit",
     "dev:build:eleventy": "wireit",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -138,7 +138,7 @@
       "dependencies": [
         "../lit-dev-tools-esm:build:ts"
       ],
-      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "build:rollup": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -64,7 +64,10 @@
       "service": true,
       "dependencies": [
         "../lit-dev-tools-esm:build",
-        "../../:start:fake-github",
+        {
+          "script": "../../:start:fake-github",
+          "cascade": false
+        },
         {
           "script": "dev:build",
           "cascade": false

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -33,7 +33,7 @@
       ]
     },
     "dev:build": {
-      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy",
+      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --quiet",
       "dependencies": [
         "dev:build:assets"
       ],

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -10,16 +10,12 @@
     "fonts:manrope": "wireit",
     "build": "wireit",
     "build:eleventy": "wireit",
-    "build:eleventy:watch": "wireit",
     "build:ts": "wireit",
-    "build:ts:watch": "npm run build:ts -- --watch",
     "build:rollup": "wireit",
-    "build:rollup:watch": "npm run build:rollup -- --watch",
     "build:samples": "wireit",
     "dev:build": "wireit",
     "dev:build:assets": "wireit",
     "dev:build:eleventy": "wireit",
-    "dev:build:eleventy:watch": "wireit",
     "dev:serve": "wireit",
     "prod:build": "wireit",
     "prod:build:assets": "wireit"
@@ -65,20 +61,6 @@
       ],
       "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
-    "build:eleventy:watch": {
-      "dependencies": [
-        "prod:build:assets"
-      ],
-      "output": [
-        "_site"
-      ],
-      "#comment": "This is awkward. We want to do the watch part for build:assets ourselves, but let eleventy do its own watch mode itself. Maybe --incremental will do a quick rebuild of just the changed parts, and we don't need --watch?",
-      "files": [
-        "site/**",
-        ".eleventy.js"
-      ],
-      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
-    },
     "dev:build:eleventy": {
       "dependencies": [
         "dev:build:assets"
@@ -91,19 +73,6 @@
         ".eleventy.js"
       ],
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
-    },
-    "dev:build:eleventy:watch": {
-      "dependencies": [
-        "dev:build:assets"
-      ],
-      "output": [
-        "_dev"
-      ],
-      "files": [
-        "site/**",
-        ".eleventy.js"
-      ],
-      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --watch --incremental"
     },
     "dev:build:assets": {
       "dependencies": [

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -13,7 +13,6 @@
     "build:rollup": "wireit",
     "build:samples": "wireit",
     "dev:build": "wireit",
-    "dev:build:assets": "wireit",
     "dev:serve": "wireit",
     "prod:build": "wireit",
     "prod:build:assets": "wireit"
@@ -35,7 +34,12 @@
     "dev:build": {
       "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy --quiet",
       "dependencies": [
-        "dev:build:assets"
+        "build:ts",
+        "fonts:manrope",
+        {
+          "script": "build:samples",
+          "cascade": false
+        }
       ],
       "files": [
         "site/**",
@@ -57,22 +61,22 @@
     },
     "dev:serve": {
       "command": "node ../lit-dev-tools-esm/lib/dev-server.js --open",
+      "service": true,
       "dependencies": [
         "../lit-dev-tools-esm:build",
-        "dev:build"
-      ]
-    },
-    "dev:build:assets": {
-      "dependencies": [
-        "build:ts",
-        "build:samples",
-        "fonts:manrope"
+        "../../:start:fake-github",
+        {
+          "script": "dev:build",
+          "cascade": false
+        }
       ]
     },
     "prod:build:assets": {
       "dependencies": [
-        "dev:build:assets",
-        "build:rollup"
+        "build:ts",
+        "build:samples",
+        "build:rollup",
+        "fonts:manrope"
       ]
     },
     "fonts:manrope": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -20,47 +20,47 @@
   },
   "wireit": {
     "build": {
+      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy",
       "dependencies": [
         "prod:build:assets"
+      ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
       ],
       "output": [
         "_site"
-      ],
-      "files": [
-        "site/**",
-        ".eleventy.js"
-      ],
-      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
+      ]
     },
     "dev:build": {
+      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy",
       "dependencies": [
         "dev:build:assets"
       ],
-      "output": [
-        "_dev"
-      ],
       "files": [
         "site/**",
         ".eleventy.js"
       ],
-      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
+      "output": [
+        "_dev"
+      ]
     },
     "prod:build": {
+      "command": "NODE_OPTIONS=--experimental-vm-modules eleventy",
       "dependencies": [
         "prod:build:assets"
       ],
       "files": [
         "site/**",
         ".eleventy.js"
-      ],
-      "command": "NODE_OPTIONS=--experimental-vm-modules eleventy"
+      ]
     },
     "dev:serve": {
+      "command": "node ../lit-dev-tools-esm/lib/dev-server.js --open",
       "dependencies": [
         "../lit-dev-tools-esm:build",
         "dev:build"
-      ],
-      "command": "node ../lit-dev-tools-esm/lib/dev-server.js --open"
+      ]
     },
     "dev:build:assets": {
       "dependencies": [
@@ -76,13 +76,17 @@
       ]
     },
     "fonts:manrope": {
+      "command": "rm -rf temp && mkdir -p site/fonts/manrope && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/manrope/ && cd ../.. && rm -rf temp",
       "files": [],
       "output": [
         "site/fonts/manrope"
-      ],
-      "command": "rm -rf temp && mkdir -p site/fonts/manrope && git clone https://github.com/sharanda/manrope.git temp/manrope && cd temp/manrope && git checkout 9ffbc349f4659065b62f780fe6e9d5a93518bd95 && cp fonts/web/*.woff2 ../../site/fonts/manrope/ && cd ../.. && rm -rf temp"
+      ]
     },
     "build:ts": {
+      "command": "tsc --build --pretty",
+      "dependencies": [
+        "../lit-dev-tools-esm:build:ts"
+      ],
       "files": [
         "src/**",
         "tsconfig.json",
@@ -91,13 +95,10 @@
       "output": [
         "lib"
       ],
-      "dependencies": [
-        "../lit-dev-tools-esm:build:ts"
-      ],
-      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "build:rollup": {
+      "command": "rollup -c",
       "dependencies": [
         "build:ts"
       ],
@@ -106,10 +107,10 @@
       ],
       "output": [
         "rollupout"
-      ],
-      "command": "rollup -c"
+      ]
     },
     "build:samples": {
+      "command": "node ../lit-dev-tools-esm/lib/generate-js-samples.js",
       "dependencies": [
         "../lit-dev-tools-esm:build"
       ],
@@ -119,8 +120,7 @@
       ],
       "output": [
         "samples/js/**"
-      ],
-      "command": "node ../lit-dev-tools-esm/lib/generate-js-samples.js"
+      ]
     }
   },
   "devDependencies": {

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -9,13 +9,11 @@
   "scripts": {
     "fonts:manrope": "wireit",
     "build": "wireit",
-    "build:eleventy": "wireit",
     "build:ts": "wireit",
     "build:rollup": "wireit",
     "build:samples": "wireit",
     "dev:build": "wireit",
     "dev:build:assets": "wireit",
-    "dev:build:eleventy": "wireit",
     "dev:serve": "wireit",
     "prod:build": "wireit",
     "prod:build:assets": "wireit"
@@ -23,13 +21,29 @@
   "wireit": {
     "build": {
       "dependencies": [
-        "build:eleventy"
-      ]
+        "prod:build:assets"
+      ],
+      "output": [
+        "_site"
+      ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
+      ],
+      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
     "dev:build": {
       "dependencies": [
-        "dev:build:eleventy"
-      ]
+        "dev:build:assets"
+      ],
+      "output": [
+        "_dev"
+      ],
+      "files": [
+        "site/**",
+        ".eleventy.js"
+      ],
+      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
     "prod:build": {
       "dependencies": [
@@ -47,32 +61,6 @@
         "dev:build"
       ],
       "command": "node ../lit-dev-tools-esm/lib/dev-server.js --open"
-    },
-    "build:eleventy": {
-      "dependencies": [
-        "prod:build:assets"
-      ],
-      "output": [
-        "_site"
-      ],
-      "files": [
-        "site/**",
-        ".eleventy.js"
-      ],
-      "command": "LITDEV_ENV=local NODE_OPTIONS=--experimental-vm-modules eleventy"
-    },
-    "dev:build:eleventy": {
-      "dependencies": [
-        "dev:build:assets"
-      ],
-      "output": [
-        "_dev"
-      ],
-      "files": [
-        "site/**",
-        ".eleventy.js"
-      ],
-      "command": "LITDEV_ENV=dev NODE_OPTIONS=--experimental-vm-modules eleventy"
     },
     "dev:build:assets": {
       "dependencies": [

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -30,7 +30,7 @@
       "output": [
         "lib"
       ],
-      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "start": {

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -36,7 +36,7 @@
     "start": {
       "dependencies": [
         "build",
-        "../lit-dev-content:build:eleventy"
+        "../lit-dev-content:build"
       ],
       "command": "node lib/server.js",
       "output": []

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -19,6 +19,7 @@
       ]
     },
     "build:ts": {
+      "command": "tsc --build --pretty",
       "dependencies": [
         "../lit-dev-tools-cjs:build"
       ],
@@ -30,15 +31,14 @@
       "output": [
         "lib"
       ],
-      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "start": {
+      "command": "node lib/server.js",
       "dependencies": [
         "build",
         "../lit-dev-content:build"
       ],
-      "command": "node lib/server.js",
       "output": []
     }
   },

--- a/packages/lit-dev-tests/package.json
+++ b/packages/lit-dev-tests/package.json
@@ -29,7 +29,7 @@
       "output": [
         "lib"
       ],
-      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "start": {

--- a/packages/lit-dev-tests/package.json
+++ b/packages/lit-dev-tests/package.json
@@ -18,6 +18,7 @@
   },
   "wireit": {
     "build": {
+      "command": "tsc --build --pretty",
       "dependencies": [
         "../lit-dev-server:build"
       ],
@@ -29,7 +30,6 @@
       "output": [
         "lib"
       ],
-      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "start": {
@@ -38,6 +38,7 @@
       ]
     },
     "test:integration": {
+      "command": "playwright install && playwright test --config=lib/playwright.config.js",
       "dependencies": [
         "build",
         "../lit-dev-content:build"
@@ -46,10 +47,10 @@
         "src/**/*.png",
         "lib/**/*.spec.js"
       ],
-      "output": [],
-      "command": "playwright install && playwright test --config=lib/playwright.config.js"
+      "output": []
     },
     "test:integration:update-golden-screenshots": {
+      "command": "playwright install && playwright test --config=lib/playwright.config.js --update-snapshots",
       "dependencies": [
         "build",
         "../lit-dev-content:build"
@@ -57,8 +58,7 @@
       "files": [],
       "output": [
         "src/**/*.png"
-      ],
-      "command": "playwright install && playwright test --config=lib/playwright.config.js --update-snapshots"
+      ]
     },
     "test:links": {
       "dependencies": [
@@ -67,6 +67,7 @@
       ]
     },
     "test:links:internal-and-external": {
+      "command": "run-p --race start test:links:cmd",
       "dependencies": [
         "build",
         "../lit-dev-content:build"
@@ -75,23 +76,22 @@
       "files": [
         "known-good-urls.txt"
       ],
-      "output": [],
-      "command": "run-p --race start test:links:cmd"
+      "output": []
     },
     "test:links:redirects": {
+      "command": "node lib/check-redirects.js",
       "dependencies": [
         "build",
         "../lit-dev-content:build"
       ],
       "files": [],
-      "output": [],
-      "command": "node lib/check-redirects.js"
+      "output": []
     },
     "test:links:cmd": {
+      "command": "wait-on tcp:6415 && node lib/check-broken-links.js",
       "dependencies": [
         "build"
-      ],
-      "command": "wait-on tcp:6415 && node lib/check-broken-links.js"
+      ]
     }
   },
   "dependencies": {

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -25,7 +25,7 @@
       "output": [
         "lib"
       ],
-      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "test": {

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -17,6 +17,7 @@
       ]
     },
     "build:ts": {
+      "command": "tsc --build --pretty",
       "files": [
         "src/**",
         "tsconfig.json",
@@ -25,16 +26,15 @@
       "output": [
         "lib"
       ],
-      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "test": {
+      "command": "uvu ./lib \".spec.js$\"",
       "dependencies": [
         "build"
       ],
       "files": [],
-      "output": [],
-      "command": "uvu ./lib \".spec.js$\""
+      "output": []
     }
   },
   "dependencies": {

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -51,7 +51,6 @@
     "@types/prettier": "^2.3.2",
     "@web/dev-server": "^0.1.6",
     "algoliasearch": "^4.14.2",
-    "chokidar": "^3.5.2",
     "co-body": "^6.1.0",
     "fast-glob": "^3.2.9",
     "lit-dev-server": "^0.0.0",

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -30,7 +30,7 @@
       "output": [
         "lib"
       ],
-      "command": "../../node_modules/.bin/tsc --build --pretty",
+      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "publish-search-index": {

--- a/packages/lit-dev-tools-esm/package.json
+++ b/packages/lit-dev-tools-esm/package.json
@@ -18,6 +18,7 @@
       ]
     },
     "build:ts": {
+      "command": "tsc --build --pretty",
       "dependencies": [
         "../lit-dev-server:build",
         "../lit-dev-tools-cjs:build"
@@ -30,10 +31,10 @@
       "output": [
         "lib"
       ],
-      "command": "tsc --build --pretty",
       "clean": "if-file-deleted"
     },
     "publish-search-index": {
+      "command": "node lib/upload-algolia-index.js",
       "dependencies": [
         "../lit-dev-content:build",
         "build"
@@ -41,8 +42,7 @@
       "files": [
         "lib/upload-algolia-index.js",
         "../lit-dev-content/_site/searchIndex.json"
-      ],
-      "command": "node lib/upload-algolia-index.js"
+      ]
     }
   },
   "dependencies": {

--- a/packages/lit-dev-tools-esm/src/generate-js-samples.ts
+++ b/packages/lit-dev-tools-esm/src/generate-js-samples.ts
@@ -43,7 +43,6 @@ const updateAndWriteProjectConfig = async (
   relPath: string,
   ignoreJsonError = false
 ) => {
-  console.log('writing config', relPath);
   const absPath = pathlib.join(TS_SAMPLES_DIR, relPath);
   const oldJson = await fs.readFile(absPath, 'utf8');
   let project: ProjectManifest;
@@ -89,7 +88,6 @@ const updateAndWriteProjectConfig = async (
  * server.
  */
 const symlinkProjectFile = async (relPath: string) => {
-  console.log('symlinking', relPath);
   const absPath = pathlib.join(TS_SAMPLES_DIR, relPath);
   const outPath = pathlib.join(JS_SAMPLES_DIR, relPath);
   await fs.mkdir(pathlib.dirname(outPath), {recursive: true});


### PR DESCRIPTION
Simplifies the build by using the new `service: true` and `cascade: false` settings in the latest preview release of Wireit.

https://github.com/google/wireit#services
https://github.com/google/wireit#execution-cascade

The top-level `dev` script should now be more reliable, and automatically starts up the gist server emulator too.

Also makes the output a little quieter by using eleventy's `--quiet` flag, and removing some logging we didn't really need in the sample generation script.

Fixes https://github.com/lit/lit.dev/issues/994