### PR TITLE
Fix web.dev link

### DIFF
--- a/packages/lit-dev-content/site/tutorials/content/carousel/04.md
+++ b/packages/lit-dev-content/site/tutorials/content/carousel/04.md
@@ -52,7 +52,7 @@ info as its `detail`.
 
 Dispatch events when an element changes state based on user interaction, rather than when properties are set directly.
 
-See the [best practices doc on web.dev](https://web.dev/index.md/#events)
+See the [best practices doc on web.dev](https://web.dev/custom-elements-best-practices/#events)
 for more info.
 
 {% endaside %}


### PR DESCRIPTION
[maintainer note]: Fixes a bad link from `https://web.dev/index.md/#events` to `https://web.dev/custom-elements-best-practices/#events`