### PR TITLE
fix-type-imports-on-docs

### DIFF
--- a/packages/lit-dev-content/samples/docs/templates/composeimports/my-page.ts
+++ b/packages/lit-dev-content/samples/docs/templates/composeimports/my-page.ts
@@ -1,9 +1,9 @@
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
 
-import './my-header.js';
-import './my-article.js';
-import './my-footer.js';
+import './my-header';
+import './my-article';
+import './my-footer';
 
 @customElement('my-page')
 class MyPage extends LitElement {


### PR DESCRIPTION
Desciption
==========
On the docs site there is an issue with not missmatching types on the ts examples, where they user .js instead of .ts

Changes
=======
- Removed file types from imports in order not to confuse the user. 

Addresses #1053 