### PR TITLE
fix(search): allow mobile to scroll to bottom

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-search.ts
+++ b/packages/lit-dev-content/src/components/litdev-search.ts
@@ -575,7 +575,7 @@ export class LitDevSearch extends LitElement {
 
       #items {
         max-height: calc(
-          100vh - var(--_input-height) - 2 * var(--search-modal-padding-block) -
+          100dvh - var(--_input-height) - 2 * var(--search-modal-padding-block) -
             var(--_items-margin-block-start)
         );
       }


### PR DESCRIPTION
users on mobile could not scroll to the bottom due to vh instead of dvh

![image](https://user-images.githubusercontent.com/5981958/230685155-30f150fd-e816-42e7-8642-08ed944374b6.png)
