### PR TITLE
fix(list-tutorial): square colors

### DIFF
--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/04/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/04/after/my-element.ts
@@ -48,6 +48,6 @@ class MyElement extends LitElement {
 }
 
 const getColor = (row: number, col: number) =>
-  (row + col) % 2 === 0 ? "white" : "black";
+  (row + col) % 2 ? "black" : "white";
 const getLabel = (row: number, col: number) =>
   `${String.fromCharCode(65 + col)}${8 - row}`;

--- a/packages/lit-dev-content/samples/tutorials/working-with-lists/04/after/my-element.ts
+++ b/packages/lit-dev-content/samples/tutorials/working-with-lists/04/after/my-element.ts
@@ -48,6 +48,6 @@ class MyElement extends LitElement {
 }
 
 const getColor = (row: number, col: number) =>
-  (row + col) % 2 ? "white" : "black";
+  (row + col) % 2 === 0 ? "white" : "black";
 const getLabel = (row: number, col: number) =>
   `${String.fromCharCode(65 + col)}${8 - row}`;


### PR DESCRIPTION
This was around the wrong way. White's bottom right square, h1, is always white.

with these changes you get a board looking like this:
<img width="400" src="https://user-images.githubusercontent.com/882995/227680266-01d89402-83fe-4a84-8ef0-f755a328deae.png">

for reference:
<img width="400" src="https://user-images.githubusercontent.com/882995/227680374-e1b91933-85d1-4cf7-af13-36baa68d6e06.png">
