### PR TITLE
Add frameworks section with React

### DIFF
--- a/packages/lit-dev-content/samples/examples/react-basics/demo-greeting.ts
+++ b/packages/lit-dev-content/samples/examples/react-basics/demo-greeting.ts
@@ -6,6 +6,9 @@ export class DemoGreeting extends LitElement {
   @property() name = 'Somebody';
 
   render() {
-    return html`Hello, ${this.name}!`;
+    return html`
+      <p>Hello, ${this.name}!</p>
+      <p>Checkout our <a href="https://lit.dev/docs/frameworks/react/" target="_blank" rel="noopener noreferrer">React framework docs</a>!</p>
+    `;
   }
 }

--- a/packages/lit-dev-content/site/docs/api/index.md
+++ b/packages/lit-dev-content/site/docs/api/index.md
@@ -3,7 +3,7 @@ title: API
 eleventyNavigation:
   title: API
   key: API
-  order: 9
+  order: 10
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/frameworks/index.md
+++ b/packages/lit-dev-content/site/docs/frameworks/index.md
@@ -1,8 +1,8 @@
 ---
-title: Framework integration
+title: Frameworks
 eleventyNavigation:
-  key: Framework integration
-  order: 12
+  key: Frameworks
+  order: 8
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/frameworks/index.md
+++ b/packages/lit-dev-content/site/docs/frameworks/index.md
@@ -1,0 +1,9 @@
+---
+title: Framework integration
+eleventyNavigation:
+  key: Framework integration
+  order: 12
+---
+
+<!-- This file exists only to create a section heading.
+     Its output is deleted by the Eleventy build process. -->

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -98,7 +98,7 @@ To render the child to a specific named slot, the standard `slot` attribute can 
 </MyElementComponent>
 ```
 
-Since React components cannot have a `slot` attribute, they will need to be wrapped with another container element. Giving it a `display: contents;` style will make this container disappear.
+Since React components are not themselves HTML elements, they usually cannot directly have a `slot` attribute. To render into a named slot, the component will need to be wrapped with a container element that has a `slot` attribute. If a wrapper element interferes with styling, like for grid and flexbox layouts, giving it a `display: contents;` style ([See MDN for details](https://developer.mozilla.org/en-US/docs/Web/CSS/display#box)) will remove the container from rendering, and only render its children.
 
 ```jsx
 <MyElementComponent>
