### PR TITLE
[labs/context] Fix typo

### DIFF
--- a/packages/lit-dev-content/site/docs/data/context.md
+++ b/packages/lit-dev-content/site/docs/data/context.md
@@ -430,12 +430,12 @@ A ReactiveController which adds context consuming behavior to a custom element b
 **Import**:
 
 ```ts
-import {ContextProvider} from '@lit-labs/context';
+import {ContextConsumer} from '@lit-labs/context';
 ```
 
 **Constructor**:
 ```ts
-ContextProvider(
+ContextConsumer(
   host: HostElement,
   context: C,
   callback?: (value: ContextType<C>, dispose?: () => void) => void,


### PR DESCRIPTION
Replaced `ContextProvider` with `ContextConsumer` where appropriate.