### PR TITLE
Updates for removed global DOM shim

### DIFF
--- a/packages/lit-dev-content/site/docs/ssr/dom-emulation.md
+++ b/packages/lit-dev-content/site/docs/ssr/dom-emulation.md
@@ -8,24 +8,14 @@ eleventyNavigation:
 
 {% labs-disclaimer %}
 
-In the DOM shim that ships with Lit SSR, only the minimal DOM interfaces needed to define and register components are implemented. These include a few key DOM classes and a roughly functioning `CustomElementRegistry`.
+When running in Node, Lit automatically imports and uses a set of DOM shims, and defines the `customElements` global. Only the minimal DOM interfaces needed to define and register components are implemented. These include a few key DOM classes and a roughly functioning `CustomElementRegistry`.
 
-Below lists all the properties, classes, and methods on the `window` object added to `globalThis`. The contents of `window` are also assigned onto `globalThis`. ✅ signifies item is implemented to be functionally the same as in the browser.
+✅ signifies item is implemented to be functionally the same as in the browser.
 
 <!-- TODO(augustinekim) Consider replacing emojis below with icons https://github.com/lit/lit.dev/pull/880#discussion_r944821511 -->
 | Property | Notes |
 |-|-|
-| `Element` | ⚠️ Empty class |
-| `HTMLElement` | ⚠️ Partial <table><tbody><tr><td>`attributes`</td><td>✅</td><tr><td>`shadowRoot`</td><td>⚠️ Returns `{host: this}` if `attachShadow()` was called with `{mode: 'open'}`</td><tr><td>`setAttribute()`</td><td>✅</td><tr><td>`removeAttribute()`</td><td>✅</td><tr><td>`hasAttribute()`</td><td>✅</td><tr><td>`attachShadow()`</td><td>⚠️ Returns `{host: this}`</td><tr><td>`getAttribute()`</td><td>✅</td></tr></tbody></table> |
-| `Document` | ⚠️ Partial <table><tbody><tr><td>`adoptedStyleSheets`</td><td>⚠️ Getter only returning `[]`</td><tr><td>`createTreeWalker()`</td><td>⚠️ Returns `{}`</td><tr><td>`createTextNode()`</td><td>⚠️ Returns `{}`</td><tr><td>`createElement()`</td><td>⚠️ Returns `{}`</td></tr></tbody></table> |
-| `document` | Instance of `Document` |
-| `cssStyleSheet` | ⚠️ Partial <table><tbody><tr><td>`replace()`</td><td>⚠️ No op</td></tr></tbody></table> |
-| `ShadowRoot` | ⚠️ Empty class |
+| `Element` | ⚠️ Partial <table><tbody><tr><td>`attributes`</td><td>✅</td><tr><td>`shadowRoot`</td><td>⚠️ Returns `{host: this}` if `attachShadow()` was called with `{mode: 'open'}`</td><tr><td>`setAttribute()`</td><td>✅</td><tr><td>`removeAttribute()`</td><td>✅</td><tr><td>`hasAttribute()`</td><td>✅</td><tr><td>`attachShadow()`</td><td>⚠️ Returns `{host: this}`</td><tr><td>`getAttribute()`</td><td>✅</td></tr></tbody></table> |
+| `HTMLElement` | ⚠️ Empty class |
 | `CustomElementRegistry` | <table><tbody><tr><td>`define()`</td><td>✅</td></tr><tr><td>`get()`</td><td>✅</td></tr></tbody></table> |
 | `customElements` | Instance of `CustomElementRegistry` |
-| `btoa()` | ✅ |
-| `fetch()` | `node-fetch` |
-| `location` | `new URL('http://localhost')` |
-| `MutationObserver` | ⚠️ Partial <table><tbody><tr><td>`observe()`</td><td>⚠️ No op</td></tr></tbody></table> |
-| `requestAnimationFrame()` | ⚠️ No op |
-| `window` | ✅ Self reference |

