### PR TITLE
fix typo in docs/components/lifecycle.md

### DIFF
--- a/packages/lit-dev-content/site/docs/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/components/lifecycle.md
@@ -421,7 +421,7 @@ In some cases, code may throw in unexpected places. As a fallback, you can add a
 
 ```js
 window.onunhandledrejection = function(e) {
-  /* handle error *
+  /* handle error */
 }
 ```
 


### PR DESCRIPTION
This fixed the invalid comment.