@@ -112,22 +112,22 @@ Try it out in the [React slots playground example](/playground/#sample=examples/
 
 #### Typing event handler props
 
-The parameter type for the event handler prop can be refined by type casting the event name in the `events` options with the provided `EventName` utility type. Non-casted event names will fall back to the `Event` type.
+In TypeScript, the event type can be specified by casting the event name to the `EventName` utility type. This is a good practice to do so that React users will get the most accurate types for their event callbacks.
+
+The `EventName` type is a string that takes an event interface as a type parameter. Here we cast the `'my-event'` name to an `EventName<MyEvent>` to provide the right event type:
 
 ```ts
-import type {EventName} from '@lit-labs/react';
 
 import React from 'react';
 import {createComponent} from '@lit-labs/react';
-import {MyElement} from './my-element.js';
+import {MyElement, type EventName} from './my-element.js';
 
 export const MyElementComponent = createComponent({
   tagName: 'my-element',
   elementClass: MyElement,
   react: React,
   events: {
-    onClick: 'pointerdown' as EventName<PointerEvent>,
-    onChange: 'input',
+    onMyEvent: 'my-event' as EventName<MyEvent>,
   },
 });
 ```
@@ -136,11 +136,8 @@ With the casting done above, a `PointerEvent` is expected for the parameter of t
 
 ```tsx
 <MyElementComponent
-  onClick={(e: PointerEvent) => {
-    // handle click
-  }}
-  onChange={(e: Event) => {
-    // handle change
+  onMyEvent={(e: MyEvent) => {
+    console.log(e.myEventData);
   }}
 />
 ```

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -161,7 +161,12 @@ See the [mouse controller example](../../composition/controllers/#example:-mouse
 
 ### How it works
 
-`useController()` uses `useState` to create and store an instance of a controller and a `ReactControllerHost`. It then calls the controller's lifecycle from the hook body and `useLayoutEffect` callbacks, emulating the `ReactiveElement` lifecycle as closely as possible. `ReactControllerHost` implements `addController` so that controller composition works and nested controller lifecycles are called correctly. `ReactControllerHost` also implements `requestUpdate` by calling a `useState` setter, so that a controller with new renderable state can cause its host component to re-render.
+`useController()` creates a custom host object for the controller passed to it and drives the controller's lifecycle by using React hooks.
+
+- `useState()` is used to store an instance of a controller and a `ReactControllerHost`
+- The hook body and `useLayoutEffect()` callbacks emulate the `ReactiveElement` lifecycle as closely as possible.
+- `ReactControllerHost` implements `addController()` so that controller composition works and nested controller lifecycles are called correctly.
+- `ReactControllerHost` also implements `requestUpdate()` by calling a `useState()` setter, so that a controller can cause its host component to re-render.
 
 Controller timings are implemented as follows:
 

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -65,6 +65,12 @@ After defining the React component, you can use it just as you would any other R
 />
 ```
 
+{% aside "positive" "no-header" %}
+
+See it in action in the [React playground examples](/playground/#sample=examples/react-basics).
+
+{% endaside %}
+
 #### Options
 
 `createComponent` takes an options object with the following properties:
@@ -73,6 +79,36 @@ After defining the React component, you can use it just as you would any other R
 - `elementClass`: The custom element class.
 - `react`: The imported `React` object. This is used to create the wrapper component with the user supplied `React`. This can also be an import of `preact-compat`.
 - `events`: An object that maps an event handler prop to an event name fired by the custom element.
+
+#### Using slots
+
+Children of component created with `createComponent()` will render to the default slot of the custom element.
+
+```jsx
+<MyElementComponent>
+  <p>This will render in the default slot.</p>
+</MyElementComponent>
+```
+
+To render the child to a specific named slot, the standard `slot` attribute can be added.
+
+```jsx
+<MyElementComponent>
+  <p slot="foo">This will render in the slot named "foo".</p>
+</MyElementComponent>
+```
+
+Since React components cannot have a `slot` attribute, they will need to be wrapped with another container element. Giving it a `display: contents;` style will make this container disappear.
+
+```jsx
+<MyElementComponent>
+  <div slot="foo" style="display: contents;">
+    <ReactComponent />
+  </div>
+</MyElementComponent>
+```
+
+Try it out in the [React slots playground example](/playground/#sample=examples/react-slots).
 
 #### Typing event handler props
 
@@ -167,15 +203,3 @@ See the [mouse controller example](../../composition/controllers/#example:-mouse
 - The hook body and `useLayoutEffect()` callbacks emulate the `ReactiveElement` lifecycle as closely as possible.
 - `ReactControllerHost` implements `addController()` so that controller composition works and nested controller lifecycles are called correctly.
 - `ReactControllerHost` also implements `requestUpdate()` by calling a `useState()` setter, so that a controller can cause its host component to re-render.
-
-Controller timings are implemented as follows:
-
-| Controller API   | React hook equivalent               |
-| ---------------- | ----------------------------------- |
-| constructor      | useState initial value              |
-| hostConnected    | useState initial value              |
-| hostDisconnected | useLayoutEffect cleanup, empty deps |
-| hostUpdate       | hook body                           |
-| hostUpdated      | useLayoutEffect                     |
-| requestUpdate    | useState setter                     |
-| updateComplete   | useLayoutEffect                     |

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -128,9 +128,7 @@ together state and behavior related to a feature. They are similar to React
 hooks in the user cases and capabilities, but are plain JavaScript objects
 instead of functions with hidden state.
 
-`useController()` is a React hook that creates and stores a reactive controller
-and drives its lifecycle using React hooks like `useState` and
-`useLayoutEffect`.
+`useController()` lets you make React hooks out of reactive controllers allowing for the sharing of state and behaviors across web components and React.
 
 ### Usage
 
@@ -139,13 +137,12 @@ import React from 'react';
 import {useController} from '@lit-labs/react/use-controller.js';
 import {MouseController} from '@example/mouse-controller';
 
-// Write a React hook function:
+// Write a custom React hook function:
 const useMouse = () => {
   // Use useController to create and store a controller instance:
   const controller = useController(React, (host) => new MouseController(host));
-  // Return the controller itself
-  // or return a custom object for a more React-idiomatic API:
-  return controller.position;
+  // Return relevant data for consumption by the component:
+  return controller.pos;
 };
 
 // Now use the new hook in a React component:
@@ -159,6 +156,8 @@ const Component = (props) => {
   );
 };
 ```
+
+See the [mouse controller example](../../composition/controllers/#example:-mousemovecontroller) in the reactive controller docs for its implementation.
 
 ### How it works
 

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -49,8 +49,8 @@ export const MyElementComponent = createComponent({
   elementClass: MyElement,
   react: React,
   events: {
-    onActivate: 'activate',
-    onChange: 'change',
+    onactivate: 'activate',
+    onchange: 'change',
   },
 });
 ```
@@ -60,8 +60,8 @@ After defining the React component, you can use it just as you would any other R
 ```jsx
 <MyElementComponent
   active={isActive}
-  onActivate={(e) => setIsActive(e.active)}
-  onChange={handleChange}
+  onactivate={(e) => setIsActive(e.active)}
+  onchange={handleChange}
 />
 ```
 
@@ -108,9 +108,15 @@ Since React components are not themselves HTML elements, they usually cannot dir
 </MyElementComponent>
 ```
 
+{% aside "positive" "no-header" %}
+
 Try it out in the [React slots playground example](/playground/#sample=examples/react-slots).
 
-#### Typing event handler props
+{% endaside %}
+
+#### Events
+
+The `events` option takes an object whose key will be the React prop name and value will be the event name. The function passed to the created React component as a prop that matches the key name will be called when the specified event is fired from the custom element. While the the React prop name can be whatever you want, the recommended convention is to add `on` in front of the event name. This is in line with how React is planning to implement event support for custom element properties. You should also make sure this prop name does not collide with any existing properties on the element.
 
 In TypeScript, the event type can be specified by casting the event name to the `EventName` utility type. This is a good practice to do so that React users will get the most accurate types for their event callbacks.
 
@@ -127,16 +133,16 @@ export const MyElementComponent = createComponent({
   elementClass: MyElement,
   react: React,
   events: {
-    onMyEvent: 'my-event' as EventName<MyEvent>,
+    'onmy-event': 'my-event' as EventName<MyEvent>,
   },
 });
 ```
 
-With the casting done above, a `PointerEvent` is expected for the parameter of the function provided to the `onClick` prop.
+Casting the event name to `EventName<MyEvent>` causes the React component to have an `onMyEvent` callback prop that accepts a `MyEvent` parameter instead of a plain `Event`:
 
 ```tsx
 <MyElementComponent
-  onMyEvent={(e: MyEvent) => {
+  onmy-event={(e: MyEvent) => {
     console.log(e.myEventData);
   }}
 />
@@ -152,7 +158,7 @@ During a render, the wrapper receives props from React and based on the options 
 
 Both properties and events are added in `componentDidMount()` and `componentDidUpdate()` callbacks, because the element must have already been instantiated by React in order to access it.
 
-For events, `createComponent()` accepts a mapping of React event prop names to events fired by the custom element. For example passing `{onFoo: 'foo'}` means a function passed via a prop named `onFoo` will be called when the custom element fires the `foo` event with the event as an argument.
+For events, `createComponent()` accepts a mapping of React event prop names to events fired by the custom element. For example passing `{onfoo: 'foo'}` means a function passed via a prop named `onfoo` will be called when the custom element fires the `foo` event with the event as an argument.
 
 ## useController
 

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -2,7 +2,7 @@
 title: React
 eleventyNavigation:
   key: React
-  parent: Framework integration
+  parent: Frameworks
   order: 1
   labs: true
 ---

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -1,0 +1,153 @@
+---
+title: React
+eleventyNavigation:
+  key: React
+  parent: Framework integration
+  order: 1
+  labs: true
+---
+
+{% labs-disclaimer %}
+
+The [@lit-labs/react](https://github.com/lit/lit/tree/main/packages/labs/react) package provides web component and reactive controller integration for React. While React can render web components as-is, there are a few gaps in the developer experience. You can't easily pass React props to custom element properties or add event listeners to custom elements. (For more information on the limitations of React's web component integration, see [Custom Elements Everywhere](https://custom-elements-everywhere.com/libraries/react/results/results.html).)
+
+The `@lit-labs/react` package provides two main entry points:
+
+-   `createComponent()` creates a React component that _wraps_ an existing web component. The wrapper allows you to set props on the component and add event listeners to the component like you would any other React component.
+
+-   `useController()` lets you use a Lit reactive controller as a React hook.  
+
+## createComponent
+
+The `createComponent()` function makes a React component wrapper for a custom element class. The wrapper correctly passes React `props` to properties accepted by the custom element and listens for events dispatched by the custom element.
+
+### How it works
+
+For properties, the wrapper interrogates the web component class to discover its available properties. Then any React props passed with property names are set on the custom element as properties and not attributes.
+
+For events, `createComponent()` accepts a mapping of React event prop names to events fired by the custom element. For example passing `{onFoo: 'foo'}` means a function passed via a prop named `onFoo` will be called when the custom element fires the `foo` event with the event as an argument.
+
+### Usage
+
+Import `React`, a custom element class, and `createComponent`.
+
+```js
+import React from 'react';
+import {createComponent} from '@lit-labs/react';
+import {MyElement} from './my-element.js';
+
+export const MyElementComponent = createComponent({
+  tagName: 'my-element',
+  elementClass: MyElement,
+  react: React,
+  events: {
+    onActivate: 'activate',
+    onChange: 'change',
+  },
+});
+```
+
+After defining the React component, you can use it just as you would any other React component.
+
+```jsx
+<MyElementComponent
+  active={isActive}
+  onActivate={(e) => setIsActive(e.active)}
+/>
+```
+
+#### Typescript
+
+Event callback types can be refined by type casting with `EventName`. The type cast helps `createComponent` correlate typed callbacks to property names in the event property map.
+
+Non-casted event names will fallback to an event type of `Event`.
+
+```ts
+import type {EventName} from '@lit-labs/react';
+
+import React from 'react';
+import {createComponent} from '@lit-labs/react';
+import {MyElement} from './my-element.js';
+
+export const MyElementComponent = createComponent({
+  tagName: 'my-element',
+  elementClass: MyElement,
+  react: React,
+  events: {
+    onClick: 'pointerdown' as EventName<PointerEvent>,
+    onChange: 'input',
+  },
+});
+```
+
+Event callbacks will match their type cast. In the example below, a `PointerEvent` is expected in the `onClick` callback.
+
+```tsx
+<MyElementComponent
+  onClick={(e: PointerEvent) => {
+    console.log('DOM PointerEvent called!');
+  }}
+  onChange={(e: Event) => {
+    console.log(e);
+  }}
+/>
+```
+
+{% aside "info" "no-header" %}
+This type casting is not associated to any component property. Be careful to use the corresponding type dispatched or bubbled from the webcomponent. Incorrect types might result in additional properties, missing properties, or properties of the wrong type.
+{% endaside %}
+
+## useController
+
+Reactive controllers allow developers to hook in to a component's lifecycle to bundle
+together state and behavior related to a feature. They are similar to React
+hooks in the user cases and capabilities, but are plain JavaScript objects
+instead of functions with hidden state.
+
+`useController()` is a React hook that creates and stores a reactive controller
+and drives its lifecycle using React hooks like `useState` and
+`useLayoutEffect`.
+
+### How it works
+
+`useController()` uses `useState` to create and store an instance of a controller and a `ReactControllerHost`. It then calls the controller's lifecycle from the hook body and `useLayoutEffect` callbacks, emulating the `ReactiveElement` lifecycle as closely as possible. `ReactControllerHost` implements `addController` so that controller composition works and nested controller lifecycles are called correctly. `ReactControllerHost` also implements `requestUpdate` by calling a `useState` setter, so that a controller with new renderable state can cause its host component to re-render.
+
+Controller timings are implemented as follows:
+
+| Controller API   | React hook equivalent               |
+| ---------------- | ----------------------------------- |
+| constructor      | useState initial value              |
+| hostConnected    | useState initial value              |
+| hostDisconnected | useLayoutEffect cleanup, empty deps |
+| hostUpdate       | hook body                           |
+| hostUpdated      | useLayoutEffect                     |
+| requestUpdate    | useState setter                     |
+| updateComplete   | useLayoutEffect                     |
+
+### Usage
+
+```jsx
+import React from 'react';
+import {useController} from '@lit-labs/react/use-controller.js';
+import {MouseController} from '@example/mouse-controller';
+
+// Write a React hook function:
+const useMouse = () => {
+  // Use useController to create and store a controller instance:
+  const controller = useController(React, (host) => new MouseController(host));
+  // Return the controller itself
+  // or return a custom object for a more React-idiomatic API:
+  return controller.position;
+};
+
+// Now use the new hook in a React component:
+const Component = (props) => {
+  const mousePosition = useMouse();
+  return (
+    <pre>
+      x: {mousePosition.x}
+      y: {mousePosition.y}
+    </pre>
+  );
+};
+```

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -61,14 +61,22 @@ After defining the React component, you can use it just as you would any other R
 <MyElementComponent
   active={isActive}
   onActivate={(e) => setIsActive(e.active)}
+  onChange={handleChange}
 />
 ```
 
-#### Typescript
+#### Options
 
-Event callback types can be refined by type casting with `EventName`. The type cast helps `createComponent` correlate typed callbacks to property names in the event property map.
+`createComponent` takes an options object with the following properties:
 
-Non-casted event names will fallback to an event type of `Event`.
+- `tagName`: The custom element's tag name.
+- `elementClass`: The custom element class.
+- `react`: The imported `React` object. This is used to create the wrapper component with the user supplied `React`. This can also be an import of `preact-compat`.
+- `events`: An object that maps an event handler prop to an event name fired by the custom element.
+
+#### Typing event handler props
+
+The parameter type for the event handler prop can be refined by type casting the event name in the `events` options with the provided `EventName` utility type. Non-casted event names will fall back to the `Event` type.
 
 ```ts
 import type {EventName} from '@lit-labs/react';
@@ -88,22 +96,18 @@ export const MyElementComponent = createComponent({
 });
 ```
 
-Event callbacks will match their type cast. In the example below, a `PointerEvent` is expected in the `onClick` callback.
+With the casting done above, a `PointerEvent` is expected for the parameter of the function provided to the `onClick` prop.
 
 ```tsx
 <MyElementComponent
   onClick={(e: PointerEvent) => {
-    console.log('DOM PointerEvent called!');
+    // handle click
   }}
   onChange={(e: Event) => {
-    console.log(e);
+    // handle change
   }}
 />
 ```
-
-{% aside "info" "no-header" %}
-This type casting is not associated to any component property. Be careful to use the corresponding type dispatched or bubbled from the webcomponent. Incorrect types might result in additional properties, missing properties, or properties of the wrong type.
-{% endaside %}
 
 ### How it works
 

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -35,18 +35,6 @@ The `@lit-labs/react` package provides two main exports:
 
 The `createComponent()` function makes a React component wrapper for a custom element class. The wrapper correctly passes React `props` to properties accepted by the custom element and listens for events dispatched by the custom element.
 
-### How it works
-
-During a render, the wrapper receives props from React and based on the options and the custom element class, changes the behavior of some of the props:
-
-* If a prop name is a property on the custom element, as determined with an `in` check, the wrapper sets that property on the element to the prop value
-* If a prop name is an event name passed to the `events` option, the prop value is passed to `addEventListener()` with the name of the event.
-* Otherwise the prop is passed to React's `createElement()` to be rendered as an attribute.
-
-Both properties and events are added in `componentDidMount()` and `componentDidUpdate()` callbacks, because the element must have already been instantiated by React in order to access it.
-
-For events, `createComponent()` accepts a mapping of React event prop names to events fired by the custom element. For example passing `{onFoo: 'foo'}` means a function passed via a prop named `onFoo` will be called when the custom element fires the `foo` event with the event as an argument.
-
 ### Usage
 
 Import `React`, a custom element class, and `createComponent`.
@@ -117,6 +105,18 @@ Event callbacks will match their type cast. In the example below, a `PointerEven
 This type casting is not associated to any component property. Be careful to use the corresponding type dispatched or bubbled from the webcomponent. Incorrect types might result in additional properties, missing properties, or properties of the wrong type.
 {% endaside %}
 
+### How it works
+
+During a render, the wrapper receives props from React and based on the options and the custom element class, changes the behavior of some of the props:
+
+* If a prop name is a property on the custom element, as determined with an `in` check, the wrapper sets that property on the element to the prop value
+* If a prop name is an event name passed to the `events` option, the prop value is passed to `addEventListener()` with the name of the event.
+* Otherwise the prop is passed to React's `createElement()` to be rendered as an attribute.
+
+Both properties and events are added in `componentDidMount()` and `componentDidUpdate()` callbacks, because the element must have already been instantiated by React in order to access it.
+
+For events, `createComponent()` accepts a mapping of React event prop names to events fired by the custom element. For example passing `{onFoo: 'foo'}` means a function passed via a prop named `onFoo` will be called when the custom element fires the `foo` event with the event as an argument.
+
 ## useController
 
 Reactive controllers allow developers to hook in to a component's lifecycle to bundle
@@ -127,22 +127,6 @@ instead of functions with hidden state.
 `useController()` is a React hook that creates and stores a reactive controller
 and drives its lifecycle using React hooks like `useState` and
 `useLayoutEffect`.
-
-### How it works
-
-`useController()` uses `useState` to create and store an instance of a controller and a `ReactControllerHost`. It then calls the controller's lifecycle from the hook body and `useLayoutEffect` callbacks, emulating the `ReactiveElement` lifecycle as closely as possible. `ReactControllerHost` implements `addController` so that controller composition works and nested controller lifecycles are called correctly. `ReactControllerHost` also implements `requestUpdate` by calling a `useState` setter, so that a controller with new renderable state can cause its host component to re-render.
-
-Controller timings are implemented as follows:
-
-| Controller API   | React hook equivalent               |
-| ---------------- | ----------------------------------- |
-| constructor      | useState initial value              |
-| hostConnected    | useState initial value              |
-| hostDisconnected | useLayoutEffect cleanup, empty deps |
-| hostUpdate       | hook body                           |
-| hostUpdated      | useLayoutEffect                     |
-| requestUpdate    | useState setter                     |
-| updateComplete   | useLayoutEffect                     |
 
 ### Usage
 
@@ -171,3 +155,19 @@ const Component = (props) => {
   );
 };
 ```
+
+### How it works
+
+`useController()` uses `useState` to create and store an instance of a controller and a `ReactControllerHost`. It then calls the controller's lifecycle from the hook body and `useLayoutEffect` callbacks, emulating the `ReactiveElement` lifecycle as closely as possible. `ReactControllerHost` implements `addController` so that controller composition works and nested controller lifecycles are called correctly. `ReactControllerHost` also implements `requestUpdate` by calling a `useState` setter, so that a controller with new renderable state can cause its host component to re-render.
+
+Controller timings are implemented as follows:
+
+| Controller API   | React hook equivalent               |
+| ---------------- | ----------------------------------- |
+| constructor      | useState initial value              |
+| hostConnected    | useState initial value              |
+| hostDisconnected | useLayoutEffect cleanup, empty deps |
+| hostUpdate       | hook body                           |
+| hostUpdated      | useLayoutEffect                     |
+| requestUpdate    | useState setter                     |
+| updateComplete   | useLayoutEffect                     |

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -9,7 +9,7 @@ eleventyNavigation:
 
 {% labs-disclaimer %}
 
-The [@lit-labs/react](https://github.com/lit/lit/tree/main/packages/labs/react) package provides utilities to create React wrapper components for web components, and custom hooks from [reactive controllers](../composition/controllers/).
+The [@lit-labs/react](https://github.com/lit/lit/tree/main/packages/labs/react) package provides utilities to create React wrapper components for web components, and custom hooks from [reactive controllers](../../composition/controllers/).
 
 The React component wrapper enables setting properties on custom elements (instead of just attributes), mapping DOM events to React-style callbacks, and enables correct type-checking in JSX by TypeScript.
 

--- a/packages/lit-dev-content/site/docs/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/frameworks/react.md
@@ -116,7 +116,9 @@ Try it out in the [React slots playground example](/playground/#sample=examples/
 
 #### Events
 
-The `events` option takes an object whose key will be the React prop name and value will be the event name. The function passed to the created React component as a prop that matches the key name will be called when the specified event is fired from the custom element. While the the React prop name can be whatever you want, the recommended convention is to add `on` in front of the event name. This is in line with how React is planning to implement event support for custom element properties. You should also make sure this prop name does not collide with any existing properties on the element.
+The `events` option takes an object that maps React prop names to event names. When a component user passes a callback prop with one of the event prop names, the wrapper will add it as an event handler for the corresponding event.
+
+While the the React prop name can be whatever you want, the recommended convention is to add `on` in front of the event name. This matches how React is planning to implement event support for custom elements. You should also make sure this prop name does not collide with any existing properties on the element.
 
 In TypeScript, the event type can be specified by casting the event name to the `EventName` utility type. This is a good practice to do so that React users will get the most accurate types for their event callbacks.
 

--- a/packages/lit-dev-content/site/docs/libraries/index.md
+++ b/packages/lit-dev-content/site/docs/libraries/index.md
@@ -2,7 +2,7 @@
 title: Related libraries
 eleventyNavigation:
   key: Related libraries
-  order: 11
+  order: 12
 versionLinks:
   v1: lit-html/introduction/
 ---

--- a/packages/lit-dev-content/site/docs/localization/index.md
+++ b/packages/lit-dev-content/site/docs/localization/index.md
@@ -2,7 +2,7 @@
 title: Localization
 eleventyNavigation:
   key: Localization
-  order: 7
+  order: 9
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/releases/index.md
+++ b/packages/lit-dev-content/site/docs/releases/index.md
@@ -2,7 +2,7 @@
 title: Releases
 eleventyNavigation:
   key: Releases
-  order: 10
+  order: 11
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/resources/index.md
+++ b/packages/lit-dev-content/site/docs/resources/index.md
@@ -2,7 +2,7 @@
 title: Resources
 eleventyNavigation:
   key: Resources
-  order: 12
+  order: 13
 ---
 
 <!-- This file exists only to create a section heading.

--- a/packages/lit-dev-content/site/docs/ssr/index.md
+++ b/packages/lit-dev-content/site/docs/ssr/index.md
@@ -2,7 +2,7 @@
 title: Server rendering
 eleventyNavigation:
   key: Server rendering
-  order: 8
+  order: 7
   labs: true
 ---
 


### PR DESCRIPTION
Redo of #1010 for cleaner history and so that preview builds can get generated without approval.

I incorporated all review comments from the previous PR and did a bit more clean up.

Content is based on `@lit-labs/react`'s README. I think there's room for improvement to expand on what the experience with React is like without the wrapper.

For future consideration too is whether the Next.js integration should be part of the "React" page or a separate page under "Framework Integration", leaning towards latter.

Closes #884 