### PR TITLE
Fix deprecated GitHub actions warning

### DIFF
--- a/.github/workflows/build-and-publish-search-index.yml
+++ b/.github/workflows/build-and-publish-search-index.yml
@@ -11,8 +11,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/check-api-data-in-sync.yml
+++ b/.github/workflows/check-api-data-in-sync.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
       - uses: google/wireit@setup-github-actions-caching/v1
         with:
           node-version: 18

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,8 +8,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,8 +8,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,8 +8,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
Github actions is warning us on our repo that Node.js 12 actions are now deprecated.
Updated `checkout`, and `setup-node` to non deprecated versions.


Result - should fix the "Deprecated" warning on the Actions page.


See issue on the example action: https://github.com/lit/lit.dev/actions/runs/4854361189
Compare with the Unit Test action on this PR: https://github.com/lit/lit.dev/actions/runs/4854750099/jobs/8652491229?pr=1089