### PR TITLE
[infra] Make cleanup skip discord-bot revision

### DIFF
--- a/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
+++ b/packages/lit-dev-cloudbuild-cleanup/src/cleanup.ts
@@ -102,7 +102,11 @@ async function main() {
       );
     }
 
-    if (new Date(rev.metadata.creationTimestamp) > ONE_WEEK_AGO) {
+    if (
+      new Date(rev.metadata.creationTimestamp) > ONE_WEEK_AGO ||
+      // always keep revision for discord-bot
+      rev.metadata.name.startsWith('lit-dev-discord-bot')
+    ) {
       revisionsToKeep.add(rev.metadata.name);
     }
   }


### PR DESCRIPTION
The cloud build cleanup job has been failing since adding the discord bot as it tried to delete that revision while it had an active traffic tag. This PR modifies the script to add the discord bot revision to the set of revision to keep.

Tested by running the script in google cloud shell.