### PR TITLE
Fix outdated config documentation for using web-dev-server

### DIFF
--- a/packages/lit-dev-content/site/docs/tools/development.md
+++ b/packages/lit-dev-content/site/docs/tools/development.md
@@ -119,9 +119,7 @@ export default {
   appIndex: 'index.html',
   nodeResolve: {
     exportConditions: ['development'],
-    dedupe: true,
   },
-  esbuildTarget: 'auto',
 };
 ```
 


### PR DESCRIPTION
The newest version of web dev server uses a more recent `plugin-node-resolve` rollup plugin that no longer accepts a bool for `dedupe`.

I also removed `esbuildTarget` as it requires a separate npm install that adds complexity to the setup.


Fixes: #1075 - See issue for the blockers on these two configuration keys.


### Testing

Tested by manually creating a new empty npm project of type module. I installed Lit, and created a a hello world sample using a `index.html` and `hello-world.js` file. Then I followed https://lit.dev/docs/tools/development/#web-dev-server to setup a development server. After this change I am able to develop my hello world sample.