### PR TITLE
Add context doc

### DIFF
--- a/packages/lit-dev-content/site/docs/api/index.md
+++ b/packages/lit-dev-content/site/docs/api/index.md
@@ -3,7 +3,7 @@ title: API
 eleventyNavigation:
   title: API
   key: API
-  order: 8
+  order: 9
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -137,7 +137,7 @@ This means that there are two main ways to create a context object:
 1. With a value that is globally unique, like an object (`{}`)  or symbol (`Symbol()`)
 2. With a value that is not globally unique, so that it can be equal under strict equality, like a string (`'logger'`) or _global_ symbol (`Symbol.for('logger')`).
 
-If you want two _separate_ `createContext()` calls to referrer to the same
+If you want two _separate_ `createContext()` calls to refer to the same
 context, then use a key that will by equal under strict equality like a
 string:
 ```ts

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -135,7 +135,7 @@ Context objects are used by providers to match a context request event to a valu
 
 This means that there are two main ways to create a context object:
 1. With a value that is globally unique, like an object (`{}`)  or symbol (`Symbol()`)
-2. With a value that is no globally unique, so that it can be equal under strict equality, like a string (`'logger'`) or _global_ symbol (`Symbol.for('logger')`).
+2. With a value that is not globally unique, so that it can be equal under strict equality, like a string (`'logger'`) or _global_ symbol (`Symbol.for('logger')`).
 
 If you want two _separate_ `createContext()` calls to referrer to the same
 context, then use a key that will by equal under strict equality like a

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   labs: true
 ---
 
+{% labs-disclaimer %}
+
 Context is a way of making data available to entire component subtrees without having to manually bind properties to every component. The data is "contextually" available, such that ancestor elements in between a provider of data and consumer of data aren't event aware of it.
 
 Lit's context implementation is part of [Lit Labs](/docs/libraries/labs/) and available in the `@lit-labs/context` package:

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -17,7 +17,7 @@ Lit's context implementation is part of [Lit Labs](/docs/libraries/labs/) and av
 npm i @lit-labs/context
 ```
 
-Context is useful for data that needs to be consumed by a wide variety and large number of components - things like an apps data store, the current user, a UI theme - or when data-binding isn't an option, such as when an element needs to provide data to its light DOM children.
+Context is useful for data that needs to be consumed by a wide variety and large number of components - things like an app's data store, the current user, a UI theme - or when data-binding isn't an option, such as when an element needs to provide data to its light DOM children.
 
 Context is very in ways to React's Context, or to dependency injection systems like Angular's, with some important differences that enable interoperability across different web components libraries, frameworks and plain JavaScript.
 
@@ -79,7 +79,7 @@ Lit's context is based on the [Context Community Protocol](https://github.com/we
 
 This protocol enables interoperability between elements (or even non-element code) regardless of how they were built. Via the context protocol, a Lit-based element can provide data to a Stencil consumer, or vice versa.
 
-The Context Protocol is based on DOM events. A consumer fires a `context-request` event that carries the context key that it wants, and any element above it can listen for the `context-request` event and provide data if it has it for that context key.
+The Context Protocol is based on DOM events. A consumer fires a `context-request` event that carries the context key that it wants, and any element above it can listen for the `context-request` event and provide data for that context key.
 
 `@lit-labs/context` implements this event-based protocol and makes it available via a few reactive controllers and decorators.
 
@@ -105,7 +105,7 @@ When a consumer requests data for a context, it can tell the provider that it wa
 
 Every usage of context must have a context object to coordinate the data request. This context object represents the identity and type of data that is provided.
 
-Context objects are created with the `createContext()` function. It is reccomended to put context objects in their own module so that they're independent of providers and consumers, unless the context is tightly coupled to a specific provider or consumer.
+Context objects are created with the `createContext()` function. It is reccomended to put context objects in their own module so that they're independent of providers and consumers.
 
 `createContext()` takes a name, which is useful for debugging.
 
@@ -267,7 +267,7 @@ One way of building a theme system would be to define a `Theme` type that contai
 
 ### HTML-based plugins
 
-Context can be used to provide data to light DOM children, which typically aren't created from the same declarative templates with databinding available.
+Context can be used to pass data from a parent to its light DOM children. Since the parent does not create the children, it cannot leverage template-based data-binding to pass data to its children, but can listen to and respond to `context-request` events.
 
 For example, consider a code editor element with plugins for different language modes. You can make a plain HTML system for adding features using context:
 

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -4,8 +4,7 @@ eleventyNavigation:
   key: Context
   parent: Components
   order: 9
