### PR TITLE
Update playground-elements for `@types` package support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7437,9 +7437,9 @@
       }
     },
     "node_modules/playground-elements": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.17.0.tgz",
-      "integrity": "sha512-kPWdVoX9ko0sHa/E3Jzk9YkbOClcmvAOZ4zJPdjxqmQz9Bp0WAs2BpbN8hscqTMbCmdQFJbtTLvShwwN4fK+xw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.17.1.tgz",
+      "integrity": "sha512-cizOM5yuq+Mh3H2fiJuLfQYV6W1IdQ2lY4kKGKwzh47XXVeZvFImcCzm9FAzxIiW/5qTfhYT5H71OJOaffnoOQ==",
       "dev": true,
       "dependencies": {
         "@material/mwc-button": "^0.27.0",
@@ -16511,9 +16511,9 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "playground-elements": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.17.0.tgz",
-      "integrity": "sha512-kPWdVoX9ko0sHa/E3Jzk9YkbOClcmvAOZ4zJPdjxqmQz9Bp0WAs2BpbN8hscqTMbCmdQFJbtTLvShwwN4fK+xw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.17.1.tgz",
+      "integrity": "sha512-cizOM5yuq+Mh3H2fiJuLfQYV6W1IdQ2lY4kKGKwzh47XXVeZvFImcCzm9FAzxIiW/5qTfhYT5H71OJOaffnoOQ==",
       "dev": true,
       "requires": {
         "@material/mwc-button": "^0.27.0",


### PR DESCRIPTION
Main motivation for this is it allows partially addressing https://github.com/lit/lit.dev/issues/885 to bring in `@types/react` but can be useful for other playground examples that might bring in packages without built in types.