--- a/packages/lit-dev-content/site/docs/ssr/server-usage.md
+++ b/packages/lit-dev-content/site/docs/ssr/server-usage.md
@@ -25,7 +25,7 @@ Rendering with VM modules allows each render request to have its own context wit
 The `render()` method takes a renderable value, usually a Lit template result, and returns an iterable of strings that can be streamed or concatenated to a string for a response.
 
 ```js
-import {render} from '@lit-labs/ssr/lib/render-lit-html.js';
+import {render} from '@lit-labs/ssr';
 import {myTemplate} from './my-template.js';
 
 // ...

--- a/packages/lit-dev-content/site/docs/ssr/server-usage.md
+++ b/packages/lit-dev-content/site/docs/ssr/server-usage.md
@@ -8,23 +8,24 @@ eleventyNavigation:
 
 {% labs-disclaimer %}
 
-In order to render custom elements in Node, they must first be defined and registered with the global `customElements` API, which is a browser-only feature. As such, Lit SSR includes a DOM shim that provides the minimal DOM APIs necessary to render Lit on the server. (For a list of emulated APIs, see [DOM emulation](/docs/ssr/dom-emulation).)
+In order to render custom elements in Node, they must first be defined and registered with the global `customElements` API, which is a browser-only feature. As such, when Lit runs in Node, it automatically uses a set of minimal DOM APIs necessary to render Lit on the server, and defines the `customElements` global. (For a list of emulated APIs, see [DOM emulation](/docs/ssr/dom-emulation).)
 
-Lit SSR provides two different ways of rendering custom elements server-side: rendering in the [global scope](#global-scope) or via [VM modules](#vm-module). VM modules utilizes Node's [`vm.Module`](https://nodejs.org/api/vm.html#class-vmmodule) API, which enables running code within V8 Virtual Machine contexts. The two methods differ primarily in how the DOM shim is loaded.
+Lit SSR provides two different ways of rendering custom elements server-side: rendering in the [global scope](#global-scope) or via [VM modules](#vm-module). VM modules utilizes Node's [`vm.Module`](https://nodejs.org/api/vm.html#class-vmmodule) API, which enables running code within V8 Virtual Machine contexts. The two methods differ primarily in how global state, such as the custom elements registry, are shared.
 
-When rendering in the global scope, shimmed DOM globals (like `window`, `HTMLElement`, `customElements`, etc.) are added directly to the Node.js global scope. This may cause unintended behaviors for other libraries. For instance, some libraries try to detect the running environment by checking for the presence of `window` in the global scope. In addition, all render requests also share the same global custom element registry, and any data that might be stored globally.
+When rendering in the global scope, a single shared `customElements` registry will be defined and shared across all render requests, along with any other global state that your component code might set.
 
-Rendering with VM modules allows each render request to have its own context with a separate global from the main Node process. DOM emulation is only installed within that context, any custom elements being registered are registered in that context, and any global data is contained within that context. VM modules are an experimental Node feature.
+Rendering with VM modules allows each render request to have its own context with a separate global from the main Node process. The `customElements` registry will only be installed within that context, and other global state will also be isolated to that context. VM modules are an experimental Node feature.
 
-| Global | VM Module |
-|-|-|
-| Pros:<ul><li>Easy to use. Can import component modules directly and call `render()` with templates.</li></ul>Cons:<ul><li>Introduces DOM shim to global scope, potentially causing issues with other libraries.</li><li>Custom elements are registered in a shared registry across different render requests.</li></ul> | Pros:<ul><li>Does not introduce DOM shim to the global scope.</li><li>Isolates contexts across different render requests.</li></ul>Cons:<ul><li>Less intuitive usage. Need to write and specify a module file with a function to call.</li><li>Slower due the module graph needing to be re-evaluated per request.</li></ul> |
+| Global                                                                                                                                                                                                                    | VM Module                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pros:<ul><li>Easy to use. Can import component modules directly and call `render()` with templates.</li></ul>Cons:<ul><li>Custom elements are registered in a shared registry across different render requests.</li></ul> | Pros:<ul><li>Isolates contexts across different render requests.</li></ul>Cons:<ul><li>Less intuitive usage. Need to write and specify a module file with a function to call.</li><li>Slower due the module graph needing to be re-evaluated per request.</li></ul> |
 
 ## Global Scope
+
 The `render()` method takes a renderable value, usually a Lit template result, and returns an iterable of strings that can be streamed or concatenated to a string for a response.
 
 ```js
-import {render} from '@lit-labs/ssr/lib/render-with-global-dom-shim.js';
+import {render} from '@lit-labs/ssr/lib/render-lit-html.js';
 import {myTemplate} from './my-template.js';
 
 // ...
@@ -37,11 +38,8 @@ app.use(async (ctx) => {
 });
 ```
 
-Importing `render()` from `@lit-labs/ssr/lib/render-with-global-dom-shim.js` will also install a minimal [DOM shim](/docs/ssr/dom-emulation) in the global scope necessary for `lit` and component definitions to be loaded for rendering the components server-side. It must be imported before any `lit` libraries or component.
-
-Note: Loading the DOM shim globally introduces `window` into the global space which some libraries might look for in determining whether the code is running in a browser environment. If this becomes an issue, consider using SSR with [VM Module](#vm-module) instead.
-
 ## VM Module
+
 Lit also provide a way to load application code into, and render from, a separate VM context with its own global object.
 
 ```js
@@ -54,23 +52,49 @@ export const renderTemplate = (someData) => {
 };
 ```
 
-```js
+{% switchable-sample %}
+
+```ts
 // server.js
-import {renderModule} from '@lit-labs/ssr/lib/render-module.js';
+import {ModuleLoader} from '@lit-labs/ssr/lib/module-loader.js';
 
 // ...
 
 // within a Koa middleware, for example
 app.use(async (ctx) => {
-  const ssrResult = await renderModule(
+  const moduleLoader = new ModuleLoader();
+  const importResult = await moduleLoader.importModule(
     './render-template.js',  // Module to load in VM context
-    import.meta.url,         // Referrer URL for module
-    'renderTemplate',        // Function to call
-    [{some: "data"}]         // Arguments to function
+    import.meta.url          // Referrer URL for module
   );
+  const {renderTemplate} = importResult.module.namespace
+    as typeof import('./render-template.js')
+  const ssrResult = await renderTemplate({some: "data"});
   ctx.type = 'text/html';
   ctx.body = Readable.from(ssrResult);
 });
 ```
+
+```js
+// server.js
+import {ModuleLoader} from '@lit-labs/ssr/lib/module-loader.js';
+
+// ...
+
+// within a Koa middleware, for example
+app.use(async (ctx) => {
+  const moduleLoader = new ModuleLoader();
+  const importResult = await moduleLoader.importModule(
+    './render-template.js',  // Module to load in VM context
+    import.meta.url          // Referrer URL for module
+  );
+  const {renderTemplate} = importResult.module.namespace;
+  const ssrResult = await renderTemplate({some: "data"});
+  ctx.type = 'text/html';
+  ctx.body = Readable.from(ssrResult);
+});
+```
+
+{% endswitchable-sample %}
 
 Note: Using this feature requires Node 14+ and passing the `--experimental-vm-modules` flag to Node because of its use of experimental VM modules for creating a module-compatible VM context.


### PR DESCRIPTION
This updates the lit.dev SSR documentation to account for the changes in https://github.com/lit/lit/pull/3522, namely the removal of the global DOM shim.