-versionLinks:
-  v1: components/context/
+  labs: true
 ---
 
 Context is a way of making data available to entire component subtrees without having to manually bind properties to every component. The data is "contextually" available, such that ancestor elements in between a provider of data and consumer of data aren't event aware of it.

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -1,0 +1,249 @@
+---
+title: Context
+eleventyNavigation:
+  key: Context
+  parent: Components
+  order: 9
+versionLinks:
+  v1: components/context/
+---
+
+Context is a way of making data available to entire component subtrees without having to manually bind properties to every component. The data is "contextually" available, such that ancestor elements in between a provider of data and consumer of data aren't event aware of it.
+
+Lit's context implementation is part of Lit Labs and available in the `@lit-labs/context` package:
+
+```bash
+npm i @lit-labs/context
+```
+
+Context is useful for data that needs to be consumed by a wide variety and large number of components - things like an apps data store, the current user, a UI theme - or when data-binding isn't an option, such as when an element needs to provide data to its light DOM children.
+
+Context is very in ways to React's Context, or to dependency injection systems like Angular's, with some important differences that enable interoperability across different web components libraries, frameworks and plain JavaScript.
+
+## Example
+
+Using context involves a _context object_ (sometimes called a key), a _provider_ and a _consumer_, which communicate using the context object.
+
+Context definition (`logger-context.ts`):
+```ts
+import {createContext} from '@lit-labs/context';
+import type {Logger} from 'my-logging-library';
+export type {Logger} from 'my-logging-library';
+export const loggerContext = createContext<Logger>('logger');
+```
+
+Provider:
+```ts
+import {LitElement, property, html} from 'lit';
+import {provide} from '@lit-labs/context';
+
+import {Logger} from 'my-logging-library';
+import {loggerContext} from './logger-context.js';
+
+@customElement('my-app')
+class MyApp extends LitElement {
+
+  @provide({context: loggerContext})
+  logger = new Logger();
+
+  render() {
+    return html`...`;
+  }
+}
+```
+
+Consumer:
+```ts
+import {LitElement, property} from 'lit';
+import {consume} from '@lit-labs/context';
+
+import {type Logger, loggerContext} from './logger.js';
+
+export class MyElement extends LitElement {
+
+  @consume({context: loggerContext})
+  @property({attribute: false})
+  public logger?: Logger;
+
+  private doThing() {
+    this.logger?.log('A thing was done');
+  }
+}
+```
+
+## Key Concepts
+
+### Context Protocol
+Lit's context is based on the [Context Community Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md) by the W3C's [Web Components Community Group](https://www.w3.org/community/webcomponents/).
+
+This protocol enables interoperability between elements (or even non-element code) regardless of how they were built. Via the context protocol, a Lit-based element can provide data to a Stencil consumer, or vice versa.
+
+The Context Protocol is based on DOM events. A consumer fires a `context-request` event that carries the context key that it wants, and any element above it can listen for the `context-request` event and provide data if it has it for that context key.
+
+`@lit-labs/context` implements this event-based protocol and makes it available via a few reactive controllers and decorators.
+
+### Context Objects
+
+Contexts are identified by _context objects_ or _context keys_. They are objects that represent some potential data to be shared by the context object identity. You can think of them as similar to Map keys.
+
+### Providers
+
+Providers are usually elements (but can be any event handler code) that provide data for specific context keys.
+
+### Consumers
+
+Consumers request data for specific context keys.
+
+### Subscriptions
+
+When a consumer requests data for a context, it can tell the provider that it wants to _subscribe_ to changes in the context. If the provider has new data, the consumer will be notified and can automatically update.
+
+## Usage
+
+### Defining a context
+
+Every usage of context must have a context object to coordinate the data request. This context object represents the identity and type of data that is provided.
+
+Context objects are created with the `createContext()` function. It is reccomended to put context objects in their own module so that they're independent of providers and consumers, unless the context is tightly coupled to a specific provider or consumer.
+
+`createContext()` takes a name, which is useful for debugging.
+
+Context objects in TypeScript are also typed: they have a generic type parameter that specifies the type of data provided with the context.
+
+`my-context.ts`:
+```ts
+import {createContext} from '@lit-labs/context';
+export interface MyData {
+  // ...
+}
+export const loggerContext = createContext<MyData>('my-data');
+```
+
+### Providing a context
+
+There are two ways in `@lit-labs/context` to provide a context value: the ContextProvider controller and the `@provide()` decorator.
+
+#### `@provide()`
+
+The `@provide()` decorator is the easiest way to provide a value if you're using decorators. It creates a ContextProvider controller for you.
+
+Decorate a property with `@provide()` and give it the context key:
+```ts
+import {LitElement, html} from 'lit';
+import {property} from 'lit/decorators.js';
+import {provide} from '@lit-labs/context';
+import {myContext, MyData} from './my-context.js';
+
+class MyApp extends LitElement {
+  @provide({context: myContext})
+  myData: MyData;
+}
+```
+
+You can make the property also a reactive property with `@property()` or `@state()` so that setting it will update the provider element as well as context consumers.
+
+```ts
+  @provide({context: myContext})
+  @property({attribute: false})
+  myData: MyData;
+```
+
+Context properties are often intended to be private. You can make private properties reactive with `@state()`:
+
+```ts
+  @provide({context: myContext})
+  @state()
+  private _myData: MyData;
+```
+
+Making a context property public lets an element provide a public field to its child tree:
+
+```ts
+  html`<my-provider-element .myData=${someData}>`
+```
+
+#### ContextProvider
+
+`ContextProvider` is a reactive controller that manages `context-request` event handlers for you.
+
+```ts
+import {LitElement, html} from 'lit';
+import {ContextProvider} from '@lit-labs/context';
+import {myContext, MyData} from './my-context.js';
+
+export class MyApp extends LitElement {
+  private _provider = new ContextProvider(this, myContext);
+}
+```
+
+ContextProvider can take an initial value in its constructor:
+
+```ts
+  private _provider = new ContextProvider(this, myContext, initialData);
+```
+
+Or you can call `setValue()`:
+```ts
+  this._provider.setValue(myData);
+```
+
+### Consuming a context
+
+#### `@consume()` decorator
+
+The `@consume()` decorator is the easiest way to consume a value if you're using decorators. It creates a ContextConsumer controller for you.
+
+Decorate a property with `@consume()` and give it the context key:
+```ts
+import {LitElement, html} from 'lit';
+import {property} from 'lit/decorators.js';
+import {provide} from '@lit-labs/context';
+import {myContext, MyData} from './my-context.js';
+
+class MyElement extends LitElement {
+  @consume({context: myContext})
+  myData: MyData;
+}
+```
+
+When this element is connected to the document, it will automatically fire a `context-request` event, get a provided value, assign it to the property, and trigger an update of the element.
+
+#### ContextConsumer
+
+ContextConsumer is a reactive controller that manages dispatching the `context-request` event for you. The controller will cause the host element to update when new values are provided. The provided value is then available at the `.value` property of the controller.
+
+```ts
+import {LitElement, property} from 'lit';
+import {ContextConsumer} from '@lit-labs/context';
+import {Logger, loggerContext} from './logger.js';
+
+export class MyElement extends LitElement {
+  private _myData = new ContextConsumer(this, myContext);
+
+  render() {
+    const myData = this._myData.value;
+    return html`...`;
+  }
+}
+```
+
+#### Subscribing to contexts
+
+Consumers can subscribe to context values so that if a provider has a new value, it can give it to all subscribed consumers, causing them to update.
+
+You can subscribe with the `@consume()` decorator:
+
+```ts
+  @consume({context: myContext, subscribe: true})
+  myData: MyData;
+```
+
+and the ContextConsumer controller:
+
+```ts
+  private _myData = new ContextConsumer(this,
+    myContext,
+    undedined, /* callback */
+    true /* subscribe */
+  );
+```

--- a/packages/lit-dev-content/site/docs/components/context.md
+++ b/packages/lit-dev-content/site/docs/components/context.md
@@ -9,7 +9,7 @@ eleventyNavigation:
 
 Context is a way of making data available to entire component subtrees without having to manually bind properties to every component. The data is "contextually" available, such that ancestor elements in between a provider of data and consumer of data aren't event aware of it.
 
-Lit's context implementation is part of Lit Labs and available in the `@lit-labs/context` package:
+Lit's context implementation is part of [Lit Labs](/docs/libraries/labs/) and available in the `@lit-labs/context` package:
 
 ```bash
 npm i @lit-labs/context

--- a/packages/lit-dev-content/site/docs/data/context.md
+++ b/packages/lit-dev-content/site/docs/data/context.md
@@ -2,8 +2,8 @@
 title: Context
 eleventyNavigation:
   key: Context
-  parent: Components
-  order: 9
+  parent: Managing Data
+  order: 1
   labs: true
 ---
 

--- a/packages/lit-dev-content/site/docs/data/index.md
+++ b/packages/lit-dev-content/site/docs/data/index.md
@@ -1,10 +1,8 @@
 ---
-title: Related libraries
+title: Managing Data
 eleventyNavigation:
-  key: Related libraries
-  order: 11
-versionLinks:
-  v1: lit-html/introduction/
+  key: Managing Data
+  order: 5
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/libraries/labs.md
+++ b/packages/lit-dev-content/site/docs/libraries/labs.md
@@ -41,7 +41,7 @@ A package containing controllers and decorators for using the [Context Protocol]
 </td>
 <td class="labs-table-links">
 
-[📄&nbsp;Docs](/docs/components/context/ "Docs")<br>[💬&nbsp;Feedback](https://github.com/lit/lit/discussions/3302 "Feedback")<br>[🐞&nbsp;Issues](https://github.com/lit/lit/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+%5Blabs%2Fcontext%5D "Issues")
+[📄&nbsp;Docs](/docs/data/context/ "Docs")<br>[💬&nbsp;Feedback](https://github.com/lit/lit/discussions/3302 "Feedback")<br>[🐞&nbsp;Issues](https://github.com/lit/lit/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+%5Blabs%2Fcontext%5D "Issues")
 
 </td>
 </tr>

--- a/packages/lit-dev-content/site/docs/libraries/labs.md
+++ b/packages/lit-dev-content/site/docs/libraries/labs.md
@@ -41,7 +41,7 @@ A package containing controllers and decorators for using the [Context Protocol]
 </td>
 <td class="labs-table-links">
 
-[📄&nbsp;Docs](https://github.com/lit/lit/tree/main/packages/labs/context#readme "Docs")<br>[💬&nbsp;Feedback](https://github.com/lit/lit/discussions/3302 "Feedback")<br>[🐞&nbsp;Issues](https://github.com/lit/lit/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+%5Blabs%2Fcontext%5D "Issues")
+[📄&nbsp;Docs](/docs/components/context/ "Docs")<br>[💬&nbsp;Feedback](https://github.com/lit/lit/discussions/3302 "Feedback")<br>[🐞&nbsp;Issues](https://github.com/lit/lit/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+%5Blabs%2Fcontext%5D "Issues")
 
 </td>
 </tr>

--- a/packages/lit-dev-content/site/docs/localization/index.md
+++ b/packages/lit-dev-content/site/docs/localization/index.md
@@ -2,7 +2,7 @@
 title: Localization
 eleventyNavigation:
   key: Localization
-  order: 6
+  order: 7
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/releases/index.md
+++ b/packages/lit-dev-content/site/docs/releases/index.md
@@ -2,7 +2,7 @@
 title: Releases
 eleventyNavigation:
   key: Releases
-  order: 9
+  order: 10
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/resources/index.md
+++ b/packages/lit-dev-content/site/docs/resources/index.md
@@ -2,7 +2,7 @@
 title: Resources
 eleventyNavigation:
   key: Resources
-  order: 11
+  order: 12
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/ssr/index.md
+++ b/packages/lit-dev-content/site/docs/ssr/index.md
@@ -2,7 +2,7 @@
 title: Server rendering
 eleventyNavigation:
   key: Server rendering
-  order: 7
+  order: 8
   labs: true
 ---
 

--- a/packages/lit-dev-content/site/docs/tools/index.md
+++ b/packages/lit-dev-content/site/docs/tools/index.md
@@ -3,7 +3,7 @@ title: Tools and workflows
 eleventyNavigation:
   title: Tools and workflows
   key: Tools
-  order: 5
+  order: 6
 ---
 
 <!-- This file exists only to create a section heading.


### PR DESCRIPTION
This adds a *Components > Context* page.

I'm not sure that's the best place in the long term, but for the next single page in component concepts it makes sense. I think I'd rather have a *Managing Data* section that also includes state managers, some conceptual information about difference ways to get state, maybe Task, etc. We could try to add that section now with just *Context* in it.