### PR TITLE
Revert "Revert "Add description about customizing event listener options in templates""

### DIFF
--- a/packages/lit-dev-content/site/docs/components/events.md
+++ b/packages/lit-dev-content/site/docs/components/events.md
@@ -42,6 +42,14 @@ private _handleTouchStart(e) { console.log(e.type) }
 
 </div>
 
+If you're not using decorators, you can customize event listener options by passing an object to the event listener expression. The object must have a `handleEvent()` method and can include any the options that would normally appear in the `options` argument to `addEventListener()`.
+
+```js
+render() {
+  return html`<button @click=${{handleEvent: () => this.onClick(), once: true}}>click</button>`
+}
+```
+
 ### Adding event listeners to the component or its shadow root
 
 To be notified of an event dispatched from the component's slotted children as well as children rendered into shadow DOM via the component template, you can add a listener to the component itself using the standard `addEventListener` DOM method. See [EventTarget.addEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) on MDN for full details.

--- a/packages/lit-dev-content/site/docs/components/events.md
+++ b/packages/lit-dev-content/site/docs/components/events.md
@@ -44,11 +44,16 @@ private _handleTouchStart(e) { console.log(e.type) }
 
 If you're not using decorators, you can customize event listener options by passing an object to the event listener expression. The object must have a `handleEvent()` method and can include any the options that would normally appear in the `options` argument to `addEventListener()`.
 
+[comment]: <> (The `raw` macro is necessary to prevent the double handlebar in the code sample from messing with the liquid templating syntax)
+{% raw %}
+
 ```js
 render() {
   return html`<button @click=${{handleEvent: () => this.onClick(), once: true}}>click</button>`
 }
 ```
+
+{% endraw %}
 
 ### Adding event listeners to the component or its shadow root
 


### PR DESCRIPTION
Reverts lit/lit.dev#1017
Fixes #1018

## Changes added

- Added `{% raw %}` macro around problematic syntax
- Added comment explaining why