### PR TITLE
fix-type-imports-on-docs

### DIFF
--- a/packages/lit-dev-content/samples/docs/templates/composeimports/my-page.ts
+++ b/packages/lit-dev-content/samples/docs/templates/composeimports/my-page.ts
@@ -1,9 +1,9 @@
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 
-import './my-header.js';
-import './my-article.js';
-import './my-footer.js';
+import './my-header.ts';
+import './my-article.ts';
+import './my-footer.ts';
 
 @customElement('my-page')
 class MyPage extends LitElement {

--- a/packages/lit-dev-content/samples/examples/element-composition/my-page.ts
+++ b/packages/lit-dev-content/samples/examples/element-composition/my-page.ts
@@ -1,9 +1,9 @@
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 
-import './my-header.js';
-import './my-article.js';
-import './my-footer.js';
+import './my-header.ts';
+import './my-article.ts';
+import './my-footer.ts';
 
 @customElement('my-page')
 class MyPage extends LitElement {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "allowImportingTsExtensions": true,
   }
 }


### PR DESCRIPTION
Desciption
==========
On the docs site there is an issue with not missmatching types on the ts examples, where they user .js instead of .ts

Changes
=======
- Updated the tsconfig.base.json with alloImportingTsExtensions in order to be able to import .ts files
- Updated the ts examples on the docs site to import .ts files instead of .js