### PR TITLE
Update TypeDoc to latest - 0.24.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8565,6 +8565,48 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
+    "node_modules/typedoc": {
+      "version": "0.24.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.6.tgz",
+      "integrity": "sha512-c3y3h45xJv3qYwKDAwU6Cl+26CjT0ZvblHzfHJ+SjQDM4p1mZxtgHky4lhmG0+nNarRht8kADfZlbspJWdZarQ==",
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -9299,50 +9341,8 @@
         "source-map": "^0.8.0-beta.0",
         "strip-comments": "^2.0.1",
         "striptags": "^3.2.0",
-        "typedoc": "^0.23.28",
+        "typedoc": "^0.24.6",
         "uvu": "^0.5.1"
-      }
-    },
-    "packages/lit-dev-tools-cjs/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/lit-dev-tools-cjs/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/lit-dev-tools-cjs/node_modules/typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
-        "shiki": "^0.14.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 14.14"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
       }
     },
     "packages/lit-dev-tools-esm": {
@@ -14523,37 +14523,8 @@
         "source-map": "^0.8.0-beta.0",
         "strip-comments": "^2.0.1",
         "striptags": "^3.2.0",
-        "typedoc": "^0.23.28",
+        "typedoc": "^0.24.6",
         "uvu": "^0.5.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "typedoc": {
-          "version": "0.23.28",
-          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-          "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
-          "requires": {
-            "lunr": "^2.3.9",
-            "marked": "^4.2.12",
-            "minimatch": "^7.1.3",
-            "shiki": "^0.14.1"
-          }
-        }
       }
     },
     "lit-dev-tools-esm": {
@@ -16421,6 +16392,35 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "typedoc": {
+      "version": "0.24.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.6.tgz",
+      "integrity": "sha512-c3y3h45xJv3qYwKDAwU6Cl+26CjT0ZvblHzfHJ+SjQDM4p1mZxtgHky4lhmG0+nNarRht8kADfZlbspJWdZarQ==",
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+          "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
     },
     "typescript": {
       "version": "4.7.4",

--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -10,7 +10,6 @@
     "items": [
       {
         "name": "LitElement",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base element class that manages element properties and attributes, and\nrenders a lit-html template.",
           "text": "To define a component, subclass `LitElement` and implement a\n`render` method to provide the component's template. Define properties\nusing the [`properties`](/docs/api/LitElement/#LitElement.properties) property or the\n[`property`](/docs/api/decorators/#property) decorator.\n"
@@ -26,20 +25,17 @@
           {
             "type": "reference",
             "name": "ReactiveElement",
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "ReactiveElement"
-            }
+            "package": "@lit/reactive-element"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "LitElement",
           "anchor": "LitElement"
@@ -48,19 +44,7 @@
           {
             "type": "reference",
             "name": "ReactiveElement",
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "ReactiveElement"
-            }
-          },
-          {
-            "type": "reference",
-            "name": "HTMLElement",
-            "qualifiedName": "HTMLElement",
-            "package": "typescript",
-            "externalLocation": {
-              "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-            }
+            "package": "@lit/reactive-element"
           }
         ],
         "expandedCategories": [
@@ -70,7 +54,6 @@
             "children": [
               {
                 "name": "attributeChangedCallback",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Synchronizes property values when attributes change.",
                   "text": "Specifically, when an attribute is set, the corresponding property is set.\nYou should rarely need to implement this callback. If this method is\noverridden, `super.attributeChangedCallback(name, _old, value)` must be\ncalled.\nSee [using the lifecycle callbacks](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks)\non MDN for more information about the `attributeChangedCallback`.\n"
@@ -85,11 +68,15 @@
                 "signatures": [
                   {
                     "name": "attributeChangedCallback",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 558
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "intrinsic",
                           "name": "string"
@@ -97,7 +84,6 @@
                       },
                       {
                         "name": "_old",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -114,7 +100,6 @@
                       },
                       {
                         "name": "value",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -142,20 +127,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.attributeChangedCallback",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.attributeChangedCallback"
-                  }
+                  "name": "ReactiveElement.attributeChangedCallback"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.attributeChangedCallback"
@@ -163,7 +144,6 @@
               },
               {
                 "name": "observedAttributes",
-                "kindString": "Accessor",
                 "flags": {
                   "isStatic": true
                 },
@@ -191,7 +171,6 @@
                 },
                 "getSignature": {
                   "name": "observedAttributes",
-                  "kindString": "Get signature",
                   "comment": {
                     "blockTags": [
                       {
@@ -200,6 +179,12 @@
                     ],
                     "shortText": "Returns a list of attributes corresponding to the registered properties."
                   },
+                  "sources": [
+                    {
+                      "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                      "line": 347
+                    }
+                  ],
                   "type": {
                     "type": "array",
                     "elementType": {
@@ -214,20 +199,16 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.observedAttributes",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.observedAttributes"
-                  }
+                  "name": "ReactiveElement.observedAttributes"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Accessor",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.observedAttributes"
@@ -241,7 +222,6 @@
             "children": [
               {
                 "name": "addController",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Registers a `ReactiveController` to participate in the element's reactive\nupdate cycle. The element automatically calls into any registered\ncontrollers during its lifecycle callbacks.",
                   "text": "If the element is connected when `addController()` is called, the\ncontroller's `hostConnected()` callback will be immediately called.\n"
@@ -256,18 +236,19 @@
                 "signatures": [
                   {
                     "name": "addController",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 497
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "controller",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "location": {
-                            "page": "controllers",
-                            "anchor": "ReactiveController"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -283,20 +264,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.addController",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.addController"
-                  }
+                  "name": "ReactiveElement.addController"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.addController"
@@ -304,7 +281,6 @@
               },
               {
                 "name": "removeController",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Removes a `ReactiveController` from the element."
                 },
@@ -318,18 +294,19 @@
                 "signatures": [
                   {
                     "name": "removeController",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 502
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "controller",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "location": {
-                            "page": "controllers",
-                            "anchor": "ReactiveController"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -345,20 +322,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.removeController",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.removeController"
-                  }
+                  "name": "ReactiveElement.removeController"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.removeController"
@@ -372,7 +345,6 @@
             "children": [
               {
                 "name": "disableWarning",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -397,7 +369,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
@@ -407,7 +378,6 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
                         "comment": {
                           "blockTags": [
                             {
@@ -417,17 +387,19 @@
                           "shortText": "Disable the given warning category for this class.",
                           "text": "This method only exists in development builds, so it should be accessed\nwith a guard like:\n```ts\n// Disable for all ReactiveElement subclasses\nReactiveElement.disableWarning?.('migration');\n// Disable for only MyElement and subclasses\nMyElement.disableWarning?.('migration');\n```\n"
                         },
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                            "line": 222
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "warningKind",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "WarningKind"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           }
                         ],
@@ -441,20 +413,16 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.disableWarning",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.disableWarning"
-                  }
+                  "name": "ReactiveElement.disableWarning"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.disableWarning"
@@ -462,7 +430,6 @@
               },
               {
                 "name": "enabledWarnings",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -488,28 +455,21 @@
                   "elementType": {
                     "type": "reference",
                     "name": "WarningKind",
-                    "location": {
-                      "page": "misc",
-                      "anchor": "WarningKind"
-                    }
+                    "package": "@lit/reactive-element"
                   }
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.enabledWarnings",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.enabledWarnings"
-                  }
+                  "name": "ReactiveElement.enabledWarnings"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.enabledWarnings"
@@ -517,7 +477,6 @@
               },
               {
                 "name": "enableWarning",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -542,7 +501,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
@@ -552,7 +510,6 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
                         "comment": {
                           "blockTags": [
                             {
@@ -562,17 +519,19 @@
                           "shortText": "Enable the given warning category for this class.",
                           "text": "This method only exists in development builds, so it should be accessed\nwith a guard like:\n```ts\n// Enable for all ReactiveElement subclasses\nReactiveElement.enableWarning?.('migration');\n// Enable for only MyElement and subclasses\nMyElement.enableWarning?.('migration');\n```\n"
                         },
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                            "line": 204
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "warningKind",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "WarningKind"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           }
                         ],
@@ -586,20 +545,16 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.enableWarning",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.enableWarning"
-                  }
+                  "name": "ReactiveElement.enableWarning"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.enableWarning"
@@ -613,7 +568,6 @@
             "children": [
               {
                 "name": "connectedCallback",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Invoked when the component is added to the document's DOM.",
                   "text": "In `connectedCallback()` you should setup tasks that should only occur when\nthe element is connected to the document. The most common of these is\nadding event listeners to nodes external to the element, like a keydown\nevent handler added to the window.\n```ts\nconnectedCallback() {\n  super.connectedCallback();\n  addEventListener('keydown', this._handleKeydown);\n}\n```\nTypically, anything done in `connectedCallback()` should be undone when the\nelement is disconnected, in `disconnectedCallback()`.\n"
@@ -628,7 +582,12 @@
                 "signatures": [
                   {
                     "name": "connectedCallback",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-element/development/lit-element.d.ts",
+                        "line": 131
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
@@ -641,20 +600,16 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.connectedCallback",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.connectedCallback"
-                  }
+                  "name": "ReactiveElement.connectedCallback"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.connectedCallback"
@@ -662,7 +617,6 @@
               },
               {
                 "name": "disconnectedCallback",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Invoked when the component is removed from the document's DOM.",
                   "text": "This callback is the main signal to the element that it may no longer be\nused. `disconnectedCallback()` should ensure that nothing is holding a\nreference to the element (such as event listeners added to nodes external\nto the element), so that it is free to be garbage collected.\n```ts\ndisconnectedCallback() {\n  super.disconnectedCallback();\n  window.removeEventListener('keydown', this._handleKeydown);\n}\n```\nAn element may be re-connected after being disconnected.\n"
@@ -677,7 +631,12 @@
                 "signatures": [
                   {
                     "name": "disconnectedCallback",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-element/development/lit-element.d.ts",
+                        "line": 151
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
@@ -690,20 +649,16 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.disconnectedCallback",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.disconnectedCallback"
-                  }
+                  "name": "ReactiveElement.disconnectedCallback"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.disconnectedCallback"
@@ -717,7 +672,6 @@
             "children": [
               {
                 "name": "addInitializer",
-                "kindString": "Method",
                 "flags": {
                   "isStatic": true
                 },
@@ -740,18 +694,19 @@
                 "signatures": [
                   {
                     "name": "addInitializer",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 256
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "initializer",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "Initializer",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "Initializer"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -767,20 +722,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.addInitializer",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.addInitializer"
-                  }
+                  "name": "ReactiveElement.addInitializer"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.addInitializer"
@@ -788,7 +739,6 @@
               },
               {
                 "name": "finalize",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -811,7 +761,12 @@
                 "signatures": [
                   {
                     "name": "finalize",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 423
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "boolean"
@@ -824,20 +779,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.finalize",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.finalize"
-                  }
+                  "name": "ReactiveElement.finalize"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.finalize"
@@ -845,7 +796,6 @@
               },
               {
                 "name": "finalized",
-                "kindString": "Property",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -867,20 +817,16 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.finalized",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.finalized"
-                  }
+                  "name": "ReactiveElement.finalized"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.finalized"
@@ -894,7 +840,6 @@
             "children": [
               {
                 "name": "createProperty",
-                "kindString": "Method",
                 "flags": {
                   "isStatic": true
                 },
@@ -917,21 +862,23 @@
                 "signatures": [
                   {
                     "name": "createProperty",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 373
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "options",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -948,10 +895,7 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyDeclaration"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -967,20 +911,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.createProperty",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.createProperty"
-                  }
+                  "name": "ReactiveElement.createProperty"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.createProperty"
@@ -988,7 +928,6 @@
               },
               {
                 "name": "elementProperties",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -1009,24 +948,21 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "name": "PropertyDeclarationMap"
+                  "name": "PropertyDeclarationMap",
+                  "package": "@lit/reactive-element"
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.elementProperties",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.elementProperties"
-                  }
+                  "name": "ReactiveElement.elementProperties"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.elementProperties"
@@ -1034,7 +970,6 @@
               },
               {
                 "name": "getPropertyDescriptor",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -1058,21 +993,23 @@
                 "signatures": [
                   {
                     "name": "getPropertyDescriptor",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 401
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "key",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -1089,7 +1026,6 @@
                       },
                       {
                         "name": "options",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "typeArguments": [
@@ -1103,10 +1039,7 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyDeclaration"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -1120,7 +1053,6 @@
                         {
                           "type": "reference",
                           "name": "PropertyDescriptor",
-                          "qualifiedName": "PropertyDescriptor",
                           "package": "typescript"
                         }
                       ]
@@ -1133,20 +1065,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.getPropertyDescriptor",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.getPropertyDescriptor"
-                  }
+                  "name": "ReactiveElement.getPropertyDescriptor"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.getPropertyDescriptor"
@@ -1154,7 +1082,6 @@
               },
               {
                 "name": "getPropertyOptions",
-                "kindString": "Method",
                 "flags": {
                   "isStatic": true
                 },
@@ -1180,15 +1107,18 @@
                 "signatures": [
                   {
                     "name": "getPropertyOptions",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 416
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -1206,10 +1136,7 @@
                         }
                       ],
                       "name": "PropertyDeclaration",
-                      "location": {
-                        "page": "ReactiveElement",
-                        "anchor": "PropertyDeclaration"
-                      }
+                      "package": "@lit/reactive-element"
                     },
                     "inheritedFrom": {
                       "type": "reference",
@@ -1219,20 +1146,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.getPropertyOptions",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.getPropertyOptions"
-                  }
+                  "name": "ReactiveElement.getPropertyOptions"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.getPropertyOptions"
@@ -1240,7 +1163,6 @@
               },
               {
                 "name": "properties",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -1263,27 +1185,20 @@
                 "type": {
                   "type": "reference",
                   "name": "PropertyDeclarations",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "PropertyDeclarations"
-                  }
+                  "package": "@lit/reactive-element"
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.properties",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.properties"
-                  }
+                  "name": "ReactiveElement.properties"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.properties"
@@ -1297,7 +1212,6 @@
             "children": [
               {
                 "name": "createRenderRoot",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -1311,27 +1225,24 @@
                 "signatures": [
                   {
                     "name": "createRenderRoot",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-element/development/lit-element.d.ts",
+                        "line": 102
+                      }
+                    ],
                     "type": {
                       "type": "union",
                       "types": [
                         {
                           "type": "reference",
                           "name": "Element",
-                          "qualifiedName": "Element",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                          }
+                          "package": "typescript"
                         },
                         {
                           "type": "reference",
                           "name": "ShadowRoot",
-                          "qualifiedName": "ShadowRoot",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
-                          }
+                          "package": "typescript"
                         }
                       ]
                     },
@@ -1343,20 +1254,16 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.createRenderRoot",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.createRenderRoot"
-                  }
+                  "name": "ReactiveElement.createRenderRoot"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.createRenderRoot"
@@ -1364,7 +1271,6 @@
               },
               {
                 "name": "render",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -1381,7 +1287,12 @@
                 "signatures": [
                   {
                     "name": "render",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-element/development/lit-element.d.ts",
+                        "line": 159
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -1391,11 +1302,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.render"
@@ -1403,7 +1314,6 @@
               },
               {
                 "name": "renderOptions",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -1417,19 +1327,16 @@
                 "type": {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.renderOptions"
@@ -1437,7 +1344,6 @@
               },
               {
                 "name": "renderRoot",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -1457,39 +1363,27 @@
                     {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     },
                     {
                       "type": "reference",
                       "name": "ShadowRoot",
-                      "qualifiedName": "ShadowRoot",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
-                      }
+                      "package": "typescript"
                     }
                   ]
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.renderRoot",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.renderRoot"
-                  }
+                  "name": "ReactiveElement.renderRoot"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.renderRoot"
@@ -1497,7 +1391,6 @@
               },
               {
                 "name": "shadowRootOptions",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -1520,28 +1413,20 @@
                 "type": {
                   "type": "reference",
                   "name": "ShadowRootInit",
-                  "qualifiedName": "ShadowRootInit",
-                  "package": "typescript",
-                  "externalLocation": {
-                    "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters"
-                  }
+                  "package": "typescript"
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.shadowRootOptions",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.shadowRootOptions"
-                  }
+                  "name": "ReactiveElement.shadowRootOptions"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.shadowRootOptions"
@@ -1555,7 +1440,6 @@
             "children": [
               {
                 "name": "elementStyles",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -1579,28 +1463,21 @@
                   "elementType": {
                     "type": "reference",
                     "name": "CSSResultOrNative",
-                    "location": {
-                      "page": "styles",
-                      "anchor": "CSSResultOrNative"
-                    }
+                    "package": "@lit/reactive-element"
                   }
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.elementStyles",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.elementStyles"
-                  }
+                  "name": "ReactiveElement.elementStyles"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.elementStyles"
@@ -1608,7 +1485,6 @@
               },
               {
                 "name": "finalizeStyles",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -1632,21 +1508,22 @@
                 "signatures": [
                   {
                     "name": "finalizeStyles",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 449
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "styles",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "CSSResultGroup",
-                          "location": {
-                            "page": "styles",
-                            "anchor": "CSSResultGroup"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -1655,10 +1532,7 @@
                       "elementType": {
                         "type": "reference",
                         "name": "CSSResultOrNative",
-                        "location": {
-                          "page": "styles",
-                          "anchor": "CSSResultOrNative"
-                        }
+                        "package": "@lit/reactive-element"
                       }
                     },
                     "inheritedFrom": {
@@ -1669,20 +1543,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.finalizeStyles",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.finalizeStyles"
-                  }
+                  "name": "ReactiveElement.finalizeStyles"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.finalizeStyles"
@@ -1690,7 +1560,6 @@
               },
               {
                 "name": "styles",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -1714,27 +1583,20 @@
                 "type": {
                   "type": "reference",
                   "name": "CSSResultGroup",
-                  "location": {
-                    "page": "styles",
-                    "anchor": "CSSResultGroup"
-                  }
+                  "package": "@lit/reactive-element"
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.styles",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.styles"
-                  }
+                  "name": "ReactiveElement.styles"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.styles"
@@ -1748,7 +1610,6 @@
             "children": [
               {
                 "name": "enableUpdating",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -1765,11 +1626,15 @@
                 "signatures": [
                   {
                     "name": "enableUpdating",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 538
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_requestedUpdate",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "intrinsic",
                           "name": "boolean"
@@ -1788,20 +1653,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.enableUpdating",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.enableUpdating"
-                  }
+                  "name": "ReactiveElement.enableUpdating"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.enableUpdating"
@@ -1809,7 +1670,6 @@
               },
               {
                 "name": "firstUpdated",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -1827,11 +1687,15 @@
                 "signatures": [
                   {
                     "name": "firstUpdated",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 725
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -1844,7 +1708,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -1853,7 +1716,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -1865,10 +1727,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -1886,20 +1745,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.firstUpdated",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.firstUpdated"
-                  }
+                  "name": "ReactiveElement.firstUpdated"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.firstUpdated"
@@ -1907,7 +1762,6 @@
               },
               {
                 "name": "getUpdateComplete",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -1935,7 +1789,12 @@
                 "signatures": [
                   {
                     "name": "getUpdateComplete",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 678
+                      }
+                    ],
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -1945,7 +1804,6 @@
                         }
                       ],
                       "name": "Promise",
-                      "qualifiedName": "Promise",
                       "package": "typescript"
                     },
                     "inheritedFrom": {
@@ -1956,20 +1814,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.getUpdateComplete",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.getUpdateComplete"
-                  }
+                  "name": "ReactiveElement.getUpdateComplete"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.getUpdateComplete"
@@ -1977,7 +1831,6 @@
               },
               {
                 "name": "hasUpdated",
-                "kindString": "Property",
                 "comment": {
                   "shortText": "Is set to `true` after the first update. The element code cannot assume\nthat `renderRoot` exists before the element `hasUpdated`."
                 },
@@ -1994,20 +1847,16 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.hasUpdated",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.hasUpdated"
-                  }
+                  "name": "ReactiveElement.hasUpdated"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.hasUpdated"
@@ -2015,7 +1864,6 @@
               },
               {
                 "name": "isUpdatePending",
-                "kindString": "Property",
                 "comment": {
                   "shortText": "True if there is a pending update as a result of calling `requestUpdate()`.\nShould only be read."
                 },
@@ -2032,20 +1880,16 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.isUpdatePending",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.isUpdatePending"
-                  }
+                  "name": "ReactiveElement.isUpdatePending"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.isUpdatePending"
@@ -2053,7 +1897,6 @@
               },
               {
                 "name": "performUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -2071,7 +1914,12 @@
                 "signatures": [
                   {
                     "name": "performUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 614
+                      }
+                    ],
                     "type": {
                       "type": "union",
                       "types": [
@@ -2088,7 +1936,6 @@
                             }
                           ],
                           "name": "Promise",
-                          "qualifiedName": "Promise",
                           "package": "typescript"
                         }
                       ]
@@ -2101,20 +1948,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.performUpdate",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.performUpdate"
-                  }
+                  "name": "ReactiveElement.performUpdate"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.performUpdate"
@@ -2122,7 +1965,6 @@
               },
               {
                 "name": "requestUpdate",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Requests an update which is processed asynchronously. This should be called\nwhen an element should update based on some state not triggered by setting\na reactive property. In this case, pass no arguments. It should also be\ncalled when manually implementing a property setter. In this case, pass the\nproperty `name` and `oldValue` to ensure that any configured property\noptions are honored."
                 },
@@ -2136,11 +1978,15 @@
                 "signatures": [
                   {
                     "name": "requestUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 574
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -2150,13 +1996,11 @@
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "oldValue",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -2170,7 +2014,6 @@
                       },
                       {
                         "name": "options",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -2190,10 +2033,7 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyDeclaration"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -2209,20 +2049,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.requestUpdate",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.requestUpdate"
-                  }
+                  "name": "ReactiveElement.requestUpdate"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.requestUpdate"
@@ -2230,7 +2066,6 @@
               },
               {
                 "name": "scheduleUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -2248,7 +2083,12 @@
                 "signatures": [
                   {
                     "name": "scheduleUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 596
+                      }
+                    ],
                     "type": {
                       "type": "union",
                       "types": [
@@ -2265,7 +2105,6 @@
                             }
                           ],
                           "name": "Promise",
-                          "qualifiedName": "Promise",
                           "package": "typescript"
                         }
                       ]
@@ -2278,20 +2117,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.scheduleUpdate",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.scheduleUpdate"
-                  }
+                  "name": "ReactiveElement.scheduleUpdate"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.scheduleUpdate"
@@ -2299,7 +2134,6 @@
               },
               {
                 "name": "shouldUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -2316,11 +2150,15 @@
                 "signatures": [
                   {
                     "name": "shouldUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 687
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -2333,7 +2171,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -2342,7 +2179,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -2354,10 +2190,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -2375,20 +2208,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.shouldUpdate",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.shouldUpdate"
-                  }
+                  "name": "ReactiveElement.shouldUpdate"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.shouldUpdate"
@@ -2396,7 +2225,6 @@
               },
               {
                 "name": "update",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -2413,11 +2241,15 @@
                 "signatures": [
                   {
                     "name": "update",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-element/development/lit-element.d.ts",
+                        "line": 110
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -2430,7 +2262,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -2439,7 +2270,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -2451,10 +2281,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -2472,20 +2299,16 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.update",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.update"
-                  }
+                  "name": "ReactiveElement.update"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.update"
@@ -2493,7 +2316,6 @@
               },
               {
                 "name": "updateComplete",
-                "kindString": "Accessor",
                 "comment": {
                   "blockTags": [
                     {
@@ -2524,12 +2346,10 @@
                     }
                   ],
                   "name": "Promise",
-                  "qualifiedName": "Promise",
                   "package": "typescript"
                 },
                 "getSignature": {
                   "name": "updateComplete",
-                  "kindString": "Get signature",
                   "comment": {
                     "blockTags": [
                       {
@@ -2544,6 +2364,12 @@
                     "shortText": "Returns a Promise that resolves when the element has completed updating.\nThe Promise value is a boolean that is `true` if the element completed the\nupdate without triggering another update. The Promise result is `false` if\na property was set inside `updated()`. If the Promise is rejected, an\nexception was thrown during the update.",
                     "text": "To await additional asynchronous work, override the `getUpdateComplete`\nmethod. For example, it is sometimes useful to await a rendered element\nbefore fulfilling this Promise. To do this, first await\n`super.getUpdateComplete()`, then any subsequent state.\n"
                   },
+                  "sources": [
+                    {
+                      "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                      "line": 654
+                    }
+                  ],
                   "type": {
                     "type": "reference",
                     "typeArguments": [
@@ -2553,7 +2379,6 @@
                       }
                     ],
                     "name": "Promise",
-                    "qualifiedName": "Promise",
                     "package": "typescript"
                   },
                   "inheritedFrom": {
@@ -2563,20 +2388,16 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.updateComplete",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.updateComplete"
-                  }
+                  "name": "ReactiveElement.updateComplete"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Accessor",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.updateComplete"
@@ -2584,7 +2405,6 @@
               },
               {
                 "name": "updated",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -2602,11 +2422,15 @@
                 "signatures": [
                   {
                     "name": "updated",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 708
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -2619,7 +2443,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -2628,7 +2451,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -2640,10 +2462,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -2661,20 +2480,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.updated",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.updated"
-                  }
+                  "name": "ReactiveElement.updated"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.updated"
@@ -2682,7 +2497,6 @@
               },
               {
                 "name": "willUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -2700,11 +2514,15 @@
                 "signatures": [
                   {
                     "name": "willUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 636
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -2714,7 +2532,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -2723,7 +2540,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -2735,10 +2551,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -2756,20 +2569,16 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.willUpdate",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "ReactiveElement.willUpdate"
-                  }
+                  "name": "ReactiveElement.willUpdate"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.willUpdate"
@@ -2781,14 +2590,12 @@
       },
       {
         "name": "RenderOptions",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Object specifying options for controlling lit-html rendering. Note that\nwhile `render` may be called multiple times on the same `container` (and\n`renderBefore` reference node) to efficiently update the rendered content,\nonly the options passed in during the first render are respected during\nthe lifetime of renders to that unique `container` + `renderBefore`\ncombination."
         },
         "children": [
           {
             "name": "creationScope",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -2806,11 +2613,9 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "children": [
                   {
                     "name": "importNode",
-                    "kindString": "Method",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -2820,21 +2625,23 @@
                     "signatures": [
                       {
                         "name": "importNode",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                            "line": 300
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "node",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "reference",
                               "name": "Node",
-                              "qualifiedName": "Node",
                               "package": "typescript"
                             }
                           },
                           {
                             "name": "deep",
-                            "kindString": "Parameter",
                             "flags": {
                               "isOptional": true
                             },
@@ -2847,7 +2654,6 @@
                         "type": {
                           "type": "reference",
                           "name": "Node",
-                          "qualifiedName": "Node",
                           "package": "typescript"
                         }
                       }
@@ -2865,11 +2671,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.creationScope"
@@ -2877,7 +2683,6 @@
           },
           {
             "name": "host",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -2898,11 +2703,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.host"
@@ -2910,7 +2715,6 @@
           },
           {
             "name": "isConnected",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -2931,11 +2735,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.isConnected"
@@ -2943,7 +2747,6 @@
           },
           {
             "name": "renderBefore",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -2967,7 +2770,6 @@
                 {
                   "type": "reference",
                   "name": "ChildNode",
-                  "qualifiedName": "ChildNode",
                   "package": "typescript"
                 }
               ]
@@ -2975,11 +2777,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.renderBefore"
@@ -2996,11 +2798,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "LitElement",
           "anchor": "RenderOptions"
@@ -3019,7 +2821,6 @@
     "items": [
       {
         "name": "ReactiveElement",
-        "kindString": "Class",
         "flags": {
           "isAbstract": true
         },
@@ -3042,41 +2843,30 @@
           {
             "type": "reference",
             "name": "HTMLElement",
-            "qualifiedName": "HTMLElement",
-            "package": "typescript",
-            "externalLocation": {
-              "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-            }
+            "package": "typescript"
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "LitElement",
-            "location": {
-              "page": "LitElement",
-              "anchor": "LitElement"
-            }
+            "name": "LitElement"
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "ReactiveControllerHost",
-            "location": {
-              "page": "controllers",
-              "anchor": "ReactiveControllerHost"
-            }
+            "package": "@lit/reactive-element"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "ReactiveElement",
           "anchor": "ReactiveElement"
@@ -3085,11 +2875,7 @@
           {
             "type": "reference",
             "name": "HTMLElement",
-            "qualifiedName": "HTMLElement",
-            "package": "typescript",
-            "externalLocation": {
-              "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-            }
+            "package": "typescript"
           }
         ],
         "expandedCategories": [
@@ -3099,7 +2885,6 @@
             "children": [
               {
                 "name": "attributeChangedCallback",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Synchronizes property values when attributes change.",
                   "text": "Specifically, when an attribute is set, the corresponding property is set.\nYou should rarely need to implement this callback. If this method is\noverridden, `super.attributeChangedCallback(name, _old, value)` must be\ncalled.\nSee [using the lifecycle callbacks](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks)\non MDN for more information about the `attributeChangedCallback`.\n"
@@ -3114,11 +2899,15 @@
                 "signatures": [
                   {
                     "name": "attributeChangedCallback",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 558
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "intrinsic",
                           "name": "string"
@@ -3126,7 +2915,6 @@
                       },
                       {
                         "name": "_old",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -3143,7 +2931,6 @@
                       },
                       {
                         "name": "value",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -3168,11 +2955,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.attributeChangedCallback"
@@ -3180,7 +2967,6 @@
               },
               {
                 "name": "observedAttributes",
-                "kindString": "Accessor",
                 "flags": {
                   "isStatic": true
                 },
@@ -3208,7 +2994,6 @@
                 },
                 "getSignature": {
                   "name": "observedAttributes",
-                  "kindString": "Get signature",
                   "comment": {
                     "blockTags": [
                       {
@@ -3217,6 +3002,12 @@
                     ],
                     "shortText": "Returns a list of attributes corresponding to the registered properties."
                   },
+                  "sources": [
+                    {
+                      "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                      "line": 347
+                    }
+                  ],
                   "type": {
                     "type": "array",
                     "elementType": {
@@ -3228,11 +3019,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Accessor",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.observedAttributes"
@@ -3246,7 +3037,6 @@
             "children": [
               {
                 "name": "addController",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Registers a `ReactiveController` to participate in the element's reactive\nupdate cycle. The element automatically calls into any registered\ncontrollers during its lifecycle callbacks.",
                   "text": "If the element is connected when `addController()` is called, the\ncontroller's `hostConnected()` callback will be immediately called.\n"
@@ -3261,18 +3051,19 @@
                 "signatures": [
                   {
                     "name": "addController",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 497
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "controller",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "location": {
-                            "page": "controllers",
-                            "anchor": "ReactiveController"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -3288,20 +3079,16 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.addController",
-                  "location": {
-                    "page": "controllers",
-                    "anchor": "ReactiveControllerHost.addController"
-                  }
+                  "name": "ReactiveControllerHost.addController"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.addController"
@@ -3309,7 +3096,6 @@
               },
               {
                 "name": "removeController",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Removes a `ReactiveController` from the element."
                 },
@@ -3323,18 +3109,19 @@
                 "signatures": [
                   {
                     "name": "removeController",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 502
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "controller",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "location": {
-                            "page": "controllers",
-                            "anchor": "ReactiveController"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -3350,20 +3137,16 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.removeController",
-                  "location": {
-                    "page": "controllers",
-                    "anchor": "ReactiveControllerHost.removeController"
-                  }
+                  "name": "ReactiveControllerHost.removeController"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.removeController"
@@ -3377,7 +3160,6 @@
             "children": [
               {
                 "name": "disableWarning",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -3402,7 +3184,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
@@ -3412,7 +3193,6 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
                         "comment": {
                           "blockTags": [
                             {
@@ -3422,17 +3202,19 @@
                           "shortText": "Disable the given warning category for this class.",
                           "text": "This method only exists in development builds, so it should be accessed\nwith a guard like:\n```ts\n// Disable for all ReactiveElement subclasses\nReactiveElement.disableWarning?.('migration');\n// Disable for only MyElement and subclasses\nMyElement.disableWarning?.('migration');\n```\n"
                         },
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                            "line": 222
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "warningKind",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "WarningKind"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           }
                         ],
@@ -3447,11 +3229,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.disableWarning"
@@ -3459,7 +3241,6 @@
               },
               {
                 "name": "enabledWarnings",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -3485,20 +3266,17 @@
                   "elementType": {
                     "type": "reference",
                     "name": "WarningKind",
-                    "location": {
-                      "page": "misc",
-                      "anchor": "WarningKind"
-                    }
+                    "package": "@lit/reactive-element"
                   }
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.enabledWarnings"
@@ -3506,7 +3284,6 @@
               },
               {
                 "name": "enableWarning",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -3531,7 +3308,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
@@ -3541,7 +3317,6 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
                         "comment": {
                           "blockTags": [
                             {
@@ -3551,17 +3326,19 @@
                           "shortText": "Enable the given warning category for this class.",
                           "text": "This method only exists in development builds, so it should be accessed\nwith a guard like:\n```ts\n// Enable for all ReactiveElement subclasses\nReactiveElement.enableWarning?.('migration');\n// Enable for only MyElement and subclasses\nMyElement.enableWarning?.('migration');\n```\n"
                         },
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                            "line": 204
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "warningKind",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "WarningKind"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           }
                         ],
@@ -3576,11 +3353,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.enableWarning"
@@ -3594,7 +3371,6 @@
             "children": [
               {
                 "name": "connectedCallback",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "On first connection, creates the element's renderRoot, sets up\nelement styling, and enables updating."
                 },
@@ -3608,7 +3384,12 @@
                 "signatures": [
                   {
                     "name": "connectedCallback",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 531
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
@@ -3618,11 +3399,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.connectedCallback"
@@ -3630,7 +3411,6 @@
               },
               {
                 "name": "disconnectedCallback",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Allows for `super.disconnectedCallback()` in extensions while\nreserving the possibility of making non-breaking feature additions\nwhen disconnecting at some point in the future."
                 },
@@ -3644,7 +3424,12 @@
                 "signatures": [
                   {
                     "name": "disconnectedCallback",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 545
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
@@ -3654,11 +3439,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.disconnectedCallback"
@@ -3672,7 +3457,6 @@
             "children": [
               {
                 "name": "addInitializer",
-                "kindString": "Method",
                 "flags": {
                   "isStatic": true
                 },
@@ -3695,18 +3479,19 @@
                 "signatures": [
                   {
                     "name": "addInitializer",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 256
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "initializer",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "Initializer",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "Initializer"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -3719,11 +3504,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.addInitializer"
@@ -3731,7 +3516,6 @@
               },
               {
                 "name": "finalize",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -3754,7 +3538,12 @@
                 "signatures": [
                   {
                     "name": "finalize",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 423
+                      }
+                    ],
                     "type": {
                       "type": "intrinsic",
                       "name": "boolean"
@@ -3764,11 +3553,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.finalize"
@@ -3776,7 +3565,6 @@
               },
               {
                 "name": "finalized",
-                "kindString": "Property",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -3798,11 +3586,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.finalized"
@@ -3816,7 +3604,6 @@
             "children": [
               {
                 "name": "createProperty",
-                "kindString": "Method",
                 "flags": {
                   "isStatic": true
                 },
@@ -3839,21 +3626,23 @@
                 "signatures": [
                   {
                     "name": "createProperty",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 373
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "options",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -3870,10 +3659,7 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyDeclaration"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -3886,11 +3672,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.createProperty"
@@ -3898,7 +3684,6 @@
               },
               {
                 "name": "elementProperties",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -3919,16 +3704,17 @@
                 ],
                 "type": {
                   "type": "reference",
-                  "name": "PropertyDeclarationMap"
+                  "name": "PropertyDeclarationMap",
+                  "package": "@lit/reactive-element"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.elementProperties"
@@ -3936,7 +3722,6 @@
               },
               {
                 "name": "getPropertyDescriptor",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -3960,21 +3745,23 @@
                 "signatures": [
                   {
                     "name": "getPropertyDescriptor",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 401
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "key",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -3991,7 +3778,6 @@
                       },
                       {
                         "name": "options",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "typeArguments": [
@@ -4005,10 +3791,7 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyDeclaration"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -4022,7 +3805,6 @@
                         {
                           "type": "reference",
                           "name": "PropertyDescriptor",
-                          "qualifiedName": "PropertyDescriptor",
                           "package": "typescript"
                         }
                       ]
@@ -4032,11 +3814,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.getPropertyDescriptor"
@@ -4044,7 +3826,6 @@
               },
               {
                 "name": "getPropertyOptions",
-                "kindString": "Method",
                 "flags": {
                   "isStatic": true
                 },
@@ -4070,15 +3851,18 @@
                 "signatures": [
                   {
                     "name": "getPropertyOptions",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 416
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -4096,21 +3880,18 @@
                         }
                       ],
                       "name": "PropertyDeclaration",
-                      "location": {
-                        "page": "ReactiveElement",
-                        "anchor": "PropertyDeclaration"
-                      }
+                      "package": "@lit/reactive-element"
                     }
                   }
                 ],
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.getPropertyOptions"
@@ -4118,7 +3899,6 @@
               },
               {
                 "name": "properties",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -4141,19 +3921,16 @@
                 "type": {
                   "type": "reference",
                   "name": "PropertyDeclarations",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "PropertyDeclarations"
-                  }
+                  "package": "@lit/reactive-element"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.properties"
@@ -4167,7 +3944,6 @@
             "children": [
               {
                 "name": "createRenderRoot",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4194,27 +3970,24 @@
                 "signatures": [
                   {
                     "name": "createRenderRoot",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 525
+                      }
+                    ],
                     "type": {
                       "type": "union",
                       "types": [
                         {
                           "type": "reference",
                           "name": "Element",
-                          "qualifiedName": "Element",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                          }
+                          "package": "typescript"
                         },
                         {
                           "type": "reference",
                           "name": "ShadowRoot",
-                          "qualifiedName": "ShadowRoot",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
-                          }
+                          "package": "typescript"
                         }
                       ]
                     }
@@ -4223,11 +3996,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.createRenderRoot"
@@ -4235,7 +4008,6 @@
               },
               {
                 "name": "renderRoot",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -4255,31 +4027,23 @@
                     {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     },
                     {
                       "type": "reference",
                       "name": "ShadowRoot",
-                      "qualifiedName": "ShadowRoot",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
-                      }
+                      "package": "typescript"
                     }
                   ]
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.renderRoot"
@@ -4287,7 +4051,6 @@
               },
               {
                 "name": "shadowRootOptions",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -4310,20 +4073,16 @@
                 "type": {
                   "type": "reference",
                   "name": "ShadowRootInit",
-                  "qualifiedName": "ShadowRootInit",
-                  "package": "typescript",
-                  "externalLocation": {
-                    "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters"
-                  }
+                  "package": "typescript"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.shadowRootOptions"
@@ -4337,7 +4096,6 @@
             "children": [
               {
                 "name": "elementStyles",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true
                 },
@@ -4361,20 +4119,17 @@
                   "elementType": {
                     "type": "reference",
                     "name": "CSSResultOrNative",
-                    "location": {
-                      "page": "styles",
-                      "anchor": "CSSResultOrNative"
-                    }
+                    "package": "@lit/reactive-element"
                   }
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.elementStyles"
@@ -4382,7 +4137,6 @@
               },
               {
                 "name": "finalizeStyles",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true,
                   "isStatic": true
@@ -4406,21 +4160,22 @@
                 "signatures": [
                   {
                     "name": "finalizeStyles",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 449
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "styles",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "CSSResultGroup",
-                          "location": {
-                            "page": "styles",
-                            "anchor": "CSSResultGroup"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -4429,10 +4184,7 @@
                       "elementType": {
                         "type": "reference",
                         "name": "CSSResultOrNative",
-                        "location": {
-                          "page": "styles",
-                          "anchor": "CSSResultOrNative"
-                        }
+                        "package": "@lit/reactive-element"
                       }
                     }
                   }
@@ -4440,11 +4192,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.finalizeStyles"
@@ -4452,7 +4204,6 @@
               },
               {
                 "name": "styles",
-                "kindString": "Property",
                 "flags": {
                   "isStatic": true,
                   "isOptional": true
@@ -4476,19 +4227,16 @@
                 "type": {
                   "type": "reference",
                   "name": "CSSResultGroup",
-                  "location": {
-                    "page": "styles",
-                    "anchor": "CSSResultGroup"
-                  }
+                  "package": "@lit/reactive-element"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.styles"
@@ -4502,7 +4250,6 @@
             "children": [
               {
                 "name": "enableUpdating",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4519,11 +4266,15 @@
                 "signatures": [
                   {
                     "name": "enableUpdating",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 538
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_requestedUpdate",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "intrinsic",
                           "name": "boolean"
@@ -4539,11 +4290,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.enableUpdating"
@@ -4551,7 +4302,6 @@
               },
               {
                 "name": "firstUpdated",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4569,11 +4319,15 @@
                 "signatures": [
                   {
                     "name": "firstUpdated",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 725
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -4586,7 +4340,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -4595,7 +4348,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -4607,10 +4359,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -4625,11 +4374,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.firstUpdated"
@@ -4637,7 +4386,6 @@
               },
               {
                 "name": "getUpdateComplete",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4665,7 +4413,12 @@
                 "signatures": [
                   {
                     "name": "getUpdateComplete",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 678
+                      }
+                    ],
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -4675,7 +4428,6 @@
                         }
                       ],
                       "name": "Promise",
-                      "qualifiedName": "Promise",
                       "package": "typescript"
                     }
                   }
@@ -4683,11 +4435,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.getUpdateComplete"
@@ -4695,7 +4447,6 @@
               },
               {
                 "name": "hasUpdated",
-                "kindString": "Property",
                 "comment": {
                   "shortText": "Is set to `true` after the first update. The element code cannot assume\nthat `renderRoot` exists before the element `hasUpdated`."
                 },
@@ -4713,11 +4464,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.hasUpdated"
@@ -4725,7 +4476,6 @@
               },
               {
                 "name": "isUpdatePending",
-                "kindString": "Property",
                 "comment": {
                   "shortText": "True if there is a pending update as a result of calling `requestUpdate()`.\nShould only be read."
                 },
@@ -4743,11 +4493,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.isUpdatePending"
@@ -4755,7 +4505,6 @@
               },
               {
                 "name": "performUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4773,7 +4522,12 @@
                 "signatures": [
                   {
                     "name": "performUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 614
+                      }
+                    ],
                     "type": {
                       "type": "union",
                       "types": [
@@ -4790,7 +4544,6 @@
                             }
                           ],
                           "name": "Promise",
-                          "qualifiedName": "Promise",
                           "package": "typescript"
                         }
                       ]
@@ -4800,11 +4553,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.performUpdate"
@@ -4812,7 +4565,6 @@
               },
               {
                 "name": "requestUpdate",
-                "kindString": "Method",
                 "comment": {
                   "shortText": "Requests an update which is processed asynchronously. This should be called\nwhen an element should update based on some state not triggered by setting\na reactive property. In this case, pass no arguments. It should also be\ncalled when manually implementing a property setter. In this case, pass the\nproperty `name` and `oldValue` to ensure that any configured property\noptions are honored."
                 },
@@ -4826,11 +4578,15 @@
                 "signatures": [
                   {
                     "name": "requestUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 574
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -4840,13 +4596,11 @@
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "oldValue",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -4860,7 +4614,6 @@
                       },
                       {
                         "name": "options",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
@@ -4880,10 +4633,7 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "location": {
-                            "page": "ReactiveElement",
-                            "anchor": "PropertyDeclaration"
-                          }
+                          "package": "@lit/reactive-element"
                         }
                       }
                     ],
@@ -4899,20 +4649,16 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.requestUpdate",
-                  "location": {
-                    "page": "controllers",
-                    "anchor": "ReactiveControllerHost.requestUpdate"
-                  }
+                  "name": "ReactiveControllerHost.requestUpdate"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.requestUpdate"
@@ -4920,7 +4666,6 @@
               },
               {
                 "name": "scheduleUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4938,7 +4683,12 @@
                 "signatures": [
                   {
                     "name": "scheduleUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 596
+                      }
+                    ],
                     "type": {
                       "type": "union",
                       "types": [
@@ -4955,7 +4705,6 @@
                             }
                           ],
                           "name": "Promise",
-                          "qualifiedName": "Promise",
                           "package": "typescript"
                         }
                       ]
@@ -4965,11 +4714,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.scheduleUpdate"
@@ -4977,7 +4726,6 @@
               },
               {
                 "name": "shouldUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -4994,11 +4742,15 @@
                 "signatures": [
                   {
                     "name": "shouldUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 687
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -5011,7 +4763,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -5020,7 +4771,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -5032,10 +4782,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -5050,11 +4797,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.shouldUpdate"
@@ -5062,7 +4809,6 @@
               },
               {
                 "name": "update",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -5079,11 +4825,15 @@
                 "signatures": [
                   {
                     "name": "update",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 697
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -5096,7 +4846,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -5105,7 +4854,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -5117,10 +4865,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -5135,11 +4880,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.update"
@@ -5147,7 +4892,6 @@
               },
               {
                 "name": "updateComplete",
-                "kindString": "Accessor",
                 "comment": {
                   "blockTags": [
                     {
@@ -5178,12 +4922,10 @@
                     }
                   ],
                   "name": "Promise",
-                  "qualifiedName": "Promise",
                   "package": "typescript"
                 },
                 "getSignature": {
                   "name": "updateComplete",
-                  "kindString": "Get signature",
                   "comment": {
                     "blockTags": [
                       {
@@ -5198,6 +4940,12 @@
                     "shortText": "Returns a Promise that resolves when the element has completed updating.\nThe Promise value is a boolean that is `true` if the element completed the\nupdate without triggering another update. The Promise result is `false` if\na property was set inside `updated()`. If the Promise is rejected, an\nexception was thrown during the update.",
                     "text": "To await additional asynchronous work, override the `getUpdateComplete`\nmethod. For example, it is sometimes useful to await a rendered element\nbefore fulfilling this Promise. To do this, first await\n`super.getUpdateComplete()`, then any subsequent state.\n"
                   },
+                  "sources": [
+                    {
+                      "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                      "line": 654
+                    }
+                  ],
                   "type": {
                     "type": "reference",
                     "typeArguments": [
@@ -5207,34 +4955,25 @@
                       }
                     ],
                     "name": "Promise",
-                    "qualifiedName": "Promise",
                     "package": "typescript"
                   },
                   "implementationOf": {
                     "type": "reference",
-                    "name": "ReactiveControllerHost.updateComplete",
-                    "location": {
-                      "page": "controllers",
-                      "anchor": "ReactiveControllerHost.updateComplete"
-                    }
+                    "name": "ReactiveControllerHost.updateComplete"
                   }
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.updateComplete",
-                  "location": {
-                    "page": "controllers",
-                    "anchor": "ReactiveControllerHost.updateComplete"
-                  }
+                  "name": "ReactiveControllerHost.updateComplete"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Accessor",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.updateComplete"
@@ -5242,7 +4981,6 @@
               },
               {
                 "name": "updated",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -5260,11 +4998,15 @@
                 "signatures": [
                   {
                     "name": "updated",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 708
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "comment": {
                           "shortText": "Map of changed properties with old values"
                         },
@@ -5277,7 +5019,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -5286,7 +5027,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -5298,10 +5038,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -5316,11 +5053,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.updated"
@@ -5328,7 +5065,6 @@
               },
               {
                 "name": "willUpdate",
-                "kindString": "Method",
                 "flags": {
                   "isProtected": true
                 },
@@ -5346,11 +5082,15 @@
                 "signatures": [
                   {
                     "name": "willUpdate",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                        "line": 636
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "_changedProperties",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
@@ -5360,7 +5100,6 @@
                                 {
                                   "type": "reference",
                                   "name": "PropertyKey",
-                                  "qualifiedName": "PropertyKey",
                                   "package": "typescript"
                                 },
                                 {
@@ -5369,7 +5108,6 @@
                                 }
                               ],
                               "name": "Map",
-                              "qualifiedName": "Map",
                               "package": "typescript"
                             },
                             {
@@ -5381,10 +5119,7 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "location": {
-                                "page": "misc",
-                                "anchor": "PropertyValueMap"
-                              }
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -5399,11 +5134,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.willUpdate"
@@ -5415,7 +5150,6 @@
       },
       {
         "name": "UpdatingElement",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -5431,20 +5165,17 @@
           "queryType": {
             "type": "reference",
             "name": "ReactiveElement",
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "ReactiveElement"
-            }
+            "package": "@lit/reactive-element"
           }
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "ReactiveElement",
           "anchor": "UpdatingElement"
@@ -5452,14 +5183,12 @@
       },
       {
         "name": "ComplexAttributeConverter",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Converts property values to and from attribute values."
         },
         "children": [
           {
             "name": "fromAttribute",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -5476,11 +5205,15 @@
             "signatures": [
               {
                 "name": "fromAttribute",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 46
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -5497,7 +5230,6 @@
                   },
                   {
                     "name": "type",
-                    "kindString": "Parameter",
                     "flags": {
                       "isOptional": true
                     },
@@ -5516,11 +5248,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "ReactiveElement",
               "anchor": "ComplexAttributeConverter.fromAttribute"
@@ -5528,7 +5260,6 @@
           },
           {
             "name": "toAttribute",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -5546,11 +5277,15 @@
             "signatures": [
               {
                 "name": "toAttribute",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 54
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Type"
@@ -5558,7 +5293,6 @@
                   },
                   {
                     "name": "type",
-                    "kindString": "Parameter",
                     "flags": {
                       "isOptional": true
                     },
@@ -5577,11 +5311,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "ReactiveElement",
               "anchor": "ComplexAttributeConverter.toAttribute"
@@ -5598,7 +5332,6 @@
         "typeParameters": [
           {
             "name": "Type",
-            "kindString": "Type parameter",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
@@ -5606,7 +5339,6 @@
           },
           {
             "name": "TypeHint",
-            "kindString": "Type parameter",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
@@ -5616,11 +5348,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "ReactiveElement",
           "anchor": "ComplexAttributeConverter"
@@ -5628,14 +5360,12 @@
       },
       {
         "name": "PropertyDeclaration",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Defines options for a property accessor."
         },
         "children": [
           {
             "name": "attribute",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -5666,11 +5396,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.attribute"
@@ -5678,7 +5408,6 @@
           },
           {
             "name": "converter",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -5705,16 +5434,17 @@
                   "name": "TypeHint"
                 }
               ],
-              "name": "AttributeConverter"
+              "name": "AttributeConverter",
+              "package": "@lit/reactive-element"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.converter"
@@ -5722,7 +5452,6 @@
           },
           {
             "name": "noAccessor",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -5744,11 +5473,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.noAccessor"
@@ -5756,7 +5485,6 @@
           },
           {
             "name": "reflect",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -5778,11 +5506,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.reflect"
@@ -5790,7 +5518,6 @@
           },
           {
             "name": "state",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -5812,11 +5539,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.state"
@@ -5824,7 +5551,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -5846,11 +5572,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.type"
@@ -5858,7 +5584,6 @@
           },
           {
             "name": "hasChanged",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -5875,11 +5600,15 @@
             "signatures": [
               {
                 "name": "hasChanged",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 109
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Type"
@@ -5887,7 +5616,6 @@
                   },
                   {
                     "name": "oldValue",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Type"
@@ -5903,11 +5631,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.hasChanged"
@@ -5924,7 +5652,6 @@
         "typeParameters": [
           {
             "name": "Type",
-            "kindString": "Type parameter",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
@@ -5932,7 +5659,6 @@
           },
           {
             "name": "TypeHint",
-            "kindString": "Type parameter",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
@@ -5942,11 +5668,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyDeclaration"
@@ -5954,7 +5680,6 @@
       },
       {
         "name": "PropertyDeclarations",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Map of properties to PropertyDeclaration options. For each property an\naccessor is made, and the property is processed according to the\nPropertyDeclaration options."
         },
@@ -5967,7 +5692,12 @@
         ],
         "indexSignature": {
           "name": "__index",
-          "kindString": "Index signature",
+          "sources": [
+            {
+              "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+              "line": 126
+            }
+          ],
           "parameters": [
             {
               "name": "key",
@@ -5980,20 +5710,17 @@
           "type": {
             "type": "reference",
             "name": "PropertyDeclaration",
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "PropertyDeclaration"
-            }
+            "package": "@lit/reactive-element"
           }
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyDeclarations"
@@ -6001,7 +5728,6 @@
       },
       {
         "name": "PropertyValues",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "A Map of property keys to values.",
           "text": "Takes an optional type parameter T, which when specified as a non-any,\nnon-unknown type, will make the Map more strongly-typed, associating the map\nkeys with their corresponding value type on T.\nUse `PropertyValues<this>` when overriding ReactiveElement.update() and\nother lifecycle methods in order to get stronger type-checking on keys\nand values.\n"
@@ -6016,7 +5742,6 @@
         "typeParameters": [
           {
             "name": "T",
-            "kindString": "Type parameter",
             "default": {
               "type": "intrinsic",
               "name": "any"
@@ -6042,10 +5767,7 @@
               }
             ],
             "name": "PropertyValueMap",
-            "location": {
-              "page": "misc",
-              "anchor": "PropertyValueMap"
-            }
+            "package": "@lit/reactive-element"
           },
           "falseType": {
             "type": "reference",
@@ -6053,7 +5775,6 @@
               {
                 "type": "reference",
                 "name": "PropertyKey",
-                "qualifiedName": "PropertyKey",
                 "package": "typescript"
               },
               {
@@ -6062,18 +5783,17 @@
               }
             ],
             "name": "Map",
-            "qualifiedName": "Map",
             "package": "typescript"
           }
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyValues"
@@ -6092,7 +5812,6 @@
     "items": [
       {
         "name": "html",
-        "kindString": "Function",
         "comment": {
           "shortText": "Interprets a template literal as an HTML template that can efficiently\nrender to and update a container.",
           "text": "```ts\nconst header = (title: string) => html`<h1>${title}</h1>`;\n```\nThe `html` tag returns a description of the DOM to render as a value. It is\nlazy, meaning no work is done until the template is rendered. When rendering,\nif a template comes from the same expression as a previously rendered result,\nit's efficiently updated instead of replaced.\n"
@@ -6107,21 +5826,23 @@
         "signatures": [
           {
             "name": "html",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                "line": 226
+              }
+            ],
             "parameters": [
               {
                 "name": "strings",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -6143,21 +5864,18 @@
                 }
               ],
               "name": "TemplateResult",
-              "location": {
-                "page": "templates",
-                "anchor": "TemplateResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "templates",
           "anchor": "html"
@@ -6165,7 +5883,6 @@
       },
       {
         "name": "nothing",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -6187,11 +5904,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "templates",
           "anchor": "nothing"
@@ -6199,7 +5916,6 @@
       },
       {
         "name": "render",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -6225,11 +5941,15 @@
         "signatures": [
           {
             "name": "render",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                "line": 548
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "Any [renderable\n  value](https://lit.dev/docs/templates/expressions/#child-expressions),\n  typically a {@linkcode TemplateResult} created by evaluating a template tag\n  like {@linkcode html} or {@linkcode svg}."
                 },
@@ -6240,7 +5960,6 @@
               },
               {
                 "name": "container",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "A DOM container to render to. The first render will append\n  the rendered value to the container, and subsequent renders will\n  efficiently update the rendered value if the same result type was\n  previously rendered there."
                 },
@@ -6250,27 +5969,18 @@
                     {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     },
                     {
                       "type": "reference",
                       "name": "DocumentFragment",
-                      "qualifiedName": "DocumentFragment",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
-                      }
+                      "package": "typescript"
                     }
                   ]
                 }
               },
               {
                 "name": "options",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -6280,31 +5990,25 @@
                 "type": {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "type": {
               "type": "reference",
               "name": "RootPart",
-              "location": {
-                "page": "misc",
-                "anchor": "RootPart"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "templates",
           "anchor": "render"
@@ -6312,7 +6016,6 @@
       },
       {
         "name": "svg",
-        "kindString": "Function",
         "comment": {
           "shortText": "Interprets a template literal as an SVG fragment that can efficiently\nrender to and update a container.",
           "text": "```ts\nconst rect = svg`<rect width=\"10\" height=\"10\"></rect>`;\nconst myImage = html`\n  <svg viewBox=\"0 0 10 10\" xmlns=\"http://www.w3.org/2000/svg\">\n    ${rect}\n  </svg>`;\n```\nThe `svg` *tag function* should only be used for SVG fragments, or elements\nthat would be contained **inside** an `<svg>` HTML element. A common error is\nplacing an `<svg>` *element* in a template tagged with the `svg` tag\nfunction. The `<svg>` element is an HTML element and should be used within a\ntemplate tagged with the `html` tag function.\nIn LitElement usage, it's invalid to return an SVG fragment from the\n`render()` method, as the SVG fragment will be contained within the element's\nshadow root and thus cannot be used within an `<svg>` HTML element.\n"
@@ -6327,21 +6030,23 @@
         "signatures": [
           {
             "name": "svg",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                "line": 250
+              }
+            ],
             "parameters": [
               {
                 "name": "strings",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -6363,21 +6068,18 @@
                 }
               ],
               "name": "TemplateResult",
-              "location": {
-                "page": "templates",
-                "anchor": "TemplateResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "templates",
           "anchor": "svg"
@@ -6385,7 +6087,6 @@
       },
       {
         "name": "SanitizerFactory",
-        "kindString": "Type alias",
         "comment": {
           "blockTags": [
             {
@@ -6411,7 +6112,6 @@
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -6421,7 +6121,6 @@
             "signatures": [
               {
                 "name": "__type",
-                "kindString": "Call signature",
                 "comment": {
                   "blockTags": [
                     {
@@ -6439,20 +6138,17 @@
                 "parameters": [
                   {
                     "name": "node",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The HTML node (usually either a #text node or an Element) that\n    is being written to. Note that this is just an exemplar node, the write\n    may take place against another instance of the same class of node."
                     },
                     "type": {
                       "type": "reference",
                       "name": "Node",
-                      "qualifiedName": "Node",
                       "package": "typescript"
                     }
                   },
                   {
                     "name": "name",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The name of an attribute or property (for example, 'href')."
                     },
@@ -6463,7 +6159,6 @@
                   },
                   {
                     "name": "type",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "Indicates whether the write that's about to be performed will\n    be to a property or a node."
                     },
@@ -6485,10 +6180,7 @@
                 "type": {
                   "type": "reference",
                   "name": "ValueSanitizer",
-                  "location": {
-                    "page": "misc",
-                    "anchor": "ValueSanitizer"
-                  }
+                  "package": "lit-html"
                 }
               }
             ]
@@ -6497,11 +6189,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "templates",
           "anchor": "SanitizerFactory"
@@ -6509,7 +6201,6 @@
       },
       {
         "name": "SVGTemplateResult",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
@@ -6524,24 +6215,22 @@
               "type": "query",
               "queryType": {
                 "type": "reference",
-                "name": "SVG_RESULT"
+                "name": "SVG_RESULT",
+                "package": "lit-html"
               }
             }
           ],
           "name": "TemplateResult",
-          "location": {
-            "page": "templates",
-            "anchor": "TemplateResult"
-          }
+          "package": "lit-html"
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "templates",
           "anchor": "SVGTemplateResult"
@@ -6549,7 +6238,6 @@
       },
       {
         "name": "TemplateResult",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "The return type of the template tag functions, `html` and\n`svg`.",
           "text": "A `TemplateResult` object holds all the information about a template\nexpression required to render it: the template strings, expression values,\nand type of template (html or svg).\n`TemplateResult` objects do not create any DOM on their own. To create or\nupdate DOM you need to render the `TemplateResult`. See\n[Rendering](https://lit.dev/docs/components/rendering) for more information.\n"
@@ -6564,14 +6252,15 @@
         "typeParameters": [
           {
             "name": "T",
-            "kindString": "Type parameter",
             "type": {
               "type": "reference",
-              "name": "ResultType"
+              "name": "ResultType",
+              "package": "lit-html"
             },
             "default": {
               "type": "reference",
-              "name": "ResultType"
+              "name": "ResultType",
+              "package": "lit-html"
             }
           }
         ],
@@ -6579,11 +6268,9 @@
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "children": [
               {
                 "name": "_$litType$",
-                "kindString": "Property",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -6597,7 +6284,6 @@
               },
               {
                 "name": "strings",
-                "kindString": "Property",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -6607,13 +6293,11 @@
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Property",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -6640,11 +6324,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "templates",
           "anchor": "TemplateResult"
@@ -6663,7 +6347,6 @@
     "items": [
       {
         "name": "adoptStyles",
-        "kindString": "Function",
         "comment": {
           "shortText": "Applies the given styles to a `shadowRoot`. When Shadow DOM is\navailable but `adoptedStyleSheets` is not, styles are appended to the\n`shadowRoot` to [mimic spec behavior](https://wicg.github.io/construct-stylesheets/#using-constructed-stylesheets).\nNote, when shimming is used, any styles that are subsequently placed into\nthe shadowRoot should be placed *before* any shimmed adopted styles. This\nwill match spec behavior that gives adopted sheets precedence over styles in\nshadowRoot."
         },
@@ -6677,33 +6360,29 @@
         "signatures": [
           {
             "name": "adoptStyles",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/css-tag.d.ts",
+                "line": 65
+              }
+            ],
             "parameters": [
               {
                 "name": "renderRoot",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "ShadowRoot",
-                  "qualifiedName": "ShadowRoot",
-                  "package": "typescript",
-                  "externalLocation": {
-                    "url": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
-                  }
+                  "package": "typescript"
                 }
               },
               {
                 "name": "styles",
-                "kindString": "Parameter",
                 "type": {
                   "type": "array",
                   "elementType": {
                     "type": "reference",
                     "name": "CSSResultOrNative",
-                    "location": {
-                      "page": "styles",
-                      "anchor": "CSSResultOrNative"
-                    }
+                    "package": "@lit/reactive-element"
                   }
                 }
               }
@@ -6717,11 +6396,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "adoptStyles"
@@ -6729,7 +6408,6 @@
       },
       {
         "name": "css",
-        "kindString": "Function",
         "comment": {
           "shortText": "A template literal tag which can be used with LitElement's\n`styles` property to set element styles.",
           "text": "For security reasons, only literal string values and number may be used in\nembedded expressions. To incorporate non-literal values [`unsafeCSS`](/docs/api/styles/#unsafeCSS)\nmay be used inside an expression.\n"
@@ -6744,21 +6422,23 @@
         "signatures": [
           {
             "name": "css",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/css-tag.d.ts",
+                "line": 55
+              }
+            ],
             "parameters": [
               {
                 "name": "strings",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -6774,10 +6454,7 @@
                       {
                         "type": "reference",
                         "name": "CSSResultGroup",
-                        "location": {
-                          "page": "styles",
-                          "anchor": "CSSResultGroup"
-                        }
+                        "package": "@lit/reactive-element"
                       }
                     ]
                   }
@@ -6787,21 +6464,18 @@
             "type": {
               "type": "reference",
               "name": "CSSResult",
-              "location": {
-                "page": "styles",
-                "anchor": "CSSResult"
-              }
+              "package": "@lit/reactive-element"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "css"
@@ -6809,7 +6483,6 @@
       },
       {
         "name": "CSSResult",
-        "kindString": "Class",
         "comment": {
           "shortText": "A container for a string of CSS text, that may be used to create a CSSStyleSheet.",
           "text": "CSSResult is the return value of `css`-tagged template literals and\n`unsafeCSS()`. In order to ensure that CSSResults are only created via the\n`css` tag and `unsafeCSS()`, CSSResult cannot be constructed directly.\n"
@@ -6817,7 +6490,6 @@
         "children": [
           {
             "name": "cssText",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -6835,11 +6507,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "styles",
               "anchor": "CSSResult.cssText"
@@ -6847,7 +6519,6 @@
           },
           {
             "name": "styleSheet",
-            "kindString": "Accessor",
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/css-tag.ts",
@@ -6865,17 +6536,18 @@
                 {
                   "type": "reference",
                   "name": "CSSStyleSheet",
-                  "qualifiedName": "CSSStyleSheet",
-                  "package": "typescript",
-                  "externalLocation": {
-                    "url": "https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet"
-                  }
+                  "package": "typescript"
                 }
               ]
             },
             "getSignature": {
               "name": "styleSheet",
-              "kindString": "Get signature",
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/css-tag.d.ts",
+                  "line": 36
+                }
+              ],
               "type": {
                 "type": "union",
                 "types": [
@@ -6886,11 +6558,7 @@
                   {
                     "type": "reference",
                     "name": "CSSStyleSheet",
-                    "qualifiedName": "CSSStyleSheet",
-                    "package": "typescript",
-                    "externalLocation": {
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet"
-                    }
+                    "package": "typescript"
                   }
                 ]
               }
@@ -6898,11 +6566,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "styles",
               "anchor": "CSSResult.styleSheet"
@@ -6910,7 +6578,6 @@
           },
           {
             "name": "toString",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/css-tag.ts",
@@ -6921,7 +6588,12 @@
             "signatures": [
               {
                 "name": "toString",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/css-tag.d.ts",
+                    "line": 37
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
@@ -6931,11 +6603,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "styles",
               "anchor": "CSSResult.toString"
@@ -6952,11 +6624,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "styles",
           "anchor": "CSSResult"
@@ -6964,7 +6636,6 @@
       },
       {
         "name": "getCompatibleStyle",
-        "kindString": "Function",
         "sources": [
           {
             "fileName": "packages/reactive-element/src/css-tag.ts",
@@ -6975,39 +6646,37 @@
         "signatures": [
           {
             "name": "getCompatibleStyle",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/css-tag.d.ts",
+                "line": 66
+              }
+            ],
             "parameters": [
               {
                 "name": "s",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "CSSResultOrNative",
-                  "location": {
-                    "page": "styles",
-                    "anchor": "CSSResultOrNative"
-                  }
+                  "package": "@lit/reactive-element"
                 }
               }
             ],
             "type": {
               "type": "reference",
               "name": "CSSResultOrNative",
-              "location": {
-                "page": "styles",
-                "anchor": "CSSResultOrNative"
-              }
+              "package": "@lit/reactive-element"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "getCompatibleStyle"
@@ -7015,7 +6684,6 @@
       },
       {
         "name": "supportsAdoptingStyleSheets",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -7036,11 +6704,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "styles",
           "anchor": "supportsAdoptingStyleSheets"
@@ -7048,7 +6716,6 @@
       },
       {
         "name": "unsafeCSS",
-        "kindString": "Function",
         "comment": {
           "shortText": "Wrap a value for interpolation in a [`css`](/docs/api/styles/#css) tagged template literal.",
           "text": "This is unsafe because untrusted CSS text can be used to phone home\nor exfiltrate data to an attacker controlled site. Take care to only use\nthis with trusted input.\n"
@@ -7063,11 +6730,15 @@
         "signatures": [
           {
             "name": "unsafeCSS",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/css-tag.d.ts",
+                "line": 46
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -7077,21 +6748,18 @@
             "type": {
               "type": "reference",
               "name": "CSSResult",
-              "location": {
-                "page": "styles",
-                "anchor": "CSSResult"
-              }
+              "package": "@lit/reactive-element"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "unsafeCSS"
@@ -7099,7 +6767,6 @@
       },
       {
         "name": "CSSResultArray",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/reactive-element/src/css-tag.ts",
@@ -7115,18 +6782,12 @@
               {
                 "type": "reference",
                 "name": "CSSResultOrNative",
-                "location": {
-                  "page": "styles",
-                  "anchor": "CSSResultOrNative"
-                }
+                "package": "@lit/reactive-element"
               },
               {
                 "type": "reference",
                 "name": "CSSResultArray",
-                "location": {
-                  "page": "styles",
-                  "anchor": "CSSResultArray"
-                }
+                "package": "@lit/reactive-element"
               }
             ]
           }
@@ -7134,11 +6795,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "styles",
           "anchor": "CSSResultArray"
@@ -7146,7 +6807,6 @@
       },
       {
         "name": "CSSResultGroup",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "A single CSSResult, CSSStyleSheet, or an array or nested arrays of those."
         },
@@ -7163,29 +6823,23 @@
             {
               "type": "reference",
               "name": "CSSResultOrNative",
-              "location": {
-                "page": "styles",
-                "anchor": "CSSResultOrNative"
-              }
+              "package": "@lit/reactive-element"
             },
             {
               "type": "reference",
               "name": "CSSResultArray",
-              "location": {
-                "page": "styles",
-                "anchor": "CSSResultArray"
-              }
+              "package": "@lit/reactive-element"
             }
           ]
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "styles",
           "anchor": "CSSResultGroup"
@@ -7193,7 +6847,6 @@
       },
       {
         "name": "CSSResultOrNative",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "A CSSResult or native CSSStyleSheet.",
           "text": "In browsers that support constructible CSS style sheets, CSSStyleSheet\nobject can be used for styling along side CSSResult from the `css`\ntemplate tag.\n"
@@ -7211,30 +6864,23 @@
             {
               "type": "reference",
               "name": "CSSResult",
-              "location": {
-                "page": "styles",
-                "anchor": "CSSResult"
-              }
+              "package": "@lit/reactive-element"
             },
             {
               "type": "reference",
               "name": "CSSStyleSheet",
-              "qualifiedName": "CSSStyleSheet",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet"
-              }
+              "package": "typescript"
             }
           ]
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "styles",
           "anchor": "CSSResultOrNative"
@@ -7253,7 +6899,6 @@
     "items": [
       {
         "name": "customElement",
-        "kindString": "Function",
         "comment": {
           "shortText": "Class decorator factory that defines the decorated class as a custom element.",
           "text": "```js\n@customElement('my-element')\nclass MyElement extends LitElement {\n  render() {\n    return html``;\n  }\n}\n```\n"
@@ -7268,11 +6913,15 @@
         "signatures": [
           {
             "name": "customElement",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/custom-element.d.ts",
+                "line": 25
+              }
+            ],
             "parameters": [
               {
                 "name": "tagName",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "The tag name of the custom element to define."
                 },
@@ -7286,7 +6935,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/custom-element.d.ts",
@@ -7296,21 +6944,27 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/custom-element.d.ts",
+                        "line": 25
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "classOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
-                              "name": "ClassDescriptor"
+                              "name": "ClassDescriptor",
+                              "package": "@lit/reactive-element"
                             },
                             {
                               "type": "reference",
-                              "name": "CustomElementClass"
+                              "name": "CustomElementClass",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
@@ -7329,11 +6983,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "customElement"
@@ -7341,7 +6995,6 @@
       },
       {
         "name": "eventOptions",
-        "kindString": "Function",
         "comment": {
           "shortText": "Adds event listener options to a method used as an event listener in a\nlit-html template."
         },
@@ -7355,11 +7008,15 @@
         "signatures": [
           {
             "name": "eventOptions",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/event-options.d.ts",
+                "line": 37
+              }
+            ],
             "parameters": [
               {
                 "name": "options",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "An object that specifies event listener options as accepted by\n`EventTarget#addEventListener` and `EventTarget#removeEventListener`.",
                   "text": "Current browsers support the `capture`, `passive`, and `once` options. See:\nhttps://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters\n```ts\nclass MyElement {\n  clicked = false;\n  render() {\n    return html`\n      <div @click=${this._onClick}>\n        <button></button>\n      </div>\n    `;\n  }\n  @eventOptions({capture: true})\n  _onClick(e) {\n    this.clicked = true;\n  }\n}\n```\n"
@@ -7367,7 +7024,6 @@
                 "type": {
                   "type": "reference",
                   "name": "AddEventListenerOptions",
-                  "qualifiedName": "AddEventListenerOptions",
                   "package": "typescript"
                 }
               }
@@ -7376,7 +7032,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/event-options.d.ts",
@@ -7386,39 +7041,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "location": {
-                                "page": "ReactiveElement",
-                                "anchor": "ReactiveElement"
-                              }
+                              "package": "@lit/reactive-element"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -7436,11 +7085,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "eventOptions"
@@ -7448,7 +7097,6 @@
       },
       {
         "name": "property",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -7468,11 +7116,15 @@
         "signatures": [
           {
             "name": "property",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/property.d.ts",
+                "line": 40
+              }
+            ],
             "parameters": [
               {
                 "name": "options",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -7489,10 +7141,7 @@
                     }
                   ],
                   "name": "PropertyDeclaration",
-                  "location": {
-                    "page": "ReactiveElement",
-                    "anchor": "PropertyDeclaration"
-                  }
+                  "package": "@lit/reactive-element"
                 }
               }
             ],
@@ -7500,7 +7149,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/property.d.ts",
@@ -7510,37 +7158,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "Object",
-                              "qualifiedName": "Object",
                               "package": "typescript"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -7558,11 +7202,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "property"
@@ -7570,7 +7214,6 @@
       },
       {
         "name": "query",
-        "kindString": "Function",
         "comment": {
           "shortText": "A property decorator that converts a class property into a getter that\nexecutes a querySelector on the element's renderRoot."
         },
@@ -7584,11 +7227,15 @@
         "signatures": [
           {
             "name": "query",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query.d.ts",
+                "line": 32
+              }
+            ],
             "parameters": [
               {
                 "name": "selector",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "A DOMString containing one or more selectors to match."
                 },
@@ -7599,7 +7246,6 @@
               },
               {
                 "name": "cache",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -7617,7 +7263,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query.d.ts",
@@ -7627,39 +7272,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "location": {
-                                "page": "ReactiveElement",
-                                "anchor": "ReactiveElement"
-                              }
+                              "package": "@lit/reactive-element"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -7677,11 +7316,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "query"
@@ -7689,7 +7328,6 @@
       },
       {
         "name": "queryAll",
-        "kindString": "Function",
         "comment": {
           "shortText": "A property decorator that converts a class property into a getter\nthat executes a querySelectorAll on the element's renderRoot."
         },
@@ -7703,11 +7341,15 @@
         "signatures": [
           {
             "name": "queryAll",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-all.d.ts",
+                "line": 31
+              }
+            ],
             "parameters": [
               {
                 "name": "selector",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "A DOMString containing one or more selectors to match.",
                   "text": "See:\nhttps://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll\n```ts\nclass MyElement {\n  @queryAll('div')\n  divs: NodeListOf<HTMLDivElement>;\n  render() {\n    return html`\n      <div id=\"first\"></div>\n      <div id=\"second\"></div>\n    `;\n  }\n}\n```\n"
@@ -7722,7 +7364,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-all.d.ts",
@@ -7732,39 +7373,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "location": {
-                                "page": "ReactiveElement",
-                                "anchor": "ReactiveElement"
-                              }
+                              "package": "@lit/reactive-element"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -7782,11 +7417,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAll"
@@ -7794,7 +7429,6 @@
       },
       {
         "name": "queryAssignedElements",
-        "kindString": "Function",
         "comment": {
           "shortText": "A property decorator that converts a class property into a getter that\nreturns the `assignedElements` of the given `slot`. Provides a declarative\nway to use\n[`HTMLSlotElement.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).",
           "text": "Can be passed an optional [`QueryAssignedElementsOptions`](/docs/api/decorators/#QueryAssignedElementsOptions) object.\nExample usage:\n```ts\nclass MyElement {\n  @queryAssignedElements({ slot: 'list' })\n  listItems!: Array<HTMLElement>;\n  @queryAssignedElements()\n  unnamedSlotEls!: Array<HTMLElement>;\n  render() {\n    return html`\n      <slot name=\"list\"></slot>\n      <slot></slot>\n    `;\n  }\n}\n```\nNote, the type of this property should be annotated as `Array<HTMLElement>`.\n"
@@ -7809,21 +7443,22 @@
         "signatures": [
           {
             "name": "queryAssignedElements",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-assigned-elements.d.ts",
+                "line": 49
+              }
+            ],
             "parameters": [
               {
                 "name": "options",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
                 "type": {
                   "type": "reference",
                   "name": "QueryAssignedElementsOptions",
-                  "location": {
-                    "page": "decorators",
-                    "anchor": "QueryAssignedElementsOptions"
-                  }
+                  "package": "@lit/reactive-element"
                 }
               }
             ],
@@ -7831,7 +7466,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-assigned-elements.d.ts",
@@ -7841,39 +7475,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "location": {
-                                "page": "ReactiveElement",
-                                "anchor": "ReactiveElement"
-                              }
+                              "package": "@lit/reactive-element"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -7891,11 +7519,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAssignedElements"
@@ -7903,7 +7531,6 @@
       },
       {
         "name": "queryAssignedNodes",
-        "kindString": "Function",
         "comment": {
           "shortText": "A property decorator that converts a class property into a getter that\nreturns the `assignedNodes` of the given `slot`.",
           "text": "Can be passed an optional [`QueryAssignedNodesOptions`](/docs/api/decorators/#QueryAssignedNodesOptions) object.\nExample usage:\n```ts\nclass MyElement {\n  @queryAssignedNodes({slot: 'list', flatten: true})\n  listItems!: Array<Node>;\n  render() {\n    return html`\n      <slot name=\"list\"></slot>\n    `;\n  }\n}\n```\nNote the type of this property should be annotated as `Array<Node>`.\n"
@@ -7923,32 +7550,33 @@
         "signatures": [
           {
             "name": "queryAssignedNodes",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-assigned-nodes.d.ts",
+                "line": 41
+              }
+            ],
             "parameters": [
               {
                 "name": "options",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
                 "type": {
                   "type": "reference",
                   "name": "QueryAssignedNodesOptions",
-                  "location": {
-                    "page": "decorators",
-                    "anchor": "QueryAssignedNodesOptions"
-                  }
+                  "package": "@lit/reactive-element"
                 }
               }
             ],
             "type": {
               "type": "reference",
-              "name": "TSDecoratorReturnType"
+              "name": "TSDecoratorReturnType",
+              "package": "@lit/reactive-element"
             }
           },
           {
             "name": "queryAssignedNodes",
-            "kindString": "Call signature",
             "comment": {
               "blockTags": [
                 {
@@ -7999,10 +7627,15 @@
               "shortText": "A property decorator that converts a class property into a getter that\nreturns the `assignedNodes` of the given named `slot`.",
               "text": "Example usage:\n```ts\nclass MyElement {\n  @queryAssignedNodes('list', true, '.item')\n  listItems!: Array<HTMLElement>;\n  render() {\n    return html`\n      <slot name=\"list\"></slot>\n    `;\n  }\n}\n```\nNote the type of this property should be annotated as `Array<Node>` if used\nwithout a `selector` or `Array<HTMLElement>` if a selector is provided.\nUse {@linkcode @queryAssignedElements} to list only\nelements, and optionally filter the element list using a CSS selector.\n"
             },
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-assigned-nodes.d.ts",
+                "line": 78
+              }
+            ],
             "parameters": [
               {
                 "name": "slotName",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -8016,7 +7649,6 @@
               },
               {
                 "name": "flatten",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -8030,7 +7662,6 @@
               },
               {
                 "name": "selector",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -8045,18 +7676,19 @@
             ],
             "type": {
               "type": "reference",
-              "name": "TSDecoratorReturnType"
+              "name": "TSDecoratorReturnType",
+              "package": "@lit/reactive-element"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAssignedNodes"
@@ -8064,7 +7696,6 @@
       },
       {
         "name": "queryAsync",
-        "kindString": "Function",
         "comment": {
           "shortText": "A property decorator that converts a class property into a getter that\nreturns a promise that resolves to the result of a querySelector on the\nelement's renderRoot done after the element's `updateComplete` promise\nresolves. When the queried property may change with element state, this\ndecorator can be used instead of requiring users to await the\n`updateComplete` before accessing the property."
         },
@@ -8078,11 +7709,15 @@
         "signatures": [
           {
             "name": "queryAsync",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-async.d.ts",
+                "line": 39
+              }
+            ],
             "parameters": [
               {
                 "name": "selector",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "A DOMString containing one or more selectors to match.",
                   "text": "See: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector\n```ts\nclass MyElement {\n  @queryAsync('#first')\n  first: Promise<HTMLDivElement>;\n  render() {\n    return html`\n      <div id=\"first\"></div>\n      <div id=\"second\"></div>\n    `;\n  }\n}\n// external usage\nasync doSomethingWithFirst() {\n (await aMyElement.first).doSomething();\n}\n```\n"
@@ -8097,7 +7732,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/query-async.d.ts",
@@ -8107,39 +7741,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "location": {
-                                "page": "ReactiveElement",
-                                "anchor": "ReactiveElement"
-                              }
+                              "package": "@lit/reactive-element"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -8157,11 +7785,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAsync"
@@ -8169,7 +7797,6 @@
       },
       {
         "name": "state",
-        "kindString": "Function",
         "comment": {
           "shortText": "Declares a private or protected reactive property that still triggers\nupdates to the element when it changes. It does not reflect from the\ncorresponding attribute.",
           "text": "Properties declared this way must not be used from HTML or HTML templating\nsystems, they're solely for properties internal to the element. These\nproperties may be renamed by optimization tools like closure compiler.\n"
@@ -8184,11 +7811,15 @@
         "signatures": [
           {
             "name": "state",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/state.d.ts",
+                "line": 24
+              }
+            ],
             "parameters": [
               {
                 "name": "options",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -8201,10 +7832,7 @@
                     }
                   ],
                   "name": "InternalPropertyDeclaration",
-                  "location": {
-                    "page": "decorators",
-                    "anchor": "InternalPropertyDeclaration"
-                  }
+                  "package": "@lit/reactive-element"
                 }
               }
             ],
@@ -8212,7 +7840,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/state.d.ts",
@@ -8222,37 +7849,33 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "protoOrDescriptor",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "Object",
-                              "qualifiedName": "Object",
                               "package": "typescript"
                             },
                             {
                               "type": "reference",
-                              "name": "ClassElement"
+                              "name": "ClassElement",
+                              "package": "@lit/reactive-element"
                             }
                           ]
                         }
                       },
                       {
                         "name": "name",
-                        "kindString": "Parameter",
                         "flags": {
                           "isOptional": true
                         },
                         "type": {
                           "type": "reference",
                           "name": "PropertyKey",
-                          "qualifiedName": "PropertyKey",
                           "package": "typescript"
                         }
                       }
@@ -8270,11 +7893,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "state"
@@ -8282,7 +7905,6 @@
       },
       {
         "name": "InternalPropertyDeclaration",
-        "kindString": "Interface",
         "comment": {
           "blockTags": [
             {
@@ -8298,7 +7920,6 @@
         "children": [
           {
             "name": "hasChanged",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -8315,11 +7936,15 @@
             "signatures": [
               {
                 "name": "hasChanged",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/decorators/state.d.ts",
+                    "line": 12
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Type"
@@ -8327,7 +7952,6 @@
                   },
                   {
                     "name": "oldValue",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Type"
@@ -8343,11 +7967,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "decorators",
               "anchor": "InternalPropertyDeclaration.hasChanged"
@@ -8364,7 +7988,6 @@
         "typeParameters": [
           {
             "name": "Type",
-            "kindString": "Type parameter",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
@@ -8374,11 +7997,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "decorators",
           "anchor": "InternalPropertyDeclaration"
@@ -8386,14 +8009,12 @@
       },
       {
         "name": "QueryAssignedElementsOptions",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Options for the [`queryAssignedElements`](/docs/api/decorators/#queryAssignedElements) decorator. Extends the\noptions that can be passed into\n[HTMLSlotElement.assignedElements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements)."
         },
         "children": [
           {
             "name": "selector",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -8414,11 +8035,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "decorators",
               "anchor": "QueryAssignedElementsOptions.selector"
@@ -8426,7 +8047,6 @@
           },
           {
             "name": "slot",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -8446,20 +8066,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "QueryAssignedNodesOptions.slot",
-              "location": {
-                "page": "decorators",
-                "anchor": "QueryAssignedNodesOptions.slot"
-              }
+              "name": "QueryAssignedNodesOptions.slot"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "decorators",
               "anchor": "QueryAssignedElementsOptions.slot"
@@ -8477,20 +8093,17 @@
           {
             "type": "reference",
             "name": "QueryAssignedNodesOptions",
-            "location": {
-              "page": "decorators",
-              "anchor": "QueryAssignedNodesOptions"
-            }
+            "package": "@lit/reactive-element"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "decorators",
           "anchor": "QueryAssignedElementsOptions"
@@ -8499,29 +8112,18 @@
           {
             "type": "reference",
             "name": "QueryAssignedNodesOptions",
-            "location": {
-              "page": "decorators",
-              "anchor": "QueryAssignedNodesOptions"
-            }
-          },
-          {
-            "type": "reference",
-            "name": "AssignedNodesOptions",
-            "qualifiedName": "AssignedNodesOptions",
-            "package": "typescript"
+            "package": "@lit/reactive-element"
           }
         ]
       },
       {
         "name": "QueryAssignedNodesOptions",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Options for the [`queryAssignedNodes`](/docs/api/decorators/#queryAssignedNodes) decorator. Extends the options\nthat can be passed into [HTMLSlotElement.assignedNodes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes)."
         },
         "children": [
           {
             "name": "slot",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -8542,11 +8144,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "decorators",
               "anchor": "QueryAssignedNodesOptions.slot"
@@ -8564,28 +8166,23 @@
           {
             "type": "reference",
             "name": "AssignedNodesOptions",
-            "qualifiedName": "AssignedNodesOptions",
             "package": "typescript"
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "QueryAssignedElementsOptions",
-            "location": {
-              "page": "decorators",
-              "anchor": "QueryAssignedElementsOptions"
-            }
+            "name": "QueryAssignedElementsOptions"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/decorators.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "decorators",
           "anchor": "QueryAssignedNodesOptions"
@@ -8594,7 +8191,6 @@
           {
             "type": "reference",
             "name": "AssignedNodesOptions",
-            "qualifiedName": "AssignedNodesOptions",
             "package": "typescript"
           }
         ]
@@ -8612,7 +8208,6 @@
     "items": [
       {
         "name": "asyncAppend",
-        "kindString": "Function",
         "comment": {
           "shortText": "A directive that renders the items of an async iterable[1], appending new\nvalues after previous values, similar to the built-in support for iterables.\nThis directive is usable only in child expressions.",
           "text": "Async iterables are objects with a [Symbol.asyncIterator] method, which\nreturns an iterator who's `next()` method returns a Promise. When a new\nvalue is available, the Promise resolves and the value is appended to the\nPart controlled by the directive. If another value other than this\ndirective has been set on the Part, the iterable will no longer be listened\nto and new values won't be written to the Part.\n[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of\n"
@@ -8627,11 +8222,15 @@
         "signatures": [
           {
             "name": "asyncAppend",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-append.d.ts",
+                "line": 33
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "An async iterable"
                 },
@@ -8644,13 +8243,11 @@
                     }
                   ],
                   "name": "AsyncIterable",
-                  "qualifiedName": "AsyncIterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "_mapper",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -8658,7 +8255,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-append.d.ts",
@@ -8668,11 +8264,15 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-append.d.ts",
+                            "line": 33
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "v",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "intrinsic",
                               "name": "unknown"
@@ -8680,7 +8280,6 @@
                           },
                           {
                             "name": "index",
-                            "kindString": "Parameter",
                             "flags": {
                               "isOptional": true
                             },
@@ -8708,30 +8307,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "AsyncAppendDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "AsyncAppendDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-append.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/async-append.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "asyncAppend"
@@ -8739,7 +8331,6 @@
       },
       {
         "name": "AsyncAppendDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "An abstract `Directive` base class whose `disconnected` method will be\ncalled when the part containing the directive is cleared as a result of\nre-rendering, or when the user calls `part.setConnected(false)` on\na part that was previously rendered containing the directive (as happens\nwhen e.g. a LitElement disconnects from the DOM).",
           "text": "If `part.setConnected(true)` is subsequently called on a\ncontaining part, the directive's `reconnected` method will be called prior\nto its next `update`/`render` callbacks. When implementing `disconnected`,\n`reconnected` should also be implemented to be compatible with reconnection.\nNote that updates may occur while the directive is disconnected. As such,\ndirectives should generally check the `this.isConnected` flag during\nrender/update to determine whether it is safe to subscribe to resources\nthat may prevent garbage collection.\n"
@@ -8747,7 +8338,6 @@
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/async-append.d.ts",
@@ -8757,29 +8347,26 @@
             "signatures": [
               {
                 "name": "new AsyncAppendDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-append.d.ts",
+                    "line": 11
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "AsyncAppendDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "AsyncAppendDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -8789,20 +8376,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.constructor",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.constructor"
-              }
+              "name": "AsyncReplaceDirective.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.constructor"
@@ -8810,7 +8393,6 @@
           },
           {
             "name": "isConnected",
-            "kindString": "Property",
             "comment": {
               "shortText": "The connection state for this Directive."
             },
@@ -8827,20 +8409,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.isConnected",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.isConnected"
-              }
+              "name": "AsyncReplaceDirective.isConnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.isConnected"
@@ -8848,7 +8426,6 @@
           },
           {
             "name": "commitValue",
-            "kindString": "Method",
             "flags": {
               "isProtected": true
             },
@@ -8862,11 +8439,15 @@
             "signatures": [
               {
                 "name": "commitValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-append.d.ts",
+                    "line": 13
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -8874,7 +8455,6 @@
                   },
                   {
                     "name": "index",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
@@ -8893,20 +8473,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.commitValue",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.commitValue"
-              }
+              "name": "AsyncReplaceDirective.commitValue"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.commitValue"
@@ -8914,7 +8490,6 @@
           },
           {
             "name": "disconnected",
-            "kindString": "Method",
             "comment": {
               "shortText": "User callbacks for implementing logic to release any resources/subscriptions\nthat may have been retained by this directive. Since directives may also be\nre-connected, `reconnected` should also be implemented to restore the\nworking state of the directive prior to the next render."
             },
@@ -8928,7 +8503,12 @@
             "signatures": [
               {
                 "name": "disconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 16
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -8941,20 +8521,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.disconnected",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.disconnected"
-              }
+              "name": "AsyncReplaceDirective.disconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.disconnected"
@@ -8962,7 +8538,6 @@
           },
           {
             "name": "reconnected",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/async-replace.ts",
@@ -8973,7 +8548,12 @@
             "signatures": [
               {
                 "name": "reconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 17
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -8986,20 +8566,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.reconnected",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.reconnected"
-              }
+              "name": "AsyncReplaceDirective.reconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.reconnected"
@@ -9007,7 +8583,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/async-replace.ts",
@@ -9018,17 +8593,20 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 13
+                  }
+                ],
                 "typeParameter": [
                   {
-                    "name": "T",
-                    "kindString": "Type parameter"
+                    "name": "T"
                   }
                 ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -9038,13 +8616,11 @@
                         }
                       ],
                       "name": "AsyncIterable",
-                      "qualifiedName": "AsyncIterable",
                       "package": "typescript"
                     }
                   },
                   {
                     "name": "_mapper",
-                    "kindString": "Parameter",
                     "flags": {
                       "isOptional": true
                     },
@@ -9056,7 +8632,8 @@
                           "name": "T"
                         }
                       ],
-                      "name": "Mapper"
+                      "name": "Mapper",
+                      "package": "lit-html"
                     }
                   }
                 ],
@@ -9072,20 +8649,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.render",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.render"
-              }
+              "name": "AsyncReplaceDirective.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.render"
@@ -9093,7 +8666,6 @@
           },
           {
             "name": "setValue",
-            "kindString": "Method",
             "comment": {
               "shortText": "Sets the value of the directive's Part outside the normal `update`/`render`\nlifecycle of a directive.",
               "text": "This method should not be called synchronously from a directive's `update`\nor `render`.\n"
@@ -9108,11 +8680,15 @@
             "signatures": [
               {
                 "name": "setValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 161
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The value to set"
                     },
@@ -9134,20 +8710,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.setValue",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.setValue"
-              }
+              "name": "AsyncReplaceDirective.setValue"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.setValue"
@@ -9155,7 +8727,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/async-append.ts",
@@ -9166,28 +8737,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-append.d.ts",
+                    "line": 12
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "params",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "value",
                           "isOptional": false,
                           "element": {
@@ -9199,12 +8770,11 @@
                               }
                             ],
                             "name": "AsyncIterable",
-                            "qualifiedName": "AsyncIterable",
                             "package": "typescript"
                           }
                         },
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "_mapper",
                           "isOptional": true,
                           "element": {
@@ -9215,7 +8785,8 @@
                                 "name": "unknown"
                               }
                             ],
-                            "name": "Mapper"
+                            "name": "Mapper",
+                            "package": "lit-html"
                           }
                         }
                       ]
@@ -9234,10 +8805,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -9250,20 +8818,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.update",
-              "location": {
-                "page": "directives",
-                "anchor": "AsyncReplaceDirective.update"
-              }
+              "name": "AsyncReplaceDirective.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.update"
@@ -9281,21 +8845,17 @@
           {
             "type": "reference",
             "name": "AsyncReplaceDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "AsyncReplaceDirective",
-              "excludeFromTOC": true
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-append.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-append.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/async-append.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "AsyncAppendDirective",
@@ -9305,33 +8865,12 @@
           {
             "type": "reference",
             "name": "AsyncReplaceDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "AsyncReplaceDirective",
-              "excludeFromTOC": true
-            }
-          },
-          {
-            "type": "reference",
-            "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
-          },
-          {
-            "type": "reference",
-            "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "asyncReplace",
-        "kindString": "Function",
         "comment": {
           "shortText": "A directive that renders the items of an async iterable[1], replacing\nprevious values with new values, so that only one value is ever rendered\nat a time. This directive may be used in any expression type.",
           "text": "Async iterables are objects with a `[Symbol.asyncIterator]` method, which\nreturns an iterator who's `next()` method returns a Promise. When a new\nvalue is available, the Promise resolves and the value is rendered to the\nPart controlled by the directive. If another value other than this\ndirective has been set on the Part, the iterable will no longer be listened\nto and new values won't be written to the Part.\n[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of\n"
@@ -9346,11 +8885,15 @@
         "signatures": [
           {
             "name": "asyncReplace",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                "line": 37
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "An async iterable"
                 },
@@ -9363,13 +8906,11 @@
                     }
                   ],
                   "name": "AsyncIterable",
-                  "qualifiedName": "AsyncIterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "_mapper",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -9381,7 +8922,8 @@
                       "name": "unknown"
                     }
                   ],
-                  "name": "Mapper"
+                  "name": "Mapper",
+                  "package": "lit-html"
                 }
               }
             ],
@@ -9393,30 +8935,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "AsyncReplaceDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "AsyncReplaceDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-replace.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/async-replace.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "asyncReplace"
@@ -9424,7 +8959,6 @@
       },
       {
         "name": "AsyncReplaceDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "An abstract `Directive` base class whose `disconnected` method will be\ncalled when the part containing the directive is cleared as a result of\nre-rendering, or when the user calls `part.setConnected(false)` on\na part that was previously rendered containing the directive (as happens\nwhen e.g. a LitElement disconnects from the DOM).",
           "text": "If `part.setConnected(true)` is subsequently called on a\ncontaining part, the directive's `reconnected` method will be called prior\nto its next `update`/`render` callbacks. When implementing `disconnected`,\n`reconnected` should also be implemented to be compatible with reconnection.\nNote that updates may occur while the directive is disconnected. As such,\ndirectives should generally check the `this.isConnected` flag during\nrender/update to determine whether it is safe to subscribe to resources\nthat may prevent garbage collection.\n"
@@ -9432,7 +8966,6 @@
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -9442,29 +8975,26 @@
             "signatures": [
               {
                 "name": "new AsyncReplaceDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "AsyncReplaceDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -9474,20 +9004,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.constructor"
-              }
+              "name": "AsyncDirective.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.constructor"
@@ -9495,7 +9021,6 @@
           },
           {
             "name": "isConnected",
-            "kindString": "Property",
             "comment": {
               "shortText": "The connection state for this Directive."
             },
@@ -9512,20 +9037,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.isConnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.isConnected"
-              }
+              "name": "AsyncDirective.isConnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.isConnected"
@@ -9533,7 +9054,6 @@
           },
           {
             "name": "commitValue",
-            "kindString": "Method",
             "flags": {
               "isProtected": true
             },
@@ -9547,11 +9067,15 @@
             "signatures": [
               {
                 "name": "commitValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 15
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -9559,7 +9083,6 @@
                   },
                   {
                     "name": "_index",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
@@ -9575,11 +9098,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.commitValue"
@@ -9587,7 +9110,6 @@
           },
           {
             "name": "disconnected",
-            "kindString": "Method",
             "comment": {
               "shortText": "User callbacks for implementing logic to release any resources/subscriptions\nthat may have been retained by this directive. Since directives may also be\nre-connected, `reconnected` should also be implemented to restore the\nworking state of the directive prior to the next render."
             },
@@ -9601,7 +9123,12 @@
             "signatures": [
               {
                 "name": "disconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 16
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -9614,20 +9141,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.disconnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.disconnected"
-              }
+              "name": "AsyncDirective.disconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.disconnected"
@@ -9635,7 +9158,6 @@
           },
           {
             "name": "reconnected",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/async-replace.ts",
@@ -9646,7 +9168,12 @@
             "signatures": [
               {
                 "name": "reconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 17
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -9659,20 +9186,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.reconnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.reconnected"
-              }
+              "name": "AsyncDirective.reconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.reconnected"
@@ -9680,7 +9203,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/async-replace.ts",
@@ -9691,17 +9213,20 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 13
+                  }
+                ],
                 "typeParameter": [
                   {
-                    "name": "T",
-                    "kindString": "Type parameter"
+                    "name": "T"
                   }
                 ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -9711,13 +9236,11 @@
                         }
                       ],
                       "name": "AsyncIterable",
-                      "qualifiedName": "AsyncIterable",
                       "package": "typescript"
                     }
                   },
                   {
                     "name": "_mapper",
-                    "kindString": "Parameter",
                     "flags": {
                       "isOptional": true
                     },
@@ -9729,7 +9252,8 @@
                           "name": "T"
                         }
                       ],
-                      "name": "Mapper"
+                      "name": "Mapper",
+                      "package": "lit-html"
                     }
                   }
                 ],
@@ -9745,20 +9269,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.render"
-              }
+              "name": "AsyncDirective.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.render"
@@ -9766,7 +9286,6 @@
           },
           {
             "name": "setValue",
-            "kindString": "Method",
             "comment": {
               "shortText": "Sets the value of the directive's Part outside the normal `update`/`render`\nlifecycle of a directive.",
               "text": "This method should not be called synchronously from a directive's `update`\nor `render`.\n"
@@ -9781,11 +9300,15 @@
             "signatures": [
               {
                 "name": "setValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 161
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The value to set"
                     },
@@ -9807,20 +9330,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.setValue",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.setValue"
-              }
+              "name": "AsyncDirective.setValue"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.setValue"
@@ -9828,7 +9347,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/async-replace.ts",
@@ -9839,28 +9357,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/async-replace.d.ts",
+                    "line": 14
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "value",
                           "isOptional": false,
                           "element": {
@@ -9872,12 +9390,11 @@
                               }
                             ],
                             "name": "AsyncIterable",
-                            "qualifiedName": "AsyncIterable",
                             "package": "typescript"
                           }
                         },
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "_mapper",
                           "isOptional": true,
                           "element": {
@@ -9888,7 +9405,8 @@
                                 "name": "unknown"
                               }
                             ],
-                            "name": "Mapper"
+                            "name": "Mapper",
+                            "package": "lit-html"
                           }
                         }
                       ]
@@ -9907,10 +9425,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -9923,20 +9438,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.update"
-              }
+              "name": "AsyncDirective.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.update"
@@ -9954,31 +9465,23 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
+            "package": "lit-html"
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "AsyncAppendDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "AsyncAppendDirective",
-              "excludeFromTOC": true
-            }
+            "name": "AsyncAppendDirective"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-replace.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/async-replace.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/async-replace.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "AsyncReplaceDirective",
@@ -9988,24 +9491,12 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
-          },
-          {
-            "type": "reference",
-            "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "cache",
-        "kindString": "Function",
         "comment": {
           "shortText": "Enables fast switching between multiple templates by caching the DOM nodes\nand TemplateInstances produced by the templates.",
           "text": "Example:\n```js\nlet checked = false;\nhtml`\n  ${cache(checked ? html`input is checked` : html`input is not checked`)}\n`\n```\n"
@@ -10020,11 +9511,15 @@
         "signatures": [
           {
             "name": "cache",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/cache.d.ts",
+                "line": 29
+              }
+            ],
             "parameters": [
               {
                 "name": "v",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -10039,30 +9534,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "CacheDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "CacheDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/cache.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/cache.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/cache.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "cache"
@@ -10070,14 +9558,12 @@
       },
       {
         "name": "CacheDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/cache.d.ts",
@@ -10087,29 +9573,26 @@
             "signatures": [
               {
                 "name": "new CacheDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/cache.d.ts",
+                    "line": 11
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "CacheDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "CacheDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -10119,20 +9602,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/cache.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/cache.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/cache.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "CacheDirective.constructor"
@@ -10140,7 +9619,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/cache.ts",
@@ -10151,11 +9629,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/cache.d.ts",
+                    "line": 12
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "v",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -10177,20 +9659,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/cache.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/cache.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/cache.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "CacheDirective.render"
@@ -10198,7 +9676,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/cache.ts",
@@ -10209,28 +9686,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/cache.d.ts",
+                    "line": 13
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "containerPart",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "v",
                           "isOptional": false,
                           "element": {
@@ -10257,20 +9734,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/cache.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/cache.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/cache.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "CacheDirective.update"
@@ -10288,20 +9761,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/cache.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/cache.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/cache.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "CacheDirective",
@@ -10311,16 +9781,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "choose",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -10345,21 +9811,23 @@
         "signatures": [
           {
             "name": "choose",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/choose.d.ts",
+                "line": 31
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               },
               {
-                "name": "V",
-                "kindString": "Type parameter"
+                "name": "V"
               }
             ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "T"
@@ -10367,7 +9835,6 @@
               },
               {
                 "name": "cases",
-                "kindString": "Parameter",
                 "type": {
                   "type": "array",
                   "elementType": {
@@ -10381,7 +9848,6 @@
                         "type": "reflection",
                         "declaration": {
                           "name": "__type",
-                          "kindString": "Type literal",
                           "sources": [
                             {
                               "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/choose.d.ts",
@@ -10391,7 +9857,12 @@
                           "signatures": [
                             {
                               "name": "__type",
-                              "kindString": "Call signature",
+                              "sources": [
+                                {
+                                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/choose.d.ts",
+                                  "line": 31
+                                }
+                              ],
                               "type": {
                                 "type": "reference",
                                 "name": "V"
@@ -10406,7 +9877,6 @@
               },
               {
                 "name": "defaultCase",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -10414,7 +9884,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/choose.d.ts",
@@ -10424,7 +9893,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/choose.d.ts",
+                            "line": 31
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "V"
@@ -10453,11 +9927,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/choose.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/choose.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/choose.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "choose"
@@ -10465,7 +9939,6 @@
       },
       {
         "name": "classMap",
-        "kindString": "Function",
         "comment": {
           "shortText": "A directive that applies dynamic CSS classes.",
           "text": "This must be used in the `class` attribute and must be the only part used in\nthe attribute. It takes each property in the `classInfo` argument and adds\nthe property name to the element's `classList` if the property value is\ntruthy; if the property value is falsey, the property name is removed from\nthe element's `class`.\nFor example `{foo: bar}` applies the class `foo` if the value of `bar` is\ntruthy.\n"
@@ -10480,19 +9953,19 @@
         "signatures": [
           {
             "name": "classMap",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/class-map.d.ts",
+                "line": 39
+              }
+            ],
             "parameters": [
               {
                 "name": "classInfo",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "ClassInfo",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ClassInfo",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -10504,30 +9977,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "ClassMapDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "ClassMapDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/class-map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/class-map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "classMap"
@@ -10535,14 +10001,12 @@
       },
       {
         "name": "ClassMapDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/class-map.d.ts",
@@ -10552,29 +10016,26 @@
             "signatures": [
               {
                 "name": "new ClassMapDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/class-map.d.ts",
+                    "line": 21
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "ClassMapDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ClassMapDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -10584,20 +10045,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/class-map.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/class-map.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/class-map.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "ClassMapDirective.constructor"
@@ -10605,7 +10062,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/class-map.ts",
@@ -10616,19 +10072,19 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/class-map.d.ts",
+                    "line": 22
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "classInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ClassInfo",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ClassInfo",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
@@ -10644,20 +10100,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/class-map.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/class-map.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/class-map.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "ClassMapDirective.render"
@@ -10665,7 +10117,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/class-map.ts",
@@ -10676,38 +10127,34 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/class-map.d.ts",
+                    "line": 23
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "AttributePart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "AttributePart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "classInfo",
                           "isOptional": false,
                           "element": {
                             "type": "reference",
                             "name": "ClassInfo",
-                            "location": {
-                              "page": "directives",
-                              "anchor": "ClassInfo",
-                              "excludeFromTOC": true
-                            }
+                            "package": "lit-html"
                           }
                         }
                       ]
@@ -10726,10 +10173,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -10742,20 +10186,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/class-map.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/class-map.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/class-map.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "ClassMapDirective.update"
@@ -10773,20 +10213,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/class-map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/class-map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "ClassMapDirective",
@@ -10796,16 +10233,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "ClassInfo",
-        "kindString": "Interface",
         "comment": {
           "shortText": "A key-value set of class names to truthy values."
         },
@@ -10818,7 +10251,12 @@
         ],
         "indexSignature": {
           "name": "__index",
-          "kindString": "Index signature",
+          "sources": [
+            {
+              "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/class-map.d.ts",
+              "line": 12
+            }
+          ],
           "parameters": [
             {
               "name": "name",
@@ -10849,11 +10287,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/class-map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/class-map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "directives",
           "anchor": "ClassInfo",
@@ -10862,7 +10300,6 @@
       },
       {
         "name": "guard",
-        "kindString": "Function",
         "comment": {
           "shortText": "Prevents re-render of a template function until a single value or an array of\nvalues changes.",
           "text": "Values are checked against previous values with strict equality (`===`), and\nso the check won't detect nested property changes inside objects or arrays.\nArrays values have each item checked against the previous value at the same\nindex with strict equality. Nested arrays are also checked only by strict\nequality.\nExample:\n```js\nhtml`\n  <div>\n    ${guard([user.id, company.id], () => html`...`)}\n  </div>\n`\n```\nIn this case, the template only rerenders if either `user.id` or `company.id`\nchanges.\nguard() is useful with immutable data patterns, by preventing expensive work\nuntil data updates.\nExample:\n```js\nhtml`\n  <div>\n    ${guard([immutableItems], () => immutableItems.map(i => html`${i}`))}\n  </div>\n`\n```\nIn this case, items are mapped over only when the array reference changes.\n"
@@ -10877,11 +10314,15 @@
         "signatures": [
           {
             "name": "guard",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
+                "line": 54
+              }
+            ],
             "parameters": [
               {
                 "name": "_value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -10889,7 +10330,6 @@
               },
               {
                 "name": "f",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "the template function"
                 },
@@ -10897,7 +10337,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
@@ -10907,7 +10346,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
+                            "line": 54
+                          }
+                        ],
                         "type": {
                           "type": "intrinsic",
                           "name": "unknown"
@@ -10926,30 +10370,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "GuardDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "GuardDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/guard.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/guard.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/guard.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "guard"
@@ -10957,14 +10394,12 @@
       },
       {
         "name": "GuardDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -10974,29 +10409,26 @@
             "signatures": [
               {
                 "name": "new GuardDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "GuardDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "GuardDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -11006,20 +10438,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/guard.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/guard.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/guard.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "GuardDirective.constructor"
@@ -11027,7 +10455,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/guard.ts",
@@ -11038,11 +10465,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
+                    "line": 10
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -11050,12 +10481,10 @@
                   },
                   {
                     "name": "f",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reflection",
                       "declaration": {
                         "name": "__type",
-                        "kindString": "Type literal",
                         "sources": [
                           {
                             "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
@@ -11065,7 +10494,12 @@
                         "signatures": [
                           {
                             "name": "__type",
-                            "kindString": "Call signature",
+                            "sources": [
+                              {
+                                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
+                                "line": 10
+                              }
+                            ],
                             "type": {
                               "type": "intrinsic",
                               "name": "unknown"
@@ -11088,20 +10522,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/guard.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/guard.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/guard.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "GuardDirective.render"
@@ -11109,7 +10539,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/guard.ts",
@@ -11120,28 +10549,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
+                    "line": 11
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "_value",
                           "isOptional": false,
                           "element": {
@@ -11150,14 +10579,13 @@
                           }
                         },
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "f",
                           "isOptional": false,
                           "element": {
                             "type": "reflection",
                             "declaration": {
                               "name": "__type",
-                              "kindString": "Type literal",
                               "sources": [
                                 {
                                   "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
@@ -11167,7 +10595,12 @@
                               "signatures": [
                                 {
                                   "name": "__type",
-                                  "kindString": "Call signature",
+                                  "sources": [
+                                    {
+                                      "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/guard.d.ts",
+                                      "line": 10
+                                    }
+                                  ],
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "unknown"
@@ -11193,20 +10626,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/guard.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/guard.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/guard.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "GuardDirective.update"
@@ -11224,20 +10653,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/guard.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/guard.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/guard.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "GuardDirective",
@@ -11247,16 +10673,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "ifDefined",
-        "kindString": "Function",
         "comment": {
           "shortText": "For AttributeParts, sets the attribute if the value is defined and removes\nthe attribute if the value is undefined.",
           "text": "For other part types, this directive is a no-op.\n"
@@ -11271,17 +10693,20 @@
         "signatures": [
           {
             "name": "ifDefined",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/if-defined.d.ts",
+                "line": 13
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "T"
@@ -11296,10 +10721,7 @@
                   "queryType": {
                     "type": "reference",
                     "name": "nothing",
-                    "location": {
-                      "page": "templates",
-                      "anchor": "nothing"
-                    }
+                    "package": "lit-html"
                   }
                 },
                 {
@@ -11311,7 +10733,6 @@
                     }
                   ],
                   "name": "NonNullable",
-                  "qualifiedName": "NonNullable",
                   "package": "typescript"
                 }
               ]
@@ -11321,11 +10742,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/if-defined.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/if-defined.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/if-defined.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "ifDefined"
@@ -11333,7 +10754,6 @@
       },
       {
         "name": "join",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -11362,21 +10782,23 @@
         "signatures": [
           {
             "name": "join",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/join.d.ts",
+                "line": 19
+              }
+            ],
             "typeParameter": [
               {
-                "name": "I",
-                "kindString": "Type parameter"
+                "name": "I"
               },
               {
-                "name": "J",
-                "kindString": "Type parameter"
+                "name": "J"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -11393,7 +10815,6 @@
                         }
                       ],
                       "name": "Iterable",
-                      "qualifiedName": "Iterable",
                       "package": "typescript"
                     }
                   ]
@@ -11401,12 +10822,10 @@
               },
               {
                 "name": "joiner",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/join.d.ts",
@@ -11416,11 +10835,15 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/join.d.ts",
+                            "line": 19
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "index",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "intrinsic",
                               "name": "number"
@@ -11455,27 +10878,28 @@
                 }
               ],
               "name": "Iterable",
-              "qualifiedName": "Iterable",
               "package": "typescript"
             }
           },
           {
             "name": "join",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/join.d.ts",
+                "line": 20
+              }
+            ],
             "typeParameter": [
               {
-                "name": "I",
-                "kindString": "Type parameter"
+                "name": "I"
               },
               {
-                "name": "J",
-                "kindString": "Type parameter"
+                "name": "J"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -11492,7 +10916,6 @@
                         }
                       ],
                       "name": "Iterable",
-                      "qualifiedName": "Iterable",
                       "package": "typescript"
                     }
                   ]
@@ -11500,7 +10923,6 @@
               },
               {
                 "name": "joiner",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "J"
@@ -11525,7 +10947,6 @@
                 }
               ],
               "name": "Iterable",
-              "qualifiedName": "Iterable",
               "package": "typescript"
             }
           }
@@ -11533,11 +10954,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/join.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/join.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/join.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "join"
@@ -11545,7 +10966,6 @@
       },
       {
         "name": "keyed",
-        "kindString": "Function",
         "comment": {
           "shortText": "Associates a renderable value with a unique key. When the key changes, the\nprevious DOM is removed and disposed before rendering the next value, even\nif the value - such as a template - is the same.",
           "text": "This is useful for forcing re-renders of stateful components, or working\nwith code that expects new data to generate new HTML elements, such as some\nanimation techniques.\n"
@@ -11560,11 +10980,15 @@
         "signatures": [
           {
             "name": "keyed",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/keyed.d.ts",
+                "line": 21
+              }
+            ],
             "parameters": [
               {
                 "name": "k",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -11572,7 +10996,6 @@
               },
               {
                 "name": "v",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -11587,30 +11010,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "Keyed",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "Keyed",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/keyed.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/keyed.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/keyed.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "keyed"
@@ -11618,14 +11034,12 @@
       },
       {
         "name": "Keyed",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -11635,29 +11049,26 @@
             "signatures": [
               {
                 "name": "new Keyed",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "Keyed",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "Keyed",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -11667,20 +11078,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/keyed.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "Keyed.constructor"
@@ -11688,7 +11095,6 @@
           },
           {
             "name": "key",
-            "kindString": "Property",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/keyed.ts",
@@ -11703,11 +11109,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/keyed.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "Keyed.key"
@@ -11715,7 +11121,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/keyed.ts",
@@ -11726,11 +11131,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/keyed.d.ts",
+                    "line": 9
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "k",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -11738,7 +11147,6 @@
                   },
                   {
                     "name": "v",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -11757,20 +11165,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/keyed.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "Keyed.render"
@@ -11778,7 +11182,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/keyed.ts",
@@ -11789,28 +11192,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/keyed.d.ts",
+                    "line": 10
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "k",
                           "isOptional": false,
                           "element": {
@@ -11819,7 +11222,7 @@
                           }
                         },
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "v",
                           "isOptional": false,
                           "element": {
@@ -11843,20 +11246,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/keyed.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "Keyed.update"
@@ -11874,20 +11273,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/keyed.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/keyed.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/keyed.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "Keyed",
@@ -11897,16 +11293,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "live",
-        "kindString": "Function",
         "comment": {
           "shortText": "Checks binding values against live DOM values, instead of previously bound\nvalues, when determining whether to update the value.",
           "text": "This is useful for cases where the DOM value may change from outside of\nlit-html, such as with a binding to an `<input>` element's `value` property,\na content editable elements text, or to a custom element that changes it's\nown properties or attributes.\nIn these cases if the DOM value changes, but the value set through lit-html\nbindings hasn't, lit-html won't know to update the DOM value and will leave\nit alone. If this is not what you want--if you want to overwrite the DOM\nvalue with the bound value no matter what--use the `live()` directive:\n```js\nhtml`<input .value=${live(x)}>`\n```\n`live()` performs a strict equality check against the live DOM value, and if\nthe new value is equal to the live value, does nothing. This means that\n`live()` should not be used when the binding will cause a type conversion. If\nyou use `live()` with an attribute binding, make sure that only strings are\npassed in, or the binding will update every render.\n"
@@ -11921,11 +11313,15 @@
         "signatures": [
           {
             "name": "live",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/live.d.ts",
+                "line": 37
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -11940,30 +11336,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "LiveDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "LiveDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/live.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/live.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/live.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "live"
@@ -11971,14 +11360,12 @@
       },
       {
         "name": "LiveDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/live.d.ts",
@@ -11988,29 +11375,26 @@
             "signatures": [
               {
                 "name": "new LiveDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/live.d.ts",
+                    "line": 9
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "LiveDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "LiveDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -12020,20 +11404,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/live.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/live.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/live.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "LiveDirective.constructor"
@@ -12041,7 +11421,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/live.ts",
@@ -12052,11 +11431,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/live.d.ts",
+                    "line": 10
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
@@ -12075,20 +11458,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/live.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/live.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/live.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "LiveDirective.render"
@@ -12096,7 +11475,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/live.ts",
@@ -12107,28 +11485,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/live.d.ts",
+                    "line": 11
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "AttributePart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "AttributePart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "value",
                           "isOptional": false,
                           "element": {
@@ -12152,20 +11530,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/live.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/live.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/live.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "LiveDirective.update"
@@ -12183,20 +11557,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/live.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/live.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/live.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "LiveDirective",
@@ -12206,16 +11577,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "map",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -12239,17 +11606,20 @@
         "signatures": [
           {
             "name": "map",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/map.d.ts",
+                "line": 22
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -12266,7 +11636,6 @@
                         }
                       ],
                       "name": "Iterable",
-                      "qualifiedName": "Iterable",
                       "package": "typescript"
                     }
                   ]
@@ -12274,12 +11643,10 @@
               },
               {
                 "name": "f",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/map.d.ts",
@@ -12289,11 +11656,15 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/map.d.ts",
+                            "line": 22
+                          }
+                        ],
                         "parameters": [
                           {
                             "name": "value",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "reference",
                               "name": "T"
@@ -12301,7 +11672,6 @@
                           },
                           {
                             "name": "index",
-                            "kindString": "Parameter",
                             "type": {
                               "type": "intrinsic",
                               "name": "number"
@@ -12335,7 +11705,6 @@
                 }
               ],
               "name": "Generator",
-              "qualifiedName": "Generator",
               "package": "typescript"
             }
           }
@@ -12343,11 +11712,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/map.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "map"
@@ -12355,7 +11724,6 @@
       },
       {
         "name": "range",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -12385,11 +11753,15 @@
         "signatures": [
           {
             "name": "range",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/range.d.ts",
+                "line": 22
+              }
+            ],
             "parameters": [
               {
                 "name": "end",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
@@ -12405,17 +11777,20 @@
                 }
               ],
               "name": "Iterable",
-              "qualifiedName": "Iterable",
               "package": "typescript"
             }
           },
           {
             "name": "range",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/range.d.ts",
+                "line": 23
+              }
+            ],
             "parameters": [
               {
                 "name": "start",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
@@ -12423,7 +11798,6 @@
               },
               {
                 "name": "end",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
@@ -12431,7 +11805,6 @@
               },
               {
                 "name": "step",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -12450,7 +11823,6 @@
                 }
               ],
               "name": "Iterable",
-              "qualifiedName": "Iterable",
               "package": "typescript"
             }
           }
@@ -12458,11 +11830,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/range.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/range.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/range.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "range"
@@ -12470,7 +11842,6 @@
       },
       {
         "name": "createRef",
-        "kindString": "Function",
         "comment": {
           "shortText": "Creates a new Ref object, which is container for a reference to an element."
         },
@@ -12484,19 +11855,19 @@
         "signatures": [
           {
             "name": "createRef",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
+                "line": 11
+              }
+            ],
             "typeParameter": [
               {
                 "name": "T",
-                "kindString": "Type parameter",
                 "default": {
                   "type": "reference",
                   "name": "Element",
-                  "qualifiedName": "Element",
-                  "package": "typescript",
-                  "externalLocation": {
-                    "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                  }
+                  "package": "typescript"
                 }
               }
             ],
@@ -12509,22 +11880,18 @@
                 }
               ],
               "name": "Ref",
-              "location": {
-                "page": "directives",
-                "anchor": "Ref",
-                "excludeFromTOC": true
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "createRef"
@@ -12532,7 +11899,6 @@
       },
       {
         "name": "ref",
-        "kindString": "Function",
         "comment": {
           "shortText": "Sets the value of a Ref object or calls a ref callback with the element it's\nbound to.",
           "text": "A Ref object acts as a container for a reference to an element. A ref\ncallback is a function that takes an element as its only argument.\nThe ref directive sets the value of the Ref object or calls the ref callback\nduring rendering, if the referenced element changed.\nNote: If a ref callback is rendered to a different element position or is\nremoved in a subsequent render, it will first be called with `undefined`,\nfollowed by another call with the new element it was rendered to (if any).\n```js\n// Using Ref object\nconst inputRef = createRef();\nrender(html`<input ${ref(inputRef)}>`, container);\ninputRef.value.focus();\n// Using callback\nconst callback = (inputElement) => inputElement.focus();\nrender(html`<input ${ref(callback)}>`, container);\n```\n"
@@ -12547,19 +11913,19 @@
         "signatures": [
           {
             "name": "ref",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
+                "line": 60
+              }
+            ],
             "parameters": [
               {
                 "name": "_ref",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "RefOrCallback",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "RefOrCallback",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -12571,30 +11937,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "RefDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "RefDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "ref"
@@ -12602,30 +11961,22 @@
       },
       {
         "name": "Ref",
-        "kindString": "Class",
         "comment": {
           "shortText": "An object that holds a ref value."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "signatures": [
               {
                 "name": "new Ref",
-                "kindString": "Constructor signature",
                 "typeParameter": [
                   {
                     "name": "T",
-                    "kindString": "Type parameter",
                     "default": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     }
                   }
                 ],
@@ -12638,22 +11989,18 @@
                     }
                   ],
                   "name": "Ref",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "Ref",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "Ref.constructor"
@@ -12661,7 +12008,6 @@
           },
           {
             "name": "value",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -12683,11 +12029,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "Ref.value"
@@ -12704,26 +12050,21 @@
         "typeParameters": [
           {
             "name": "T",
-            "kindString": "Type parameter",
             "default": {
               "type": "reference",
               "name": "Element",
-              "qualifiedName": "Element",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-              }
+              "package": "typescript"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "Ref",
@@ -12732,7 +12073,6 @@
       },
       {
         "name": "RefDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "An abstract `Directive` base class whose `disconnected` method will be\ncalled when the part containing the directive is cleared as a result of\nre-rendering, or when the user calls `part.setConnected(false)` on\na part that was previously rendered containing the directive (as happens\nwhen e.g. a LitElement disconnects from the DOM).",
           "text": "If `part.setConnected(true)` is subsequently called on a\ncontaining part, the directive's `reconnected` method will be called prior\nto its next `update`/`render` callbacks. When implementing `disconnected`,\n`reconnected` should also be implemented to be compatible with reconnection.\nNote that updates may occur while the directive is disconnected. As such,\ndirectives should generally check the `this.isConnected` flag during\nrender/update to determine whether it is safe to subscribe to resources\nthat may prevent garbage collection.\n"
@@ -12740,7 +12080,6 @@
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -12750,29 +12089,26 @@
             "signatures": [
               {
                 "name": "new RefDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "RefDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "RefDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -12782,20 +12118,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.constructor"
-              }
+              "name": "AsyncDirective.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.constructor"
@@ -12803,7 +12135,6 @@
           },
           {
             "name": "isConnected",
-            "kindString": "Property",
             "comment": {
               "shortText": "The connection state for this Directive."
             },
@@ -12820,20 +12151,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.isConnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.isConnected"
-              }
+              "name": "AsyncDirective.isConnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.isConnected"
@@ -12841,7 +12168,6 @@
           },
           {
             "name": "disconnected",
-            "kindString": "Method",
             "comment": {
               "shortText": "User callbacks for implementing logic to release any resources/subscriptions\nthat may have been retained by this directive. Since directives may also be\nre-connected, `reconnected` should also be implemented to restore the\nworking state of the directive prior to the next render."
             },
@@ -12855,7 +12181,12 @@
             "signatures": [
               {
                 "name": "disconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
+                    "line": 32
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -12868,20 +12199,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.disconnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.disconnected"
-              }
+              "name": "AsyncDirective.disconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.disconnected"
@@ -12889,7 +12216,6 @@
           },
           {
             "name": "reconnected",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
@@ -12900,7 +12226,12 @@
             "signatures": [
               {
                 "name": "reconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
+                    "line": 33
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -12913,20 +12244,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.reconnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.reconnected"
-              }
+              "name": "AsyncDirective.reconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.reconnected"
@@ -12934,7 +12261,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
@@ -12945,19 +12271,19 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
+                    "line": 28
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_ref",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "RefOrCallback",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "RefOrCallback",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
@@ -12973,20 +12299,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.render"
-              }
+              "name": "AsyncDirective.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.render"
@@ -12994,7 +12316,6 @@
           },
           {
             "name": "setValue",
-            "kindString": "Method",
             "comment": {
               "shortText": "Sets the value of the directive's Part outside the normal `update`/`render`\nlifecycle of a directive.",
               "text": "This method should not be called synchronously from a directive's `update`\nor `render`.\n"
@@ -13009,11 +12330,15 @@
             "signatures": [
               {
                 "name": "setValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 161
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The value to set"
                     },
@@ -13035,20 +12360,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.setValue",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.setValue"
-              }
+              "name": "AsyncDirective.setValue"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.setValue"
@@ -13056,7 +12377,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/ref.ts",
@@ -13067,38 +12387,34 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
+                    "line": 29
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ElementPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ElementPart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "_ref",
                           "isOptional": false,
                           "element": {
                             "type": "reference",
                             "name": "RefOrCallback",
-                            "location": {
-                              "page": "directives",
-                              "anchor": "RefOrCallback",
-                              "excludeFromTOC": true
-                            }
+                            "package": "lit-html"
                           }
                         }
                       ]
@@ -13117,20 +12433,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.update"
-              }
+              "name": "AsyncDirective.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.update"
@@ -13148,20 +12460,17 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "RefDirective",
@@ -13171,24 +12480,12 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
-          },
-          {
-            "type": "reference",
-            "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "RefOrCallback",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/ref.ts",
@@ -13202,17 +12499,12 @@
             {
               "type": "reference",
               "name": "Ref",
-              "location": {
-                "page": "directives",
-                "anchor": "Ref",
-                "excludeFromTOC": true
-              }
+              "package": "lit-html"
             },
             {
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/ref.d.ts",
@@ -13222,22 +12514,16 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
                     "parameters": [
                       {
                         "name": "el",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "union",
                           "types": [
                             {
                               "type": "reference",
                               "name": "Element",
-                              "qualifiedName": "Element",
-                              "package": "typescript",
-                              "externalLocation": {
-                                "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                              }
+                              "package": "typescript"
                             },
                             {
                               "type": "intrinsic",
@@ -13260,11 +12546,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/ref.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "directives",
           "anchor": "RefOrCallback",
@@ -13273,7 +12559,6 @@
       },
       {
         "name": "repeat",
-        "kindString": "Function",
         "comment": {
           "shortText": "A directive that repeats a series of values (usually `TemplateResults`)\ngenerated from an iterable, and updates those items efficiently when the\niterable changes based on user-provided `keys` associated with each item.",
           "text": "Note that if a `keyFn` is provided, strict key-to-DOM mapping is maintained,\nmeaning previous DOM for a given key is moved into the new position if\nneeded, and DOM will never be reused with values for different keys (new DOM\nwill always be created for new keys). This is generally the most efficient\nway to use `repeat` since it performs minimum unnecessary work for insertions\nand removals.\nThe `keyFn` takes two parameters, the item and its index, and returns a unique key value.\n```js\nhtml`\n  <ol>\n    ${repeat(this.items, (item) => item.id, (item, index) => {\n      return html`<li>${index}: ${item.name}</li>`;\n    })}\n  </ol>\n`\n```\n**Important**: If providing a `keyFn`, keys *must* be unique for all items in a\ngiven call to `repeat`. The behavior when two or more items have the same key\nis undefined.\nIf no `keyFn` is provided, this directive will perform similar to mapping\nitems to values, and DOM will be reused against potentially different items.\n"
@@ -13288,17 +12573,20 @@
         "signatures": [
           {
             "name": "repeat",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                "line": 23
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -13308,13 +12596,11 @@
                     }
                   ],
                   "name": "Iterable",
-                  "qualifiedName": "Iterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "keyFnOrTemplate",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -13327,11 +12613,7 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "KeyFn",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     },
                     {
                       "type": "reference",
@@ -13342,18 +12624,13 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ItemTemplate",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   ]
                 }
               },
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -13366,11 +12643,7 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ItemTemplate",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -13381,21 +12654,24 @@
           },
           {
             "name": "repeat",
-            "kindString": "Call signature",
             "comment": {
               "shortText": "A directive that repeats a series of values (usually `TemplateResults`)\ngenerated from an iterable, and updates those items efficiently when the\niterable changes based on user-provided `keys` associated with each item.",
               "text": "Note that if a `keyFn` is provided, strict key-to-DOM mapping is maintained,\nmeaning previous DOM for a given key is moved into the new position if\nneeded, and DOM will never be reused with values for different keys (new DOM\nwill always be created for new keys). This is generally the most efficient\nway to use `repeat` since it performs minimum unnecessary work for insertions\nand removals.\nThe `keyFn` takes two parameters, the item and its index, and returns a unique key value.\n```js\nhtml`\n  <ol>\n    ${repeat(this.items, (item) => item.id, (item, index) => {\n      return html`<li>${index}: ${item.name}</li>`;\n    })}\n  </ol>\n`\n```\n**Important**: If providing a `keyFn`, keys *must* be unique for all items in a\ngiven call to `repeat`. The behavior when two or more items have the same key\nis undefined.\nIf no `keyFn` is provided, this directive will perform similar to mapping\nitems to values, and DOM will be reused against potentially different items.\n"
             },
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                "line": 24
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -13405,13 +12681,11 @@
                     }
                   ],
                   "name": "Iterable",
-                  "qualifiedName": "Iterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -13421,11 +12695,7 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ItemTemplate",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -13436,21 +12706,24 @@
           },
           {
             "name": "repeat",
-            "kindString": "Call signature",
             "comment": {
               "shortText": "A directive that repeats a series of values (usually `TemplateResults`)\ngenerated from an iterable, and updates those items efficiently when the\niterable changes based on user-provided `keys` associated with each item.",
               "text": "Note that if a `keyFn` is provided, strict key-to-DOM mapping is maintained,\nmeaning previous DOM for a given key is moved into the new position if\nneeded, and DOM will never be reused with values for different keys (new DOM\nwill always be created for new keys). This is generally the most efficient\nway to use `repeat` since it performs minimum unnecessary work for insertions\nand removals.\nThe `keyFn` takes two parameters, the item and its index, and returns a unique key value.\n```js\nhtml`\n  <ol>\n    ${repeat(this.items, (item) => item.id, (item, index) => {\n      return html`<li>${index}: ${item.name}</li>`;\n    })}\n  </ol>\n`\n```\n**Important**: If providing a `keyFn`, keys *must* be unique for all items in a\ngiven call to `repeat`. The behavior when two or more items have the same key\nis undefined.\nIf no `keyFn` is provided, this directive will perform similar to mapping\nitems to values, and DOM will be reused against potentially different items.\n"
             },
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                "line": 25
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -13460,13 +12733,11 @@
                     }
                   ],
                   "name": "Iterable",
-                  "qualifiedName": "Iterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "keyFn",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -13479,11 +12750,7 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "KeyFn",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     },
                     {
                       "type": "reference",
@@ -13494,18 +12761,13 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ItemTemplate",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   ]
                 }
               },
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -13515,11 +12777,7 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ItemTemplate",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -13532,11 +12790,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "repeat"
@@ -13544,14 +12802,12 @@
       },
       {
         "name": "RepeatDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/repeat.d.ts",
@@ -13561,29 +12817,26 @@
             "signatures": [
               {
                 "name": "new RepeatDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                    "line": 12
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "RepeatDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "RepeatDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -13593,20 +12846,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/repeat.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/repeat.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "RepeatDirective.constructor"
@@ -13614,7 +12863,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/repeat.ts",
@@ -13630,17 +12878,20 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                    "line": 14
+                  }
+                ],
                 "typeParameter": [
                   {
-                    "name": "T",
-                    "kindString": "Type parameter"
+                    "name": "T"
                   }
                 ],
                 "parameters": [
                   {
                     "name": "items",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -13650,13 +12901,11 @@
                         }
                       ],
                       "name": "Iterable",
-                      "qualifiedName": "Iterable",
                       "package": "typescript"
                     }
                   },
                   {
                     "name": "template",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -13666,11 +12915,7 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ItemTemplate",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
@@ -13688,17 +12933,20 @@
               },
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                    "line": 15
+                  }
+                ],
                 "typeParameter": [
                   {
-                    "name": "T",
-                    "kindString": "Type parameter"
+                    "name": "T"
                   }
                 ],
                 "parameters": [
                   {
                     "name": "items",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -13708,13 +12956,11 @@
                         }
                       ],
                       "name": "Iterable",
-                      "qualifiedName": "Iterable",
                       "package": "typescript"
                     }
                   },
                   {
                     "name": "keyFn",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -13727,11 +12973,7 @@
                             }
                           ],
                           "name": "KeyFn",
-                          "location": {
-                            "page": "directives",
-                            "anchor": "KeyFn",
-                            "excludeFromTOC": true
-                          }
+                          "package": "lit-html"
                         },
                         {
                           "type": "reference",
@@ -13742,18 +12984,13 @@
                             }
                           ],
                           "name": "ItemTemplate",
-                          "location": {
-                            "page": "directives",
-                            "anchor": "ItemTemplate",
-                            "excludeFromTOC": true
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
                   },
                   {
                     "name": "template",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
@@ -13763,11 +13000,7 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ItemTemplate",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
@@ -13786,20 +13019,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/repeat.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/repeat.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RepeatDirective.render"
@@ -13807,7 +13036,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/repeat.ts",
@@ -13818,29 +13046,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                    "line": 16
+                  }
+                ],
                 "typeParameter": [
                   {
-                    "name": "T",
-                    "kindString": "Type parameter"
+                    "name": "T"
                   }
                 ],
                 "parameters": [
                   {
                     "name": "containerPart",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
@@ -13853,7 +13080,6 @@
                             }
                           ],
                           "name": "Iterable",
-                          "qualifiedName": "Iterable",
                           "package": "typescript"
                         },
                         {
@@ -13868,11 +13094,7 @@
                                 }
                               ],
                               "name": "KeyFn",
-                              "location": {
-                                "page": "directives",
-                                "anchor": "KeyFn",
-                                "excludeFromTOC": true
-                              }
+                              "package": "lit-html"
                             },
                             {
                               "type": "reference",
@@ -13883,11 +13105,7 @@
                                 }
                               ],
                               "name": "ItemTemplate",
-                              "location": {
-                                "page": "directives",
-                                "anchor": "ItemTemplate",
-                                "excludeFromTOC": true
-                              }
+                              "package": "lit-html"
                             }
                           ]
                         },
@@ -13900,11 +13118,7 @@
                             }
                           ],
                           "name": "ItemTemplate",
-                          "location": {
-                            "page": "directives",
-                            "anchor": "ItemTemplate",
-                            "excludeFromTOC": true
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -13925,10 +13139,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -13941,20 +13152,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/repeat.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/repeat.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RepeatDirective.update"
@@ -13972,20 +13179,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "RepeatDirective",
@@ -13995,16 +13199,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "ItemTemplate",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/repeat.ts",
@@ -14014,15 +13214,13 @@
         ],
         "typeParameters": [
           {
-            "name": "T",
-            "kindString": "Type parameter"
+            "name": "T"
           }
         ],
         "type": {
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
@@ -14032,11 +13230,9 @@
             "signatures": [
               {
                 "name": "__type",
-                "kindString": "Call signature",
                 "parameters": [
                   {
                     "name": "item",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "T"
@@ -14044,7 +13240,6 @@
                   },
                   {
                     "name": "index",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
@@ -14062,11 +13257,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "directives",
           "anchor": "ItemTemplate",
@@ -14075,7 +13270,6 @@
       },
       {
         "name": "KeyFn",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/repeat.ts",
@@ -14085,15 +13279,13 @@
         ],
         "typeParameters": [
           {
-            "name": "T",
-            "kindString": "Type parameter"
+            "name": "T"
           }
         ],
         "type": {
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
@@ -14103,11 +13295,9 @@
             "signatures": [
               {
                 "name": "__type",
-                "kindString": "Call signature",
                 "parameters": [
                   {
                     "name": "item",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "T"
@@ -14115,7 +13305,6 @@
                   },
                   {
                     "name": "index",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
@@ -14133,11 +13322,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "directives",
           "anchor": "KeyFn",
@@ -14146,7 +13335,6 @@
       },
       {
         "name": "RepeatDirectiveFn",
-        "kindString": "Interface",
         "sources": [
           {
             "fileName": "packages/lit-html/src/directives/repeat.ts",
@@ -14157,17 +13345,20 @@
         "signatures": [
           {
             "name": "RepeatDirectiveFn",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                "line": 23
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -14177,13 +13368,11 @@
                     }
                   ],
                   "name": "Iterable",
-                  "qualifiedName": "Iterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "keyFnOrTemplate",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -14196,11 +13385,7 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "KeyFn",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     },
                     {
                       "type": "reference",
@@ -14211,18 +13396,13 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ItemTemplate",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   ]
                 }
               },
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -14235,11 +13415,7 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ItemTemplate",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -14250,17 +13426,20 @@
           },
           {
             "name": "RepeatDirectiveFn",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                "line": 24
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -14270,13 +13449,11 @@
                     }
                   ],
                   "name": "Iterable",
-                  "qualifiedName": "Iterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -14286,11 +13463,7 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ItemTemplate",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -14301,17 +13474,20 @@
           },
           {
             "name": "RepeatDirectiveFn",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/repeat.d.ts",
+                "line": 25
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               }
             ],
             "parameters": [
               {
                 "name": "items",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -14321,13 +13497,11 @@
                     }
                   ],
                   "name": "Iterable",
-                  "qualifiedName": "Iterable",
                   "package": "typescript"
                 }
               },
               {
                 "name": "keyFn",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -14340,11 +13514,7 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "KeyFn",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     },
                     {
                       "type": "reference",
@@ -14355,18 +13525,13 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "ItemTemplate",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   ]
                 }
               },
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -14376,11 +13541,7 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "ItemTemplate",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -14393,11 +13554,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/repeat.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "directives",
           "anchor": "RepeatDirectiveFn",
@@ -14406,7 +13567,6 @@
       },
       {
         "name": "styleMap",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -14432,26 +13592,25 @@
         "signatures": [
           {
             "name": "styleMap",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/style-map.d.ts",
+                "line": 44
+              }
+            ],
             "parameters": [
               {
                 "name": "styleInfo",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
                     {
                       "type": "reference",
                       "name": "StyleInfo",
-                      "location": {
-                        "page": "directives",
-                        "anchor": "StyleInfo",
-                        "excludeFromTOC": true
-                      }
+                      "package": "lit-html"
                     }
                   ],
                   "name": "Readonly",
-                  "qualifiedName": "Readonly",
                   "package": "typescript"
                 }
               }
@@ -14464,30 +13623,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "StyleMapDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "StyleMapDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/style-map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/style-map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "styleMap"
@@ -14495,14 +13647,12 @@
       },
       {
         "name": "StyleMapDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/style-map.d.ts",
@@ -14512,29 +13662,26 @@
             "signatures": [
               {
                 "name": "new StyleMapDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/style-map.d.ts",
+                    "line": 20
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "StyleMapDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "StyleMapDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -14544,20 +13691,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/style-map.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/style-map.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/style-map.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "StyleMapDirective.constructor"
@@ -14565,7 +13708,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/style-map.ts",
@@ -14576,26 +13718,25 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/style-map.d.ts",
+                    "line": 21
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "styleInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "typeArguments": [
                         {
                           "type": "reference",
                           "name": "StyleInfo",
-                          "location": {
-                            "page": "directives",
-                            "anchor": "StyleInfo",
-                            "excludeFromTOC": true
-                          }
+                          "package": "lit-html"
                         }
                       ],
                       "name": "Readonly",
-                      "qualifiedName": "Readonly",
                       "package": "typescript"
                     }
                   }
@@ -14612,20 +13753,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/style-map.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/style-map.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/style-map.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "StyleMapDirective.render"
@@ -14633,7 +13770,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/style-map.ts",
@@ -14644,28 +13780,28 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/style-map.d.ts",
+                    "line": 22
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "AttributePart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "AttributePart"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "__namedParameters",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "tuple",
                       "elements": [
                         {
-                          "type": "named-tuple-member",
+                          "type": "namedTupleMember",
                           "name": "styleInfo",
                           "isOptional": false,
                           "element": {
@@ -14674,15 +13810,10 @@
                               {
                                 "type": "reference",
                                 "name": "StyleInfo",
-                                "location": {
-                                  "page": "directives",
-                                  "anchor": "StyleInfo",
-                                  "excludeFromTOC": true
-                                }
+                                "package": "lit-html"
                               }
                             ],
                             "name": "Readonly",
-                            "qualifiedName": "Readonly",
                             "package": "typescript"
                           }
                         }
@@ -14702,10 +13833,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -14718,20 +13846,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/style-map.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/style-map.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/style-map.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "StyleMapDirective.update"
@@ -14749,20 +13873,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/style-map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/style-map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "StyleMapDirective",
@@ -14772,16 +13893,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "StyleInfo",
-        "kindString": "Interface",
         "comment": {
           "shortText": "A key-value set of CSS properties and values.",
           "text": "The key should be either a valid CSS property name string, like\n`'background-color'`, or a valid JavaScript camel case property name\nfor CSSStyleDeclaration like `backgroundColor`.\n"
@@ -14795,7 +13912,12 @@
         ],
         "indexSignature": {
           "name": "__index",
-          "kindString": "Index signature",
+          "sources": [
+            {
+              "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/style-map.d.ts",
+              "line": 16
+            }
+          ],
           "parameters": [
             {
               "name": "name",
@@ -14830,11 +13952,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/style-map.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/style-map.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "directives",
           "anchor": "StyleInfo",
@@ -14843,7 +13965,6 @@
       },
       {
         "name": "templateContent",
-        "kindString": "Function",
         "comment": {
           "shortText": "Renders the content of a template element as HTML.",
           "text": "Note, the template should be developer controlled and not user controlled.\nRendering a user-controlled template with this directive\ncould lead to cross-site-scripting vulnerabilities.\n"
@@ -14858,19 +13979,19 @@
         "signatures": [
           {
             "name": "templateContent",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/template-content.d.ts",
+                "line": 20
+              }
+            ],
             "parameters": [
               {
                 "name": "template",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "HTMLTemplateElement",
-                  "qualifiedName": "HTMLTemplateElement",
-                  "package": "typescript",
-                  "externalLocation": {
-                    "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
-                  }
+                  "package": "typescript"
                 }
               }
             ],
@@ -14882,30 +14003,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "TemplateContentDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "TemplateContentDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/template-content.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/template-content.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/template-content.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "templateContent"
@@ -14913,14 +14027,12 @@
       },
       {
         "name": "TemplateContentDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/template-content.d.ts",
@@ -14930,29 +14042,26 @@
             "signatures": [
               {
                 "name": "new TemplateContentDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/template-content.d.ts",
+                    "line": 10
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "TemplateContentDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "TemplateContentDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -14962,20 +14071,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/template-content.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/template-content.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/template-content.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "TemplateContentDirective.constructor"
@@ -14983,7 +14088,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/template-content.ts",
@@ -14994,19 +14098,19 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/template-content.d.ts",
+                    "line": 11
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "template",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "HTMLTemplateElement",
-                      "qualifiedName": "HTMLTemplateElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
-                      }
+                      "package": "typescript"
                     }
                   }
                 ],
@@ -15016,21 +14120,14 @@
                     {
                       "type": "reference",
                       "name": "DocumentFragment",
-                      "qualifiedName": "DocumentFragment",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
-                      }
+                      "package": "typescript"
                     },
                     {
                       "type": "query",
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -15043,20 +14140,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/template-content.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/template-content.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/template-content.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "TemplateContentDirective.render"
@@ -15064,7 +14157,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directive.ts",
@@ -15075,23 +14167,23 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 64
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "array",
                       "elementType": {
@@ -15113,20 +14205,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/template-content.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/template-content.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/template-content.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "TemplateContentDirective.update"
@@ -15144,20 +14232,17 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/template-content.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/template-content.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/template-content.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "TemplateContentDirective",
@@ -15167,16 +14252,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "unsafeHTML",
-        "kindString": "Function",
         "comment": {
           "shortText": "Renders the result as HTML, rather than text.",
           "text": "The values `undefined`, `null`, and `nothing`, will all result in no content\n(empty string) being rendered.\nNote, this is unsafe to use with any user-provided input that hasn't been\nsanitized or escaped, as it may lead to cross-site-scripting\nvulnerabilities.\n"
@@ -15191,11 +14272,15 @@
         "signatures": [
           {
             "name": "unsafeHTML",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/unsafe-html.d.ts",
+                "line": 26
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -15216,10 +14301,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     },
                     {
@@ -15227,10 +14309,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "location": {
-                          "page": "templates",
-                          "anchor": "nothing"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -15245,30 +14324,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "UnsafeHTMLDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "UnsafeHTMLDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/unsafe-html.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "unsafeHTML"
@@ -15276,14 +14348,12 @@
       },
       {
         "name": "UnsafeHTMLDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/unsafe-html.d.ts",
@@ -15293,29 +14363,26 @@
             "signatures": [
               {
                 "name": "new UnsafeHTMLDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/unsafe-html.d.ts",
+                    "line": 13
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "UnsafeHTMLDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "UnsafeHTMLDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -15325,20 +14392,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.constructor"
@@ -15346,7 +14409,6 @@
           },
           {
             "name": "directiveName",
-            "kindString": "Property",
             "flags": {
               "isStatic": true
             },
@@ -15364,11 +14426,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.directiveName"
@@ -15376,7 +14438,6 @@
           },
           {
             "name": "resultType",
-            "kindString": "Property",
             "flags": {
               "isStatic": true
             },
@@ -15394,11 +14455,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.resultType"
@@ -15406,7 +14467,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/unsafe-html.ts",
@@ -15417,11 +14477,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/unsafe-html.d.ts",
+                    "line": 14
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -15442,10 +14506,7 @@
                           "queryType": {
                             "type": "reference",
                             "name": "noChange",
-                            "location": {
-                              "page": "custom-directives",
-                              "anchor": "noChange"
-                            }
+                            "package": "lit-html"
                           }
                         },
                         {
@@ -15453,10 +14514,7 @@
                           "queryType": {
                             "type": "reference",
                             "name": "nothing",
-                            "location": {
-                              "page": "templates",
-                              "anchor": "nothing"
-                            }
+                            "package": "lit-html"
                           }
                         }
                       ]
@@ -15479,10 +14537,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     },
                     {
@@ -15490,10 +14545,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "location": {
-                          "page": "templates",
-                          "anchor": "nothing"
-                        }
+                        "package": "lit-html"
                       }
                     },
                     {
@@ -15514,10 +14566,7 @@
                         }
                       ],
                       "name": "TemplateResult",
-                      "location": {
-                        "page": "templates",
-                        "anchor": "TemplateResult"
-                      }
+                      "package": "lit-html"
                     }
                   ]
                 },
@@ -15529,20 +14578,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.render"
@@ -15550,7 +14595,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directive.ts",
@@ -15561,23 +14605,23 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 64
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "array",
                       "elementType": {
@@ -15599,20 +14643,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.update"
@@ -15630,31 +14670,23 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "UnsafeSVGDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "UnsafeSVGDirective",
-              "excludeFromTOC": true
-            }
+            "name": "UnsafeSVGDirective"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/unsafe-html.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "UnsafeHTMLDirective",
@@ -15664,16 +14696,12 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "unsafeSVG",
-        "kindString": "Function",
         "comment": {
           "shortText": "Renders the result as SVG, rather than text.",
           "text": "The values `undefined`, `null`, and `nothing`, will all result in no content\n(empty string) being rendered.\nNote, this is unsafe to use with any user-provided input that hasn't been\nsanitized or escaped, as it may lead to cross-site-scripting\nvulnerabilities.\n"
@@ -15688,11 +14716,15 @@
         "signatures": [
           {
             "name": "unsafeSVG",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/unsafe-svg.d.ts",
+                "line": 21
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -15713,10 +14745,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     },
                     {
@@ -15724,10 +14753,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "location": {
-                          "page": "templates",
-                          "anchor": "nothing"
-                        }
+                        "package": "lit-html"
                       }
                     }
                   ]
@@ -15742,30 +14768,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "UnsafeSVGDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "UnsafeSVGDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/unsafe-svg.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "unsafeSVG"
@@ -15773,14 +14792,12 @@
       },
       {
         "name": "UnsafeSVGDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "Base class for creating custom directives. Users should extend this class,\nimplement `render` and/or `update`, and then pass their subclass to\n`directive`."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directives/unsafe-html.d.ts",
@@ -15790,29 +14807,26 @@
             "signatures": [
               {
                 "name": "new UnsafeSVGDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/unsafe-html.d.ts",
+                    "line": 13
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "UnsafeSVGDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "UnsafeSVGDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -15822,20 +14836,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.constructor",
-              "location": {
-                "page": "directives",
-                "anchor": "UnsafeHTMLDirective.constructor"
-              }
+              "name": "UnsafeHTMLDirective.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.constructor"
@@ -15843,7 +14853,6 @@
           },
           {
             "name": "directiveName",
-            "kindString": "Property",
             "flags": {
               "isStatic": true
             },
@@ -15860,20 +14869,16 @@
             },
             "overwrites": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.directiveName",
-              "location": {
-                "page": "directives",
-                "anchor": "UnsafeHTMLDirective.directiveName"
-              }
+              "name": "UnsafeHTMLDirective.directiveName"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.directiveName"
@@ -15881,7 +14886,6 @@
           },
           {
             "name": "resultType",
-            "kindString": "Property",
             "flags": {
               "isStatic": true
             },
@@ -15898,20 +14902,16 @@
             },
             "overwrites": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.resultType",
-              "location": {
-                "page": "directives",
-                "anchor": "UnsafeHTMLDirective.resultType"
-              }
+              "name": "UnsafeHTMLDirective.resultType"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.resultType"
@@ -15919,7 +14919,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/unsafe-html.ts",
@@ -15930,11 +14929,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/unsafe-html.d.ts",
+                    "line": 14
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -15955,10 +14958,7 @@
                           "queryType": {
                             "type": "reference",
                             "name": "noChange",
-                            "location": {
-                              "page": "custom-directives",
-                              "anchor": "noChange"
-                            }
+                            "package": "lit-html"
                           }
                         },
                         {
@@ -15966,10 +14966,7 @@
                           "queryType": {
                             "type": "reference",
                             "name": "nothing",
-                            "location": {
-                              "page": "templates",
-                              "anchor": "nothing"
-                            }
+                            "package": "lit-html"
                           }
                         }
                       ]
@@ -15992,10 +14989,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "location": {
-                          "page": "custom-directives",
-                          "anchor": "noChange"
-                        }
+                        "package": "lit-html"
                       }
                     },
                     {
@@ -16003,10 +14997,7 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "location": {
-                          "page": "templates",
-                          "anchor": "nothing"
-                        }
+                        "package": "lit-html"
                       }
                     },
                     {
@@ -16027,10 +15018,7 @@
                         }
                       ],
                       "name": "TemplateResult",
-                      "location": {
-                        "page": "templates",
-                        "anchor": "TemplateResult"
-                      }
+                      "package": "lit-html"
                     }
                   ]
                 },
@@ -16042,20 +15030,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.render",
-              "location": {
-                "page": "directives",
-                "anchor": "UnsafeHTMLDirective.render"
-              }
+              "name": "UnsafeHTMLDirective.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.render"
@@ -16063,7 +15047,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directive.ts",
@@ -16074,23 +15057,23 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 64
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "array",
                       "elementType": {
@@ -16112,20 +15095,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.update",
-              "location": {
-                "page": "directives",
-                "anchor": "UnsafeHTMLDirective.update"
-              }
+              "name": "UnsafeHTMLDirective.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.update"
@@ -16143,21 +15122,17 @@
           {
             "type": "reference",
             "name": "UnsafeHTMLDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "UnsafeHTMLDirective",
-              "excludeFromTOC": true
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-svg.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/unsafe-svg.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/unsafe-svg.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "UnsafeSVGDirective",
@@ -16167,25 +15142,12 @@
           {
             "type": "reference",
             "name": "UnsafeHTMLDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "UnsafeHTMLDirective",
-              "excludeFromTOC": true
-            }
-          },
-          {
-            "type": "reference",
-            "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "until",
-        "kindString": "Function",
         "comment": {
           "shortText": "Renders one of a series of values, including Promises, to a Part.",
           "text": "Values are rendered in priority order, with the first argument having the\nhighest priority and the last argument having the lowest priority. If a\nvalue is a Promise, low-priority values will be rendered until it resolves.\nThe priority of values can be used to create placeholder content for async\ndata. For example, a Promise with pending content can be the first,\nhighest-priority, argument, and a non_promise loading indicator template can\nbe used as the second, lower-priority, argument. The loading indicator will\nrender immediately, and the primary content will render when the Promise\nresolves.\nExample:\n```js\nconst content = fetch('./content.txt').then(r => r.text());\nhtml`${until(content, html`<span>Loading...</span>`)}`\n```\n"
@@ -16200,11 +15162,15 @@
         "signatures": [
           {
             "name": "until",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/until.d.ts",
+                "line": 39
+              }
+            ],
             "parameters": [
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -16225,30 +15191,23 @@
                   "queryType": {
                     "type": "reference",
                     "name": "UntilDirective",
-                    "location": {
-                      "page": "directives",
-                      "anchor": "UntilDirective",
-                      "excludeFromTOC": true
-                    }
+                    "package": "lit-html"
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/until.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/until.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "until"
@@ -16256,7 +15215,6 @@
       },
       {
         "name": "UntilDirective",
-        "kindString": "Class",
         "comment": {
           "shortText": "An abstract `Directive` base class whose `disconnected` method will be\ncalled when the part containing the directive is cleared as a result of\nre-rendering, or when the user calls `part.setConnected(false)` on\na part that was previously rendered containing the directive (as happens\nwhen e.g. a LitElement disconnects from the DOM).",
           "text": "If `part.setConnected(true)` is subsequently called on a\ncontaining part, the directive's `reconnected` method will be called prior\nto its next `update`/`render` callbacks. When implementing `disconnected`,\n`reconnected` should also be implemented to be compatible with reconnection.\nNote that updates may occur while the directive is disconnected. As such,\ndirectives should generally check the `this.isConnected` flag during\nrender/update to determine whether it is safe to subscribe to resources\nthat may prevent garbage collection.\n"
@@ -16264,7 +15222,6 @@
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -16274,29 +15231,26 @@
             "signatures": [
               {
                 "name": "new UntilDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "UntilDirective",
-                  "location": {
-                    "page": "directives",
-                    "anchor": "UntilDirective",
-                    "excludeFromTOC": true
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -16306,20 +15260,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.constructor"
-              }
+              "name": "AsyncDirective.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.constructor"
@@ -16327,7 +15277,6 @@
           },
           {
             "name": "isConnected",
-            "kindString": "Property",
             "comment": {
               "shortText": "The connection state for this Directive."
             },
@@ -16344,20 +15293,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.isConnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.isConnected"
-              }
+              "name": "AsyncDirective.isConnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.isConnected"
@@ -16365,7 +15310,6 @@
           },
           {
             "name": "disconnected",
-            "kindString": "Method",
             "comment": {
               "shortText": "User callbacks for implementing logic to release any resources/subscriptions\nthat may have been retained by this directive. Since directives may also be\nre-connected, `reconnected` should also be implemented to restore the\nworking state of the directive prior to the next render."
             },
@@ -16379,7 +15323,12 @@
             "signatures": [
               {
                 "name": "disconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/until.d.ts",
+                    "line": 15
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -16392,20 +15341,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.disconnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.disconnected"
-              }
+              "name": "AsyncDirective.disconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.disconnected"
@@ -16413,7 +15358,6 @@
           },
           {
             "name": "reconnected",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/until.ts",
@@ -16424,7 +15368,12 @@
             "signatures": [
               {
                 "name": "reconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/until.d.ts",
+                    "line": 16
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -16437,20 +15386,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.reconnected",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.reconnected"
-              }
+              "name": "AsyncDirective.reconnected"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.reconnected"
@@ -16458,7 +15403,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/until.ts",
@@ -16469,11 +15413,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/until.d.ts",
+                    "line": 13
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "args",
-                    "kindString": "Parameter",
                     "flags": {
                       "isRest": true
                     },
@@ -16498,20 +15446,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.render"
-              }
+              "name": "AsyncDirective.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.render"
@@ -16519,7 +15463,6 @@
           },
           {
             "name": "setValue",
-            "kindString": "Method",
             "comment": {
               "shortText": "Sets the value of the directive's Part outside the normal `update`/`render`\nlifecycle of a directive.",
               "text": "This method should not be called synchronously from a directive's `update`\nor `render`.\n"
@@ -16534,11 +15477,15 @@
             "signatures": [
               {
                 "name": "setValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 161
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The value to set"
                     },
@@ -16560,20 +15507,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.setValue",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.setValue"
-              }
+              "name": "AsyncDirective.setValue"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.setValue"
@@ -16581,7 +15524,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directives/until.ts",
@@ -16592,23 +15534,23 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/until.d.ts",
+                    "line": 14
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "args",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "array",
                       "elementType": {
@@ -16630,20 +15572,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AsyncDirective.update"
-              }
+              "name": "AsyncDirective.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.update"
@@ -16661,20 +15599,17 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/until.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/until.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/until.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "UntilDirective",
@@ -16684,24 +15619,12 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
-          },
-          {
-            "type": "reference",
-            "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "when",
-        "kindString": "Function",
         "comment": {
           "blockTags": [
             {
@@ -16736,21 +15659,23 @@
         "signatures": [
           {
             "name": "when",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                "line": 23
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               },
               {
-                "name": "F",
-                "kindString": "Type parameter"
+                "name": "F"
               }
             ],
             "parameters": [
               {
                 "name": "condition",
-                "kindString": "Parameter",
                 "type": {
                   "type": "literal",
                   "value": true
@@ -16758,12 +15683,10 @@
               },
               {
                 "name": "trueCase",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
@@ -16773,7 +15696,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                            "line": 23
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "T"
@@ -16785,7 +15713,6 @@
               },
               {
                 "name": "falseCase",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -16793,7 +15720,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
@@ -16803,7 +15729,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                            "line": 23
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "F"
@@ -16821,15 +15752,18 @@
           },
           {
             "name": "when",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                "line": 24
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               },
               {
                 "name": "F",
-                "kindString": "Type parameter",
                 "default": {
                   "type": "intrinsic",
                   "name": "undefined"
@@ -16839,7 +15773,6 @@
             "parameters": [
               {
                 "name": "condition",
-                "kindString": "Parameter",
                 "type": {
                   "type": "literal",
                   "value": false
@@ -16847,12 +15780,10 @@
               },
               {
                 "name": "trueCase",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
@@ -16862,7 +15793,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                            "line": 24
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "T"
@@ -16874,7 +15810,6 @@
               },
               {
                 "name": "falseCase",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -16882,7 +15817,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
@@ -16892,7 +15826,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                            "line": 24
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "F"
@@ -16910,15 +15849,18 @@
           },
           {
             "name": "when",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                "line": 25
+              }
+            ],
             "typeParameter": [
               {
-                "name": "T",
-                "kindString": "Type parameter"
+                "name": "T"
               },
               {
                 "name": "F",
-                "kindString": "Type parameter",
                 "default": {
                   "type": "intrinsic",
                   "name": "undefined"
@@ -16928,7 +15870,6 @@
             "parameters": [
               {
                 "name": "condition",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -16936,12 +15877,10 @@
               },
               {
                 "name": "trueCase",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
@@ -16951,7 +15890,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                            "line": 25
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "T"
@@ -16963,7 +15907,6 @@
               },
               {
                 "name": "falseCase",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -16971,7 +15914,6 @@
                   "type": "reflection",
                   "declaration": {
                     "name": "__type",
-                    "kindString": "Type literal",
                     "sources": [
                       {
                         "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
@@ -16981,7 +15923,12 @@
                     "signatures": [
                       {
                         "name": "__type",
-                        "kindString": "Call signature",
+                        "sources": [
+                          {
+                            "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directives/when.d.ts",
+                            "line": 25
+                          }
+                        ],
                         "type": {
                           "type": "reference",
                           "name": "F"
@@ -17010,11 +15957,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/when.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directives/when.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directives/when.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "when"
@@ -17033,7 +15980,6 @@
     "items": [
       {
         "name": "AsyncDirective",
-        "kindString": "Class",
         "flags": {
           "isAbstract": true
         },
@@ -17044,7 +15990,6 @@
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -17054,28 +15999,26 @@
             "signatures": [
               {
                 "name": "new AsyncDirective",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "AsyncDirective",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "AsyncDirective"
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -17085,20 +16028,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.constructor"
-              }
+              "name": "Directive.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.constructor"
@@ -17106,7 +16045,6 @@
           },
           {
             "name": "isConnected",
-            "kindString": "Property",
             "comment": {
               "shortText": "The connection state for this Directive."
             },
@@ -17124,11 +16062,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.isConnected"
@@ -17136,7 +16074,6 @@
           },
           {
             "name": "disconnected",
-            "kindString": "Method",
             "flags": {
               "isProtected": true
             },
@@ -17153,7 +16090,12 @@
             "signatures": [
               {
                 "name": "disconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 168
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -17163,11 +16105,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.disconnected"
@@ -17175,7 +16117,6 @@
           },
           {
             "name": "reconnected",
-            "kindString": "Method",
             "flags": {
               "isProtected": true
             },
@@ -17189,7 +16130,12 @@
             "signatures": [
               {
                 "name": "reconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 169
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -17199,11 +16145,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.reconnected"
@@ -17211,7 +16157,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "flags": {
               "isAbstract": true
             },
@@ -17225,11 +16170,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 63
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "flags": {
                       "isRest": true
                     },
@@ -17254,20 +16203,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.render",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.render"
-              }
+              "name": "Directive.render"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.render"
@@ -17275,7 +16220,6 @@
           },
           {
             "name": "setValue",
-            "kindString": "Method",
             "comment": {
               "shortText": "Sets the value of the directive's Part outside the normal `update`/`render`\nlifecycle of a directive.",
               "text": "This method should not be called synchronously from a directive's `update`\nor `render`.\n"
@@ -17290,11 +16234,15 @@
             "signatures": [
               {
                 "name": "setValue",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/async-directive.d.ts",
+                    "line": 161
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The value to set"
                     },
@@ -17313,11 +16261,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.setValue"
@@ -17325,7 +16273,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directive.ts",
@@ -17336,23 +16283,23 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 64
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "array",
                       "elementType": {
@@ -17374,20 +16321,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.update",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive.update"
-              }
+              "name": "Directive.update"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.update"
@@ -17405,49 +16348,31 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "AsyncReplaceDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "AsyncReplaceDirective",
-              "excludeFromTOC": true
-            }
+            "name": "AsyncReplaceDirective"
           },
           {
             "type": "reference",
-            "name": "RefDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "RefDirective",
-              "excludeFromTOC": true
-            }
+            "name": "RefDirective"
           },
           {
             "type": "reference",
-            "name": "UntilDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "UntilDirective",
-              "excludeFromTOC": true
-            }
+            "name": "UntilDirective"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "AsyncDirective"
@@ -17456,20 +16381,15 @@
           {
             "type": "reference",
             "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "AttributePart",
-        "kindString": "Class",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -17479,24 +16399,23 @@
             "signatures": [
               {
                 "name": "new AttributePart",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 451
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "element",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     }
                   },
                   {
                     "name": "name",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
@@ -17504,7 +16423,6 @@
                   },
                   {
                     "name": "strings",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
@@ -17512,19 +16430,14 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "Disconnectable"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "options",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -17535,10 +16448,7 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -17547,21 +16457,18 @@
                 "type": {
                   "type": "reference",
                   "name": "AttributePart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "AttributePart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.constructor"
@@ -17569,7 +16476,6 @@
           },
           {
             "name": "element",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -17583,20 +16489,16 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "qualifiedName": "HTMLElement",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-              }
+              "package": "typescript"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.element"
@@ -17604,7 +16506,6 @@
           },
           {
             "name": "name",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -17622,11 +16523,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.name"
@@ -17634,7 +16535,6 @@
           },
           {
             "name": "options",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -17655,21 +16555,18 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.options"
@@ -17677,7 +16574,6 @@
           },
           {
             "name": "strings",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -17699,11 +16595,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.strings"
@@ -17711,7 +16607,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -17746,11 +16641,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.type"
@@ -17758,7 +16653,6 @@
           },
           {
             "name": "tagName",
-            "kindString": "Accessor",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -17772,7 +16666,12 @@
             },
             "getSignature": {
               "name": "tagName",
-              "kindString": "Get signature",
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 449
+                }
+              ],
               "type": {
                 "type": "intrinsic",
                 "name": "string"
@@ -17781,11 +16680,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.tagName"
@@ -17802,47 +16701,32 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "BooleanAttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "BooleanAttributePart"
-            }
+            "name": "BooleanAttributePart"
           },
           {
             "type": "reference",
-            "name": "EventPart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "EventPart"
-            }
+            "name": "EventPart"
           },
           {
             "type": "reference",
-            "name": "PropertyPart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "PropertyPart"
-            }
+            "name": "PropertyPart"
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "Disconnectable",
-            "location": {
-              "page": "misc",
-              "anchor": "Disconnectable"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "AttributePart"
@@ -17850,11 +16734,9 @@
       },
       {
         "name": "BooleanAttributePart",
-        "kindString": "Class",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -17864,24 +16746,23 @@
             "signatures": [
               {
                 "name": "new BooleanAttributePart",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 451
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "element",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     }
                   },
                   {
                     "name": "name",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
@@ -17889,7 +16770,6 @@
                   },
                   {
                     "name": "strings",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
@@ -17897,19 +16777,14 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "Disconnectable"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "options",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -17920,10 +16795,7 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -17932,10 +16804,7 @@
                 "type": {
                   "type": "reference",
                   "name": "BooleanAttributePart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "BooleanAttributePart"
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -17945,20 +16814,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.constructor"
-              }
+              "name": "AttributePart.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.constructor"
@@ -17966,7 +16831,6 @@
           },
           {
             "name": "element",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -17980,28 +16844,20 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "qualifiedName": "HTMLElement",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-              }
+              "package": "typescript"
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.element",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.element"
-              }
+              "name": "AttributePart.element"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.element"
@@ -18009,7 +16865,6 @@
           },
           {
             "name": "name",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -18026,20 +16881,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.name",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.name"
-              }
+              "name": "AttributePart.name"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.name"
@@ -18047,7 +16898,6 @@
           },
           {
             "name": "options",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -18068,29 +16918,22 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.options",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.options"
-              }
+              "name": "AttributePart.options"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.options"
@@ -18098,7 +16941,6 @@
           },
           {
             "name": "strings",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -18119,20 +16961,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.strings",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.strings"
-              }
+              "name": "AttributePart.strings"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.strings"
@@ -18140,7 +16978,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -18158,20 +16995,16 @@
             "defaultValue": "4",
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.type",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.type"
-              }
+              "name": "AttributePart.type"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.type"
@@ -18179,7 +17012,6 @@
           },
           {
             "name": "tagName",
-            "kindString": "Accessor",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -18193,7 +17025,12 @@
             },
             "getSignature": {
               "name": "tagName",
-              "kindString": "Get signature",
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 449
+                }
+              ],
               "type": {
                 "type": "intrinsic",
                 "name": "string"
@@ -18205,20 +17042,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.tagName",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.tagName"
-              }
+              "name": "AttributePart.tagName"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.tagName"
@@ -18236,20 +17069,17 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "BooleanAttributePart"
@@ -18258,20 +17088,15 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "ChildPart",
-        "kindString": "Class",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -18281,21 +17106,23 @@
             "signatures": [
               {
                 "name": "new ChildPart",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 377
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "startNode",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildNode",
-                      "qualifiedName": "ChildNode",
                       "package": "typescript"
                     }
                   },
                   {
                     "name": "endNode",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -18306,7 +17133,6 @@
                         {
                           "type": "reference",
                           "name": "ChildNode",
-                          "qualifiedName": "ChildNode",
                           "package": "typescript"
                         }
                       ]
@@ -18314,7 +17140,6 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -18325,25 +17150,18 @@
                         {
                           "type": "reference",
                           "name": "ChildPart",
-                          "location": {
-                            "page": "custom-directives",
-                            "anchor": "ChildPart"
-                          }
+                          "package": "lit-html"
                         },
                         {
                           "type": "reference",
                           "name": "TemplateInstance",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "TemplateInstance"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
                   },
                   {
                     "name": "options",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -18354,10 +17172,7 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -18366,21 +17181,18 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.constructor"
@@ -18388,7 +17200,6 @@
           },
           {
             "name": "options",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -18409,21 +17220,18 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.options"
@@ -18431,7 +17239,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -18450,11 +17257,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.type"
@@ -18462,7 +17269,6 @@
           },
           {
             "name": "endNode",
-            "kindString": "Accessor",
             "comment": {
               "shortText": "The part's trailing marker node, if any. See `.parentNode` for more\ninformation."
             },
@@ -18483,17 +17289,21 @@
                 {
                   "type": "reference",
                   "name": "Node",
-                  "qualifiedName": "Node",
                   "package": "typescript"
                 }
               ]
             },
             "getSignature": {
               "name": "endNode",
-              "kindString": "Get signature",
               "comment": {
                 "shortText": "The part's trailing marker node, if any. See `.parentNode` for more\ninformation."
               },
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 406
+                }
+              ],
               "type": {
                 "type": "union",
                 "types": [
@@ -18504,7 +17314,6 @@
                   {
                     "type": "reference",
                     "name": "Node",
-                    "qualifiedName": "Node",
                     "package": "typescript"
                   }
                 ]
@@ -18513,11 +17322,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.endNode"
@@ -18525,7 +17334,6 @@
           },
           {
             "name": "parentNode",
-            "kindString": "Accessor",
             "comment": {
               "shortText": "The parent node into which the part renders its content.",
               "text": "A ChildPart's content consists of a range of adjacent child nodes of\n`.parentNode`, possibly bordered by 'marker nodes' (`.startNode` and\n`.endNode`).\n- If both `.startNode` and `.endNode` are non-null, then the part's content\nconsists of all siblings between `.startNode` and `.endNode`, exclusively.\n- If `.startNode` is non-null but `.endNode` is null, then the part's\ncontent consists of all siblings following `.startNode`, up to and\nincluding the last child of `.parentNode`. If `.endNode` is non-null, then\n`.startNode` will always be non-null.\n- If both `.endNode` and `.startNode` are null, then the part's content\nconsists of all child nodes of `.parentNode`.\n"
@@ -18540,31 +17348,34 @@
             "type": {
               "type": "reference",
               "name": "Node",
-              "qualifiedName": "Node",
               "package": "typescript"
             },
             "getSignature": {
               "name": "parentNode",
-              "kindString": "Get signature",
               "comment": {
                 "shortText": "The parent node into which the part renders its content.",
                 "text": "A ChildPart's content consists of a range of adjacent child nodes of\n`.parentNode`, possibly bordered by 'marker nodes' (`.startNode` and\n`.endNode`).\n- If both `.startNode` and `.endNode` are non-null, then the part's content\nconsists of all siblings between `.startNode` and `.endNode`, exclusively.\n- If `.startNode` is non-null but `.endNode` is null, then the part's\ncontent consists of all siblings following `.startNode`, up to and\nincluding the last child of `.parentNode`. If `.endNode` is non-null, then\n`.startNode` will always be non-null.\n- If both `.endNode` and `.startNode` are null, then the part's content\nconsists of all child nodes of `.parentNode`.\n"
               },
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 396
+                }
+              ],
               "type": {
                 "type": "reference",
                 "name": "Node",
-                "qualifiedName": "Node",
                 "package": "typescript"
               }
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.parentNode"
@@ -18572,7 +17383,6 @@
           },
           {
             "name": "startNode",
-            "kindString": "Accessor",
             "comment": {
               "shortText": "The part's leading marker node, if any. See `.parentNode` for more\ninformation."
             },
@@ -18593,17 +17403,21 @@
                 {
                   "type": "reference",
                   "name": "Node",
-                  "qualifiedName": "Node",
                   "package": "typescript"
                 }
               ]
             },
             "getSignature": {
               "name": "startNode",
-              "kindString": "Get signature",
               "comment": {
                 "shortText": "The part's leading marker node, if any. See `.parentNode` for more\ninformation."
               },
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 401
+                }
+              ],
               "type": {
                 "type": "union",
                 "types": [
@@ -18614,7 +17428,6 @@
                   {
                     "type": "reference",
                     "name": "Node",
-                    "qualifiedName": "Node",
                     "package": "typescript"
                   }
                 ]
@@ -18623,11 +17436,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.startNode"
@@ -18644,31 +17457,24 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "RootPart",
-            "location": {
-              "page": "misc",
-              "anchor": "RootPart"
-            }
+            "name": "RootPart"
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "Disconnectable",
-            "location": {
-              "page": "misc",
-              "anchor": "Disconnectable"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "ChildPart"
@@ -18676,7 +17482,6 @@
       },
       {
         "name": "directive",
-        "kindString": "Function",
         "comment": {
           "shortText": "Creates a user-facing directive function from a Directive class. This\nfunction has the same parameters as the directive's render() method."
         },
@@ -18690,25 +17495,25 @@
         "signatures": [
           {
             "name": "directive",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                "line": 54
+              }
+            ],
             "typeParameter": [
               {
                 "name": "C",
-                "kindString": "Type parameter",
                 "type": {
                   "type": "reference",
                   "name": "DirectiveClass",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "DirectiveClass"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "parameters": [
               {
                 "name": "c",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "C"
@@ -18719,7 +17524,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
@@ -18729,11 +17533,15 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                        "line": 54
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "values",
-                        "kindString": "Parameter",
                         "flags": {
                           "isRest": true
                         },
@@ -18755,13 +17563,11 @@
                                   }
                                 ],
                                 "name": "InstanceType",
-                                "qualifiedName": "InstanceType",
                                 "package": "typescript"
                               }
                             }
                           ],
                           "name": "Parameters",
-                          "qualifiedName": "Parameters",
                           "package": "typescript"
                         }
                       }
@@ -18775,10 +17581,7 @@
                         }
                       ],
                       "name": "DirectiveResult",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "DirectiveResult"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ]
@@ -18789,11 +17592,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "directive"
@@ -18801,7 +17604,6 @@
       },
       {
         "name": "Directive",
-        "kindString": "Class",
         "flags": {
           "isAbstract": true
         },
@@ -18811,7 +17613,6 @@
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/directive.d.ts",
@@ -18821,39 +17622,37 @@
             "signatures": [
               {
                 "name": "new Directive",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 61
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_partInfo",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "Directive",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "Directive"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "Directive.constructor"
@@ -18861,7 +17660,6 @@
           },
           {
             "name": "render",
-            "kindString": "Method",
             "flags": {
               "isAbstract": true
             },
@@ -18875,11 +17673,15 @@
             "signatures": [
               {
                 "name": "render",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 63
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "flags": {
                       "isRest": true
                     },
@@ -18901,11 +17703,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "Directive.render"
@@ -18913,7 +17715,6 @@
           },
           {
             "name": "update",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directive.ts",
@@ -18924,23 +17725,23 @@
             "signatures": [
               {
                 "name": "update",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 64
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "_part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "props",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "array",
                       "elementType": {
@@ -18959,11 +17760,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "Directive.update"
@@ -18980,112 +17781,60 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "AsyncDirective",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AsyncDirective"
-            }
+            "name": "AsyncDirective"
           },
           {
             "type": "reference",
-            "name": "CacheDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "CacheDirective",
-              "excludeFromTOC": true
-            }
+            "name": "CacheDirective"
           },
           {
             "type": "reference",
-            "name": "ClassMapDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "ClassMapDirective",
-              "excludeFromTOC": true
-            }
+            "name": "ClassMapDirective"
           },
           {
             "type": "reference",
-            "name": "GuardDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "GuardDirective",
-              "excludeFromTOC": true
-            }
+            "name": "GuardDirective"
           },
           {
             "type": "reference",
-            "name": "Keyed",
-            "location": {
-              "page": "directives",
-              "anchor": "Keyed",
-              "excludeFromTOC": true
-            }
+            "name": "Keyed"
           },
           {
             "type": "reference",
-            "name": "LiveDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "LiveDirective",
-              "excludeFromTOC": true
-            }
+            "name": "LiveDirective"
           },
           {
             "type": "reference",
-            "name": "RepeatDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "RepeatDirective",
-              "excludeFromTOC": true
-            }
+            "name": "RepeatDirective"
           },
           {
             "type": "reference",
-            "name": "StyleMapDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "StyleMapDirective",
-              "excludeFromTOC": true
-            }
+            "name": "StyleMapDirective"
           },
           {
             "type": "reference",
-            "name": "TemplateContentDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "TemplateContentDirective",
-              "excludeFromTOC": true
-            }
+            "name": "TemplateContentDirective"
           },
           {
             "type": "reference",
-            "name": "UnsafeHTMLDirective",
-            "location": {
-              "page": "directives",
-              "anchor": "UnsafeHTMLDirective",
-              "excludeFromTOC": true
-            }
+            "name": "UnsafeHTMLDirective"
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "Disconnectable",
-            "location": {
-              "page": "misc",
-              "anchor": "Disconnectable"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "Directive"
@@ -19093,11 +17842,9 @@
       },
       {
         "name": "ElementPart",
-        "kindString": "Class",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -19107,36 +17854,31 @@
             "signatures": [
               {
                 "name": "new ElementPart",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 484
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "element",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     }
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "Disconnectable"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "options",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -19147,10 +17889,7 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -19159,21 +17898,18 @@
                 "type": {
                   "type": "reference",
                   "name": "ElementPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ElementPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.constructor"
@@ -19181,7 +17917,6 @@
           },
           {
             "name": "element",
-            "kindString": "Property",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -19192,20 +17927,16 @@
             "type": {
               "type": "reference",
               "name": "Element",
-              "qualifiedName": "Element",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-              }
+              "package": "typescript"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.element"
@@ -19213,7 +17944,6 @@
           },
           {
             "name": "options",
-            "kindString": "Property",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -19231,21 +17961,18 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.options"
@@ -19253,7 +17980,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -19272,11 +17998,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.type"
@@ -19294,20 +18020,17 @@
           {
             "type": "reference",
             "name": "Disconnectable",
-            "location": {
-              "page": "misc",
-              "anchor": "Disconnectable"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "ElementPart"
@@ -19315,11 +18038,9 @@
       },
       {
         "name": "EventPart",
-        "kindString": "Class",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -19329,24 +18050,23 @@
             "signatures": [
               {
                 "name": "new EventPart",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 475
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "element",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     }
                   },
                   {
                     "name": "name",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
@@ -19354,7 +18074,6 @@
                   },
                   {
                     "name": "strings",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
@@ -19362,19 +18081,14 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "Disconnectable"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "options",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -19385,10 +18099,7 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -19397,10 +18108,7 @@
                 "type": {
                   "type": "reference",
                   "name": "EventPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "EventPart"
-                  }
+                  "package": "lit-html"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -19410,20 +18118,16 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.constructor"
-              }
+              "name": "AttributePart.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.constructor"
@@ -19431,7 +18135,6 @@
           },
           {
             "name": "element",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -19445,28 +18148,20 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "qualifiedName": "HTMLElement",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-              }
+              "package": "typescript"
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.element",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.element"
-              }
+              "name": "AttributePart.element"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.element"
@@ -19474,7 +18169,6 @@
           },
           {
             "name": "name",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -19491,20 +18185,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.name",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.name"
-              }
+              "name": "AttributePart.name"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.name"
@@ -19512,7 +18202,6 @@
           },
           {
             "name": "options",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -19533,29 +18222,22 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.options",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.options"
-              }
+              "name": "AttributePart.options"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.options"
@@ -19563,7 +18245,6 @@
           },
           {
             "name": "strings",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -19584,20 +18265,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.strings",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.strings"
-              }
+              "name": "AttributePart.strings"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.strings"
@@ -19605,7 +18282,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -19623,20 +18299,16 @@
             "defaultValue": "5",
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.type",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.type"
-              }
+              "name": "AttributePart.type"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.type"
@@ -19644,7 +18316,6 @@
           },
           {
             "name": "tagName",
-            "kindString": "Accessor",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -19658,7 +18329,12 @@
             },
             "getSignature": {
               "name": "tagName",
-              "kindString": "Get signature",
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 449
+                }
+              ],
               "type": {
                 "type": "intrinsic",
                 "name": "string"
@@ -19670,20 +18346,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.tagName",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.tagName"
-              }
+              "name": "AttributePart.tagName"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.tagName"
@@ -19691,7 +18363,6 @@
           },
           {
             "name": "handleEvent",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -19702,15 +18373,18 @@
             "signatures": [
               {
                 "name": "handleEvent",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 476
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "event",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Event",
-                      "qualifiedName": "Event",
                       "package": "typescript"
                     }
                   }
@@ -19724,11 +18398,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.handleEvent"
@@ -19746,20 +18420,17 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "EventPart"
@@ -19768,16 +18439,12 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "PartType",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -19797,11 +18464,9 @@
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "children": [
               {
                 "name": "ATTRIBUTE",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -19818,7 +18483,6 @@
               },
               {
                 "name": "BOOLEAN_ATTRIBUTE",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -19835,7 +18499,6 @@
               },
               {
                 "name": "CHILD",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -19852,7 +18515,6 @@
               },
               {
                 "name": "ELEMENT",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -19869,7 +18531,6 @@
               },
               {
                 "name": "EVENT",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -19886,7 +18547,6 @@
               },
               {
                 "name": "PROPERTY",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -19913,11 +18573,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "custom-directives",
           "anchor": "PartType"
@@ -19925,11 +18585,9 @@
       },
       {
         "name": "PropertyPart",
-        "kindString": "Class",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -19939,24 +18597,23 @@
             "signatures": [
               {
                 "name": "new PropertyPart",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 451
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "element",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "qualifiedName": "HTMLElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                      }
+                      "package": "typescript"
                     }
                   },
                   {
                     "name": "name",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
@@ -19964,7 +18621,6 @@
                   },
                   {
                     "name": "strings",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
@@ -19972,19 +18628,14 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "Disconnectable"
-                      }
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "options",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -19995,10 +18646,7 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     }
@@ -20007,10 +18655,7 @@
                 "type": {
                   "type": "reference",
                   "name": "PropertyPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "PropertyPart"
-                  }
+                  "package": "lit-html"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -20020,20 +18665,16 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.constructor",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.constructor"
-              }
+              "name": "AttributePart.constructor"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.constructor"
@@ -20041,7 +18682,6 @@
           },
           {
             "name": "element",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20055,28 +18695,20 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "qualifiedName": "HTMLElement",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-              }
+              "package": "typescript"
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.element",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.element"
-              }
+              "name": "AttributePart.element"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.element"
@@ -20084,7 +18716,6 @@
           },
           {
             "name": "name",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20101,20 +18732,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.name",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.name"
-              }
+              "name": "AttributePart.name"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.name"
@@ -20122,7 +18749,6 @@
           },
           {
             "name": "options",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20143,29 +18769,22 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.options",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.options"
-              }
+              "name": "AttributePart.options"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.options"
@@ -20173,7 +18792,6 @@
           },
           {
             "name": "strings",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -20194,20 +18812,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.strings",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.strings"
-              }
+              "name": "AttributePart.strings"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.strings"
@@ -20215,7 +18829,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20233,20 +18846,16 @@
             "defaultValue": "3",
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.type",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.type"
-              }
+              "name": "AttributePart.type"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.type"
@@ -20254,7 +18863,6 @@
           },
           {
             "name": "tagName",
-            "kindString": "Accessor",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -20268,7 +18876,12 @@
             },
             "getSignature": {
               "name": "tagName",
-              "kindString": "Get signature",
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 449
+                }
+              ],
               "type": {
                 "type": "intrinsic",
                 "name": "string"
@@ -20280,20 +18893,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.tagName",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart.tagName"
-              }
+              "name": "AttributePart.tagName"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.tagName"
@@ -20311,20 +18920,17 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "PropertyPart"
@@ -20333,20 +18939,15 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "AttributePartInfo",
-        "kindString": "Interface",
         "children": [
           {
             "name": "name",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20364,11 +18965,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.name"
@@ -20376,7 +18977,6 @@
           },
           {
             "name": "strings",
-            "kindString": "Property",
             "flags": {
               "isOptional": true,
               "isReadonly": true
@@ -20395,11 +18995,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.strings"
@@ -20407,7 +19007,6 @@
           },
           {
             "name": "tagName",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20425,11 +19024,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.tagName"
@@ -20437,7 +19036,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20472,11 +19070,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.type"
@@ -20493,11 +19091,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "AttributePartInfo"
@@ -20505,11 +19103,9 @@
       },
       {
         "name": "ChildPartInfo",
-        "kindString": "Interface",
         "children": [
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20527,11 +19123,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPartInfo.type"
@@ -20548,11 +19144,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "ChildPartInfo"
@@ -20560,11 +19156,9 @@
       },
       {
         "name": "DirectiveClass",
-        "kindString": "Interface",
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/directive.ts",
@@ -20575,39 +19169,37 @@
             "signatures": [
               {
                 "name": "new DirectiveClass",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
+                    "line": 9
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "part",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "PartInfo"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "Directive",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "Directive"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "DirectiveClass.constructor"
@@ -20624,11 +19216,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "DirectiveClass"
@@ -20636,7 +19228,6 @@
       },
       {
         "name": "DirectiveParameters",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "This utility type extracts the signature of a directive class's render()\nmethod so we can use it for the type of the generated directive function."
         },
@@ -20650,14 +19241,10 @@
         "typeParameters": [
           {
             "name": "C",
-            "kindString": "Type parameter",
             "type": {
               "type": "reference",
               "name": "Directive",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "Directive"
-              }
+              "package": "lit-html"
             }
           }
         ],
@@ -20677,17 +19264,16 @@
             }
           ],
           "name": "Parameters",
-          "qualifiedName": "Parameters",
           "package": "typescript"
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "custom-directives",
           "anchor": "DirectiveParameters"
@@ -20695,7 +19281,6 @@
       },
       {
         "name": "DirectiveResult",
-        "kindString": "Interface",
         "comment": {
           "shortText": "A generated directive function doesn't evaluate the directive, but just\nreturns a DirectiveResult object that captures the arguments."
         },
@@ -20709,33 +19294,26 @@
         "typeParameters": [
           {
             "name": "C",
-            "kindString": "Type parameter",
             "type": {
               "type": "reference",
               "name": "DirectiveClass",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveClass"
-              }
+              "package": "lit-html"
             },
             "default": {
               "type": "reference",
               "name": "DirectiveClass",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "DirectiveClass"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "DirectiveResult"
@@ -20743,11 +19321,9 @@
       },
       {
         "name": "ElementPartInfo",
-        "kindString": "Interface",
         "children": [
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -20765,11 +19341,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPartInfo.type"
@@ -20786,11 +19362,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "ElementPartInfo"
@@ -20798,7 +19374,6 @@
       },
       {
         "name": "Part",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
@@ -20812,61 +19387,43 @@
             {
               "type": "reference",
               "name": "ChildPart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "AttributePart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePart"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "PropertyPart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "PropertyPart"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "BooleanAttributePart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "BooleanAttributePart"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "ElementPart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ElementPart"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "EventPart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "EventPart"
-              }
+              "package": "lit-html"
             }
           ]
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "custom-directives",
           "anchor": "Part"
@@ -20874,7 +19431,6 @@
       },
       {
         "name": "PartInfo",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "Information about the part a directive is bound to.",
           "text": "This is useful for checking that a directive is attached to a valid part,\nsuch as with directive that can only be used on attribute bindings.\n"
@@ -20892,37 +19448,28 @@
             {
               "type": "reference",
               "name": "ChildPartInfo",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPartInfo"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "AttributePartInfo",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "AttributePartInfo"
-              }
+              "package": "lit-html"
             },
             {
               "type": "reference",
               "name": "ElementPartInfo",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ElementPartInfo"
-              }
+              "package": "lit-html"
             }
           ]
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/async-directive.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "custom-directives",
           "anchor": "PartInfo"
@@ -20930,7 +19477,6 @@
       },
       {
         "name": "clearPart",
-        "kindString": "Function",
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
@@ -20941,18 +19487,19 @@
         "signatures": [
           {
             "name": "clearPart",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 104
+              }
+            ],
             "parameters": [
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -20965,11 +19512,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "clearPart"
@@ -20977,7 +19524,6 @@
       },
       {
         "name": "getCommittedValue",
-        "kindString": "Function",
         "comment": {
           "shortText": "Returns the committed value of a ChildPart.",
           "text": "The committed value is used for change detection and efficient updates of\nthe part. It can differ from the value set by the template or directive in\ncases where the template value is transformed before being committed.\n- `TemplateResult`s are committed as a `TemplateInstance`\n- Iterables are committed as `Array<ChildPart>`\n- All other types are committed as the template value or value returned or\n  set by a directive.\n"
@@ -20992,18 +19538,19 @@
         "signatures": [
           {
             "name": "getCommittedValue",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 97
+              }
+            ],
             "parameters": [
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -21016,11 +19563,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "getCommittedValue"
@@ -21028,7 +19575,6 @@
       },
       {
         "name": "getDirectiveClass",
-        "kindString": "Function",
         "comment": {
           "shortText": "Retrieves the Directive class for a DirectiveResult"
         },
@@ -21042,11 +19588,15 @@
         "signatures": [
           {
             "name": "getDirectiveClass",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 31
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -21063,10 +19613,7 @@
                 {
                   "type": "reference",
                   "name": "DirectiveClass",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "DirectiveClass"
-                  }
+                  "package": "lit-html"
                 }
               ]
             }
@@ -21075,11 +19622,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "getDirectiveClass"
@@ -21087,7 +19634,6 @@
       },
       {
         "name": "insertPart",
-        "kindString": "Function",
         "comment": {
           "shortText": "Inserts a ChildPart into the given container ChildPart's DOM, either at the\nend of the container ChildPart, or before the optional `refPart`.",
           "text": "This does not add the part to the containerPart's committed value. That must\nbe done by callers.\n"
@@ -21102,26 +19648,26 @@
         "signatures": [
           {
             "name": "insertPart",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 53
+              }
+            ],
             "parameters": [
               {
                 "name": "containerPart",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "Part within which to add the new ChildPart"
                 },
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               },
               {
                 "name": "refPart",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -21131,15 +19677,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               },
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -21149,31 +19691,25 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "type": {
               "type": "reference",
               "name": "ChildPart",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "insertPart"
@@ -21181,7 +19717,6 @@
       },
       {
         "name": "isDirectiveResult",
-        "kindString": "Function",
         "comment": {
           "shortText": "Tests if a value is a DirectiveResult."
         },
@@ -21195,11 +19730,15 @@
         "signatures": [
           {
             "name": "isDirectiveResult",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 27
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -21216,17 +19755,11 @@
                   {
                     "type": "reference",
                     "name": "DirectiveClass",
-                    "location": {
-                      "page": "custom-directives",
-                      "anchor": "DirectiveClass"
-                    }
+                    "package": "lit-html"
                   }
                 ],
                 "name": "DirectiveResult",
-                "location": {
-                  "page": "custom-directives",
-                  "anchor": "DirectiveResult"
-                }
+                "package": "lit-html"
               }
             }
           }
@@ -21234,11 +19767,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isDirectiveResult"
@@ -21246,7 +19779,6 @@
       },
       {
         "name": "isPrimitive",
-        "kindString": "Function",
         "comment": {
           "shortText": "Tests if a value is a primitive value.",
           "text": "See https://tc39.github.io/ecma262/#sec-typeof-operator\n"
@@ -21261,11 +19793,15 @@
         "signatures": [
           {
             "name": "isPrimitive",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 14
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -21278,7 +19814,8 @@
               "asserts": false,
               "targetType": {
                 "type": "reference",
-                "name": "Primitive"
+                "name": "Primitive",
+                "package": "lit-html"
               }
             }
           }
@@ -21286,11 +19823,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isPrimitive"
@@ -21298,7 +19835,6 @@
       },
       {
         "name": "isSingleExpression",
-        "kindString": "Function",
         "comment": {
           "shortText": "Tests whether a part has only a single-expression with no strings to\ninterpolate between.",
           "text": "Only AttributePart and PropertyPart can have multiple expressions.\nMulti-expression parts have a `strings` property and single-expression\nparts do not.\n"
@@ -21313,18 +19849,19 @@
         "signatures": [
           {
             "name": "isSingleExpression",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 40
+              }
+            ],
             "parameters": [
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "PartInfo",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "PartInfo"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -21337,11 +19874,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isSingleExpression"
@@ -21349,7 +19886,6 @@
       },
       {
         "name": "isTemplateResult",
-        "kindString": "Function",
         "comment": {
           "shortText": "Tests if a value is a TemplateResult."
         },
@@ -21363,11 +19899,15 @@
         "signatures": [
           {
             "name": "isTemplateResult",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 23
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -21375,17 +19915,13 @@
               },
               {
                 "name": "type",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
                 "type": {
                   "type": "reference",
                   "name": "TemplateResultType",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "TemplateResultType"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -21411,10 +19947,7 @@
                   }
                 ],
                 "name": "TemplateResult",
-                "location": {
-                  "page": "templates",
-                  "anchor": "TemplateResult"
-                }
+                "package": "lit-html"
               }
             }
           }
@@ -21422,11 +19955,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isTemplateResult"
@@ -21434,7 +19967,6 @@
       },
       {
         "name": "removePart",
-        "kindString": "Function",
         "comment": {
           "shortText": "Removes a ChildPart from the DOM, including any of its content."
         },
@@ -21448,21 +19980,22 @@
         "signatures": [
           {
             "name": "removePart",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 103
+              }
+            ],
             "parameters": [
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "The Part to remove"
                 },
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -21475,11 +20008,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "removePart"
@@ -21487,7 +20020,6 @@
       },
       {
         "name": "setChildPartValue",
-        "kindString": "Function",
         "comment": {
           "shortText": "Sets the value of a Part.",
           "text": "Note that this should only be used to set/update the value of user-created\nparts (i.e. those created using `insertPart`); it should not be used\nby directives to set the value of the directive's container part. Directives\nshould return a value from `update`/`render` to update their part state.\nFor directives that require setting their part value asynchronously, they\nshould extend `AsyncDirective` and call `this.setValue()`.\n"
@@ -21502,11 +20034,15 @@
         "signatures": [
           {
             "name": "setChildPartValue",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 70
+              }
+            ],
             "typeParameter": [
               {
                 "name": "T",
-                "kindString": "Type parameter",
                 "type": {
                   "type": "reference",
                   "typeArguments": [
@@ -21516,17 +20052,13 @@
                     }
                   ],
                   "name": "ChildPart",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "ChildPart"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "parameters": [
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "Part to set"
                 },
@@ -21537,7 +20069,6 @@
               },
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "comment": {
                   "shortText": "Value to set"
                 },
@@ -21548,7 +20079,6 @@
               },
               {
                 "name": "directiveParent",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -21558,10 +20088,7 @@
                 "type": {
                   "type": "reference",
                   "name": "DirectiveParent",
-                  "location": {
-                    "page": "misc",
-                    "anchor": "DirectiveParent"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
@@ -21574,11 +20101,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "setChildPartValue"
@@ -21586,7 +20113,6 @@
       },
       {
         "name": "setCommittedValue",
-        "kindString": "Function",
         "comment": {
           "shortText": "Sets the committed value of a ChildPart directly without triggering the\ncommit stage of the part.",
           "text": "This is useful in cases where a directive needs to update the part such\nthat the next update detects a value change or not. When value is omitted,\nthe next update will be guaranteed to be detected as a change.\n"
@@ -21601,23 +20127,23 @@
         "signatures": [
           {
             "name": "setCommittedValue",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
+                "line": 82
+              }
+            ],
             "parameters": [
               {
                 "name": "part",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "Part",
-                  "location": {
-                    "page": "custom-directives",
-                    "anchor": "Part"
-                  }
+                  "package": "lit-html"
                 }
               },
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "flags": {
                   "isOptional": true
                 },
@@ -21636,11 +20162,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "setCommittedValue"
@@ -21648,7 +20174,6 @@
       },
       {
         "name": "TemplateResultType",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -21668,11 +20193,9 @@
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "children": [
               {
                 "name": "HTML",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -21689,7 +20212,6 @@
               },
               {
                 "name": "SVG",
-                "kindString": "Property",
                 "flags": {
                   "isReadonly": true
                 },
@@ -21716,11 +20238,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/directive-helpers.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "custom-directives",
           "anchor": "TemplateResultType"
@@ -21728,7 +20250,6 @@
       },
       {
         "name": "noChange",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -21749,11 +20270,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "custom-directives",
           "anchor": "noChange"
@@ -21772,7 +20293,6 @@
     "items": [
       {
         "name": "html",
-        "kindString": "Function",
         "comment": {
           "shortText": "Interprets a template literal as an HTML template that can efficiently\nrender to and update a container.",
           "text": "Includes static value support from `lit-html/static.js`.\n"
@@ -21787,21 +20307,23 @@
         "signatures": [
           {
             "name": "html",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
+                "line": 73
+              }
+            ],
             "parameters": [
               {
                 "name": "strings",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -21819,25 +20341,23 @@
               "typeArguments": [
                 {
                   "type": "reference",
-                  "name": "ResultType"
+                  "name": "ResultType",
+                  "package": "lit-html"
                 }
               ],
               "name": "TemplateResult",
-              "location": {
-                "page": "templates",
-                "anchor": "TemplateResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "html"
@@ -21845,7 +20365,6 @@
       },
       {
         "name": "literal",
-        "kindString": "Function",
         "comment": {
           "shortText": "Tags a string literal so that it behaves like part of the static template\nstrings instead of a dynamic value.",
           "text": "The only values that may be used in template expressions are other tagged\n`literal` results or `unsafeStatic` values (note that untrusted content\nshould never be passed to `unsafeStatic`).\nUsers must take care to ensure that adding the static string to the template\nresults in well-formed HTML, or else templates may break unexpectedly.\nStatic values can be changed, but they will cause a complete re-render since\nthey effectively create a new template.\n"
@@ -21860,21 +20379,23 @@
         "signatures": [
           {
             "name": "literal",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
+                "line": 62
+              }
+            ],
             "parameters": [
               {
                 "name": "strings",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -21890,21 +20411,18 @@
             "type": {
               "type": "reference",
               "name": "StaticValue",
-              "location": {
-                "page": "static-html",
-                "anchor": "StaticValue"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "literal"
@@ -21912,7 +20430,6 @@
       },
       {
         "name": "svg",
-        "kindString": "Function",
         "comment": {
           "shortText": "Interprets a template literal as an SVG template that can efficiently\nrender to and update a container.",
           "text": "Includes static value support from `lit-html/static.js`.\n"
@@ -21927,21 +20444,23 @@
         "signatures": [
           {
             "name": "svg",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
+                "line": 80
+              }
+            ],
             "parameters": [
               {
                 "name": "strings",
-                "kindString": "Parameter",
                 "type": {
                   "type": "reference",
                   "name": "TemplateStringsArray",
-                  "qualifiedName": "TemplateStringsArray",
                   "package": "typescript"
                 }
               },
               {
                 "name": "values",
-                "kindString": "Parameter",
                 "flags": {
                   "isRest": true
                 },
@@ -21959,25 +20478,23 @@
               "typeArguments": [
                 {
                   "type": "reference",
-                  "name": "ResultType"
+                  "name": "ResultType",
+                  "package": "lit-html"
                 }
               ],
               "name": "TemplateResult",
-              "location": {
-                "page": "templates",
-                "anchor": "TemplateResult"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "svg"
@@ -21985,7 +20502,6 @@
       },
       {
         "name": "unsafeStatic",
-        "kindString": "Function",
         "comment": {
           "shortText": "Wraps a string so that it behaves like part of the static template\nstrings instead of a dynamic value.",
           "text": "Users must take care to ensure that adding the static string to the template\nresults in well-formed HTML, or else templates may break unexpectedly.\nNote that this function is unsafe to use on untrusted content, as it will be\ndirectly parsed into HTML. Do not pass user input to this function\nwithout sanitizing it.\nStatic values can be changed, but they will cause a complete re-render\nsince they effectively create a new template.\n"
@@ -22000,11 +20516,15 @@
         "signatures": [
           {
             "name": "unsafeStatic",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
+                "line": 47
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
@@ -22014,21 +20534,18 @@
             "type": {
               "type": "reference",
               "name": "StaticValue",
-              "location": {
-                "page": "static-html",
-                "anchor": "StaticValue"
-              }
+              "package": "lit-html"
             }
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "unsafeStatic"
@@ -22036,7 +20553,6 @@
       },
       {
         "name": "withStatic",
-        "kindString": "Function",
         "comment": {
           "shortText": "Wraps a lit-html template tag (`html` or `svg`) to add static value support."
         },
@@ -22050,11 +20566,15 @@
         "signatures": [
           {
             "name": "withStatic",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
+                "line": 66
+              }
+            ],
             "parameters": [
               {
                 "name": "coreTag",
-                "kindString": "Parameter",
                 "type": {
                   "type": "union",
                   "types": [
@@ -22062,7 +20582,6 @@
                       "type": "reflection",
                       "declaration": {
                         "name": "__type",
-                        "kindString": "Type literal",
                         "sources": [
                           {
                             "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -22072,7 +20591,6 @@
                         "signatures": [
                           {
                             "name": "__type",
-                            "kindString": "Call signature",
                             "comment": {
                               "summary": [
                                 {
@@ -22092,20 +20610,23 @@
                                 }
                               ]
                             },
+                            "sources": [
+                              {
+                                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                                "line": 226
+                              }
+                            ],
                             "parameters": [
                               {
                                 "name": "strings",
-                                "kindString": "Parameter",
                                 "type": {
                                   "type": "reference",
                                   "name": "TemplateStringsArray",
-                                  "qualifiedName": "TemplateStringsArray",
                                   "package": "typescript"
                                 }
                               },
                               {
                                 "name": "values",
-                                "kindString": "Parameter",
                                 "flags": {
                                   "isRest": true
                                 },
@@ -22127,10 +20648,7 @@
                                 }
                               ],
                               "name": "TemplateResult",
-                              "location": {
-                                "page": "templates",
-                                "anchor": "TemplateResult"
-                              }
+                              "package": "lit-html"
                             }
                           }
                         ]
@@ -22140,7 +20658,6 @@
                       "type": "reflection",
                       "declaration": {
                         "name": "__type",
-                        "kindString": "Type literal",
                         "sources": [
                           {
                             "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -22150,7 +20667,6 @@
                         "signatures": [
                           {
                             "name": "__type",
-                            "kindString": "Call signature",
                             "comment": {
                               "summary": [
                                 {
@@ -22194,7 +20710,8 @@
                                 },
                                 {
                                   "tag": "@linkcode",
-                                  "text": "html"
+                                  "text": "html",
+                                  "tsLinkText": ""
                                 },
                                 {
                                   "text": " tag function.\n\nIn LitElement usage, it's invalid to return an SVG fragment from the\n"
@@ -22213,20 +20730,23 @@
                                 }
                               ]
                             },
+                            "sources": [
+                              {
+                                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                                "line": 250
+                              }
+                            ],
                             "parameters": [
                               {
                                 "name": "strings",
-                                "kindString": "Parameter",
                                 "type": {
                                   "type": "reference",
                                   "name": "TemplateStringsArray",
-                                  "qualifiedName": "TemplateStringsArray",
                                   "package": "typescript"
                                 }
                               },
                               {
                                 "name": "values",
-                                "kindString": "Parameter",
                                 "flags": {
                                   "isRest": true
                                 },
@@ -22248,10 +20768,7 @@
                                 }
                               ],
                               "name": "TemplateResult",
-                              "location": {
-                                "page": "templates",
-                                "anchor": "TemplateResult"
-                              }
+                              "package": "lit-html"
                             }
                           }
                         ]
@@ -22265,7 +20782,6 @@
               "type": "reflection",
               "declaration": {
                 "name": "__type",
-                "kindString": "Type literal",
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
@@ -22275,21 +20791,23 @@
                 "signatures": [
                   {
                     "name": "__type",
-                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/static.d.ts",
+                        "line": 66
+                      }
+                    ],
                     "parameters": [
                       {
                         "name": "strings",
-                        "kindString": "Parameter",
                         "type": {
                           "type": "reference",
                           "name": "TemplateStringsArray",
-                          "qualifiedName": "TemplateStringsArray",
                           "package": "typescript"
                         }
                       },
                       {
                         "name": "values",
-                        "kindString": "Parameter",
                         "flags": {
                           "isRest": true
                         },
@@ -22307,14 +20825,12 @@
                       "typeArguments": [
                         {
                           "type": "reference",
-                          "name": "ResultType"
+                          "name": "ResultType",
+                          "package": "lit-html"
                         }
                       ],
                       "name": "TemplateResult",
-                      "location": {
-                        "page": "templates",
-                        "anchor": "TemplateResult"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ]
@@ -22325,11 +20841,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "withStatic"
@@ -22337,11 +20853,9 @@
       },
       {
         "name": "StaticValue",
-        "kindString": "Interface",
         "children": [
           {
             "name": "r",
-            "kindString": "Property",
             "comment": {
               "shortText": "A value that can't be decoded from ordinary JSON, make it harder for\na attacker-controlled data that goes through JSON.parse to produce a valid\nStaticValue."
             },
@@ -22356,17 +20870,18 @@
               "type": "query",
               "queryType": {
                 "type": "reference",
-                "name": "brand"
+                "name": "brand",
+                "package": "lit-html"
               }
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/static-html.ts",
-                "line": 7,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+                "line": 1,
                 "moduleSpecifier": "lit/static-html.js"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "static-html",
               "anchor": "StaticValue.r"
@@ -22383,11 +20898,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
-            "line": 7,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/static-html.ts#L7",
+            "line": 1,
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "static-html",
           "anchor": "StaticValue"
@@ -22406,7 +20921,6 @@
     "items": [
       {
         "name": "ReactiveController",
-        "kindString": "Interface",
         "comment": {
           "shortText": "A Reactive Controller is an object that enables sub-component code\norganization and reuse by aggregating the state, behavior, and lifecycle\nhooks related to a single feature.",
           "text": "Controllers are added to a host component, or other object that implements\nthe `ReactiveControllerHost` interface, via the `addController()` method.\nThey can hook their host components's lifecycle by implementing one or more\nof the lifecycle callbacks, or initiate an update of the host component by\ncalling `requestUpdate()` on the host.\n"
@@ -22414,7 +20928,6 @@
         "children": [
           {
             "name": "hostConnected",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -22431,7 +20944,12 @@
             "signatures": [
               {
                 "name": "hostConnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 54
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -22441,11 +20959,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostConnected"
@@ -22453,7 +20971,6 @@
           },
           {
             "name": "hostDisconnected",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -22470,7 +20987,12 @@
             "signatures": [
               {
                 "name": "hostDisconnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 61
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -22480,11 +21002,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostDisconnected"
@@ -22492,7 +21014,6 @@
           },
           {
             "name": "hostUpdate",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -22510,7 +21031,12 @@
             "signatures": [
               {
                 "name": "hostUpdate",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 69
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -22520,11 +21046,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostUpdate"
@@ -22532,7 +21058,6 @@
           },
           {
             "name": "hostUpdated",
-            "kindString": "Method",
             "flags": {
               "isOptional": true
             },
@@ -22549,7 +21074,12 @@
             "signatures": [
               {
                 "name": "hostUpdated",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 75
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -22559,11 +21089,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostUpdated"
@@ -22580,11 +21110,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "controllers",
           "anchor": "ReactiveController"
@@ -22592,14 +21122,12 @@
       },
       {
         "name": "ReactiveControllerHost",
-        "kindString": "Interface",
         "comment": {
           "shortText": "An object that can host Reactive Controllers and call their lifecycle\ncallbacks."
         },
         "children": [
           {
             "name": "updateComplete",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -22632,17 +21160,16 @@
                 }
               ],
               "name": "Promise",
-              "qualifiedName": "Promise",
               "package": "typescript"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.updateComplete"
@@ -22650,7 +21177,6 @@
           },
           {
             "name": "addController",
-            "kindString": "Method",
             "comment": {
               "shortText": "Adds a controller to the host, which sets up the controller's lifecycle\nmethods to be called with the host's lifecycle."
             },
@@ -22664,18 +21190,19 @@
             "signatures": [
               {
                 "name": "addController",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 15
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "controller",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ReactiveController",
-                      "location": {
-                        "page": "controllers",
-                        "anchor": "ReactiveController"
-                      }
+                      "package": "@lit/reactive-element"
                     }
                   }
                 ],
@@ -22688,11 +21215,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.addController"
@@ -22700,7 +21227,6 @@
           },
           {
             "name": "removeController",
-            "kindString": "Method",
             "comment": {
               "shortText": "Removes a controller from the host."
             },
@@ -22714,18 +21240,19 @@
             "signatures": [
               {
                 "name": "removeController",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 19
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "controller",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ReactiveController",
-                      "location": {
-                        "page": "controllers",
-                        "anchor": "ReactiveController"
-                      }
+                      "package": "@lit/reactive-element"
                     }
                   }
                 ],
@@ -22738,11 +21265,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.removeController"
@@ -22750,7 +21277,6 @@
           },
           {
             "name": "requestUpdate",
-            "kindString": "Method",
             "comment": {
               "shortText": "Requests a host update which is processed asynchronously. The update can\nbe waited on via the `updateComplete` property."
             },
@@ -22764,7 +21290,12 @@
             "signatures": [
               {
                 "name": "requestUpdate",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-controller.d.ts",
+                    "line": 24
+                  }
+                ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
@@ -22774,11 +21305,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.requestUpdate"
@@ -22795,21 +21326,17 @@
         "implementedBy": [
           {
             "type": "reference",
-            "name": "ReactiveElement",
-            "location": {
-              "page": "ReactiveElement",
-              "anchor": "ReactiveElement"
-            }
+            "name": "ReactiveElement"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "controllers",
           "anchor": "ReactiveControllerHost"
@@ -22828,7 +21355,6 @@
     "items": [
       {
         "name": "defaultConverter",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -22842,19 +21368,16 @@
         "type": {
           "type": "reference",
           "name": "ComplexAttributeConverter",
-          "location": {
-            "page": "ReactiveElement",
-            "anchor": "ComplexAttributeConverter"
-          }
+          "package": "@lit/reactive-element"
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "misc",
           "anchor": "defaultConverter"
@@ -22862,7 +21385,6 @@
       },
       {
         "name": "isServer",
-        "kindString": "Variable",
         "flags": {
           "isConst": true
         },
@@ -22885,11 +21407,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Variable",
         "location": {
           "page": "misc",
           "anchor": "isServer"
@@ -22897,7 +21419,6 @@
       },
       {
         "name": "LitUnstable",
-        "kindString": "Namespace",
         "comment": {
           "shortText": "Contains types that are part of the unstable debug API.",
           "text": "Everything in this API is not stable and may change or be removed in the future,\neven on patch releases.\n"
@@ -22905,7 +21426,6 @@
         "children": [
           {
             "name": "DebugLog",
-            "kindString": "Namespace",
             "comment": {
               "shortText": "When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,\nwe will emit 'lit-debug' events to window, with live details about the update and render\nlifecycle. These can be useful for writing debug tooling and visualizations.",
               "text": "Please be aware that running with window.emitLitDebugLogEvents has performance overhead,\nmaking certain operations that are normally very cheap (like a no-op render) much slower,\nbecause we must copy data and dispatch events.\n"
@@ -22913,11 +21433,9 @@
             "children": [
               {
                 "name": "BeginRender",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "container",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -22931,31 +21449,23 @@
                         {
                           "type": "reference",
                           "name": "HTMLElement",
-                          "qualifiedName": "HTMLElement",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                          }
+                          "package": "typescript"
                         },
                         {
                           "type": "reference",
                           "name": "DocumentFragment",
-                          "qualifiedName": "DocumentFragment",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
-                          }
+                          "package": "typescript"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.container"
@@ -22963,7 +21473,6 @@
                   },
                   {
                     "name": "id",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -22978,11 +21487,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.id"
@@ -22990,7 +21499,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23005,11 +21513,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.kind"
@@ -23017,7 +21525,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23035,21 +21542,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.options"
@@ -23057,7 +21561,6 @@
                   },
                   {
                     "name": "part",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23075,21 +21578,18 @@
                         {
                           "type": "reference",
                           "name": "ChildPart",
-                          "location": {
-                            "page": "custom-directives",
-                            "anchor": "ChildPart"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.part"
@@ -23097,7 +21597,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23112,11 +21611,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.value"
@@ -23133,11 +21632,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.BeginRender"
@@ -23145,11 +21644,9 @@
               },
               {
                 "name": "CommitAttribute",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "element",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23160,20 +21657,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.element"
@@ -23181,7 +21674,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23196,11 +21688,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.kind"
@@ -23208,7 +21700,6 @@
                   },
                   {
                     "name": "name",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23223,11 +21714,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.name"
@@ -23235,7 +21726,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23253,21 +21743,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.options"
@@ -23275,7 +21762,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23290,11 +21776,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.value"
@@ -23311,11 +21797,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitAttribute"
@@ -23323,11 +21809,9 @@
               },
               {
                 "name": "CommitBooleanAttribute",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "element",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23338,20 +21822,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.element"
@@ -23359,7 +21839,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23374,11 +21853,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.kind"
@@ -23386,7 +21865,6 @@
                   },
                   {
                     "name": "name",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23401,11 +21879,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.name"
@@ -23413,7 +21891,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23431,21 +21908,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.options"
@@ -23453,7 +21927,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23468,11 +21941,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.value"
@@ -23489,11 +21962,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
@@ -23501,11 +21974,9 @@
               },
               {
                 "name": "CommitEventListener",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "addListener",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23520,11 +21991,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.addListener"
@@ -23532,7 +22003,6 @@
                   },
                   {
                     "name": "element",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23543,20 +22013,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.element"
@@ -23564,7 +22030,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23579,11 +22044,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.kind"
@@ -23591,7 +22056,6 @@
                   },
                   {
                     "name": "name",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23606,11 +22070,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.name"
@@ -23618,7 +22082,6 @@
                   },
                   {
                     "name": "oldListener",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23633,11 +22096,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.oldListener"
@@ -23645,7 +22108,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23663,21 +22125,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.options"
@@ -23685,7 +22144,6 @@
                   },
                   {
                     "name": "removeListener",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23700,11 +22158,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.removeListener"
@@ -23712,7 +22170,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23727,11 +22184,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.value"
@@ -23748,11 +22205,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitEventListener"
@@ -23760,11 +22217,9 @@
               },
               {
                 "name": "CommitNode",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23779,11 +22234,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.kind"
@@ -23791,7 +22246,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23809,21 +22263,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.options"
@@ -23831,7 +22282,6 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23849,21 +22299,18 @@
                         {
                           "type": "reference",
                           "name": "Disconnectable",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "Disconnectable"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.parent"
@@ -23871,7 +22318,6 @@
                   },
                   {
                     "name": "start",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23882,17 +22328,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Node",
-                      "qualifiedName": "Node",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.start"
@@ -23900,7 +22345,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23911,17 +22355,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Node",
-                      "qualifiedName": "Node",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.value"
@@ -23938,11 +22381,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitNode"
@@ -23950,11 +22393,9 @@
               },
               {
                 "name": "CommitNothingToChildEntry",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "end",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -23972,7 +22413,6 @@
                         {
                           "type": "reference",
                           "name": "ChildNode",
-                          "qualifiedName": "ChildNode",
                           "package": "typescript"
                         }
                       ]
@@ -23980,11 +22420,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.end"
@@ -23992,7 +22432,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24007,11 +22446,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.kind"
@@ -24019,7 +22458,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24037,21 +22475,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.options"
@@ -24059,7 +22494,6 @@
                   },
                   {
                     "name": "parent",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24077,21 +22511,18 @@
                         {
                           "type": "reference",
                           "name": "Disconnectable",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "Disconnectable"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.parent"
@@ -24099,7 +22530,6 @@
                   },
                   {
                     "name": "start",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24110,17 +22540,16 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildNode",
-                      "qualifiedName": "ChildNode",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.start"
@@ -24137,11 +22566,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
@@ -24149,11 +22578,9 @@
               },
               {
                 "name": "CommitProperty",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "element",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24164,20 +22591,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.element"
@@ -24185,7 +22608,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24200,11 +22622,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.kind"
@@ -24212,7 +22634,6 @@
                   },
                   {
                     "name": "name",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24227,11 +22648,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.name"
@@ -24239,7 +22660,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24257,21 +22677,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.options"
@@ -24279,7 +22696,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24294,11 +22710,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.value"
@@ -24315,11 +22731,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitProperty"
@@ -24327,11 +22743,9 @@
               },
               {
                 "name": "CommitText",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24346,11 +22760,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.kind"
@@ -24358,7 +22772,6 @@
                   },
                   {
                     "name": "node",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24369,17 +22782,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Text",
-                      "qualifiedName": "Text",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.node"
@@ -24387,7 +22799,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24405,21 +22816,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.options"
@@ -24427,7 +22835,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24442,11 +22849,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.value"
@@ -24463,11 +22870,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitText"
@@ -24475,11 +22882,9 @@
               },
               {
                 "name": "CommitToElementBinding",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "element",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24490,20 +22895,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "qualifiedName": "Element",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
-                      }
+                      "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.element"
@@ -24511,7 +22912,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24526,11 +22926,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.kind"
@@ -24538,7 +22938,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24556,21 +22955,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.options"
@@ -24578,7 +22974,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24593,11 +22988,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.value"
@@ -24614,11 +23009,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
@@ -24626,11 +23021,9 @@
               },
               {
                 "name": "EndRender",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "container",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24644,31 +23037,23 @@
                         {
                           "type": "reference",
                           "name": "HTMLElement",
-                          "qualifiedName": "HTMLElement",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
-                          }
+                          "package": "typescript"
                         },
                         {
                           "type": "reference",
                           "name": "DocumentFragment",
-                          "qualifiedName": "DocumentFragment",
-                          "package": "typescript",
-                          "externalLocation": {
-                            "url": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
-                          }
+                          "package": "typescript"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.container"
@@ -24676,7 +23061,6 @@
                   },
                   {
                     "name": "id",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24691,11 +23075,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.id"
@@ -24703,7 +23087,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24718,11 +23101,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.kind"
@@ -24730,7 +23113,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24748,21 +23130,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.options"
@@ -24770,7 +23149,6 @@
                   },
                   {
                     "name": "part",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24781,19 +23159,16 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.part"
@@ -24801,7 +23176,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24816,11 +23190,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.value"
@@ -24837,11 +23211,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.EndRender"
@@ -24849,11 +23223,9 @@
               },
               {
                 "name": "SetPartValue",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24868,11 +23240,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.kind"
@@ -24880,7 +23252,6 @@
                   },
                   {
                     "name": "part",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24891,19 +23262,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "Part"
-                      }
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.part"
@@ -24911,7 +23279,6 @@
                   },
                   {
                     "name": "templateInstance",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24922,19 +23289,16 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "TemplateInstance"
-                      }
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.templateInstance"
@@ -24942,7 +23306,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24957,11 +23320,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.value"
@@ -24969,7 +23332,6 @@
                   },
                   {
                     "name": "valueIndex",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -24984,11 +23346,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.valueIndex"
@@ -24996,7 +23358,6 @@
                   },
                   {
                     "name": "values",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25014,11 +23375,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.values"
@@ -25035,11 +23396,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.SetPartValue"
@@ -25047,11 +23408,9 @@
               },
               {
                 "name": "TemplateInstantiated",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "fragment",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25062,17 +23421,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Node",
-                      "qualifiedName": "Node",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.fragment"
@@ -25080,7 +23438,6 @@
                   },
                   {
                     "name": "instance",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25091,19 +23448,16 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "TemplateInstance"
-                      }
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.instance"
@@ -25111,7 +23465,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25126,11 +23479,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.kind"
@@ -25138,7 +23491,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25156,21 +23508,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.options"
@@ -25178,7 +23527,6 @@
                   },
                   {
                     "name": "parts",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25198,10 +23546,7 @@
                           {
                             "type": "reference",
                             "name": "Part",
-                            "location": {
-                              "page": "custom-directives",
-                              "anchor": "Part"
-                            }
+                            "package": "lit-html"
                           }
                         ]
                       }
@@ -25209,11 +23554,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.parts"
@@ -25221,7 +23566,6 @@
                   },
                   {
                     "name": "template",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25234,26 +23578,24 @@
                       "types": [
                         {
                           "type": "reference",
-                          "name": "Template"
+                          "name": "Template",
+                          "package": "lit-html"
                         },
                         {
                           "type": "reference",
                           "name": "CompiledTemplate",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "CompiledTemplate"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.template"
@@ -25261,7 +23603,6 @@
                   },
                   {
                     "name": "values",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25279,11 +23620,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.values"
@@ -25300,11 +23641,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
@@ -25312,11 +23653,9 @@
               },
               {
                 "name": "TemplateInstantiatedAndUpdated",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "fragment",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25327,17 +23666,16 @@
                     "type": {
                       "type": "reference",
                       "name": "Node",
-                      "qualifiedName": "Node",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.fragment"
@@ -25345,7 +23683,6 @@
                   },
                   {
                     "name": "instance",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25356,19 +23693,16 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "TemplateInstance"
-                      }
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.instance"
@@ -25376,7 +23710,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25391,11 +23724,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.kind"
@@ -25403,7 +23736,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25421,21 +23753,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.options"
@@ -25443,7 +23772,6 @@
                   },
                   {
                     "name": "parts",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25463,10 +23791,7 @@
                           {
                             "type": "reference",
                             "name": "Part",
-                            "location": {
-                              "page": "custom-directives",
-                              "anchor": "Part"
-                            }
+                            "package": "lit-html"
                           }
                         ]
                       }
@@ -25474,11 +23799,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.parts"
@@ -25486,7 +23811,6 @@
                   },
                   {
                     "name": "template",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25499,26 +23823,24 @@
                       "types": [
                         {
                           "type": "reference",
-                          "name": "Template"
+                          "name": "Template",
+                          "package": "lit-html"
                         },
                         {
                           "type": "reference",
                           "name": "CompiledTemplate",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "CompiledTemplate"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.template"
@@ -25526,7 +23848,6 @@
                   },
                   {
                     "name": "values",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25544,11 +23865,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.values"
@@ -25565,11 +23886,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
@@ -25577,11 +23898,9 @@
               },
               {
                 "name": "TemplatePrep",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "clonableTemplate",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25592,20 +23911,16 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLTemplateElement",
-                      "qualifiedName": "HTMLTemplateElement",
-                      "package": "typescript",
-                      "externalLocation": {
-                        "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
-                      }
+                      "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.clonableTemplate"
@@ -25613,7 +23928,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25628,11 +23942,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.kind"
@@ -25640,7 +23954,6 @@
                   },
                   {
                     "name": "parts",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25652,17 +23965,18 @@
                       "type": "array",
                       "elementType": {
                         "type": "reference",
-                        "name": "TemplatePart"
+                        "name": "TemplatePart",
+                        "package": "lit-html"
                       }
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.parts"
@@ -25670,7 +23984,6 @@
                   },
                   {
                     "name": "strings",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25681,17 +23994,16 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateStringsArray",
-                      "qualifiedName": "TemplateStringsArray",
                       "package": "typescript"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.strings"
@@ -25699,7 +24011,6 @@
                   },
                   {
                     "name": "template",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25709,16 +24020,17 @@
                     ],
                     "type": {
                       "type": "reference",
-                      "name": "Template"
+                      "name": "Template",
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.template"
@@ -25735,11 +24047,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplatePrep"
@@ -25747,11 +24059,9 @@
               },
               {
                 "name": "TemplateUpdating",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "instance",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25762,19 +24072,16 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "TemplateInstance"
-                      }
+                      "package": "lit-html"
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.instance"
@@ -25782,7 +24089,6 @@
                   },
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25797,11 +24103,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.kind"
@@ -25809,7 +24115,6 @@
                   },
                   {
                     "name": "options",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25827,21 +24132,18 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "location": {
-                            "page": "LitElement",
-                            "anchor": "RenderOptions"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.options"
@@ -25849,7 +24151,6 @@
                   },
                   {
                     "name": "parts",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25869,10 +24170,7 @@
                           {
                             "type": "reference",
                             "name": "Part",
-                            "location": {
-                              "page": "custom-directives",
-                              "anchor": "Part"
-                            }
+                            "package": "lit-html"
                           }
                         ]
                       }
@@ -25880,11 +24178,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.parts"
@@ -25892,7 +24190,6 @@
                   },
                   {
                     "name": "template",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25905,26 +24202,24 @@
                       "types": [
                         {
                           "type": "reference",
-                          "name": "Template"
+                          "name": "Template",
+                          "package": "lit-html"
                         },
                         {
                           "type": "reference",
                           "name": "CompiledTemplate",
-                          "location": {
-                            "page": "misc",
-                            "anchor": "CompiledTemplate"
-                          }
+                          "package": "lit-html"
                         }
                       ]
                     },
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.template"
@@ -25932,7 +24227,6 @@
                   },
                   {
                     "name": "values",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25950,11 +24244,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.values"
@@ -25971,11 +24265,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplateUpdating"
@@ -25983,7 +24277,6 @@
               },
               {
                 "name": "CommitPartEntry",
-                "kindString": "Type alias",
                 "sources": [
                   {
                     "fileName": "packages/lit-html/src/lit-html.ts",
@@ -25997,77 +24290,61 @@
                     {
                       "type": "reference",
                       "name": "CommitNothingToChildEntry",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitNothingToChildEntry"
                     },
                     {
                       "type": "reference",
                       "name": "CommitText",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitText"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitText"
                     },
                     {
                       "type": "reference",
                       "name": "CommitNode",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitNode"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitNode"
                     },
                     {
                       "type": "reference",
                       "name": "CommitAttribute",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitAttribute"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitAttribute"
                     },
                     {
                       "type": "reference",
                       "name": "CommitProperty",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitProperty"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitProperty"
                     },
                     {
                       "type": "reference",
                       "name": "CommitBooleanAttribute",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitBooleanAttribute"
                     },
                     {
                       "type": "reference",
                       "name": "CommitEventListener",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitEventListener"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitEventListener"
                     },
                     {
                       "type": "reference",
                       "name": "CommitToElementBinding",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitToElementBinding"
                     }
                   ]
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitPartEntry"
@@ -26075,7 +24352,6 @@
               },
               {
                 "name": "Entry",
-                "kindString": "Type alias",
                 "sources": [
                   {
                     "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26089,77 +24365,61 @@
                     {
                       "type": "reference",
                       "name": "TemplatePrep",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.TemplatePrep"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.TemplatePrep"
                     },
                     {
                       "type": "reference",
                       "name": "TemplateInstantiated",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.TemplateInstantiated"
                     },
                     {
                       "type": "reference",
                       "name": "TemplateInstantiatedAndUpdated",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
                     },
                     {
                       "type": "reference",
                       "name": "TemplateUpdating",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.TemplateUpdating"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.TemplateUpdating"
                     },
                     {
                       "type": "reference",
                       "name": "BeginRender",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.BeginRender"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.BeginRender"
                     },
                     {
                       "type": "reference",
                       "name": "EndRender",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.EndRender"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.EndRender"
                     },
                     {
                       "type": "reference",
                       "name": "CommitPartEntry",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.CommitPartEntry"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.CommitPartEntry"
                     },
                     {
                       "type": "reference",
                       "name": "SetPartValue",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.SetPartValue"
-                      }
+                      "package": "lit-html",
+                      "qualifiedName": "LitUnstable.DebugLog.SetPartValue"
                     }
                   ]
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.Entry"
@@ -26176,11 +24436,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Namespace",
             "location": {
               "page": "misc",
               "anchor": "LitUnstable.DebugLog"
@@ -26197,11 +24457,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Namespace",
         "location": {
           "page": "misc",
           "anchor": "LitUnstable"
@@ -26209,7 +24469,6 @@
       },
       {
         "name": "notEqual",
-        "kindString": "Function",
         "comment": {
           "shortText": "Change function that returns true if `value` is different from `oldValue`.\nThis method is used as the default for a property's `hasChanged` function."
         },
@@ -26223,11 +24482,15 @@
         "signatures": [
           {
             "name": "notEqual",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                "line": 152
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -26235,7 +24498,6 @@
               },
               {
                 "name": "old",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -26251,11 +24513,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Function",
         "location": {
           "page": "misc",
           "anchor": "notEqual"
@@ -26263,7 +24525,6 @@
       },
       {
         "name": "ReactiveUnstable",
-        "kindString": "Namespace",
         "comment": {
           "shortText": "Contains types that are part of the unstable debug API.",
           "text": "Everything in this API is not stable and may change or be removed in the future,\neven on patch releases.\n"
@@ -26271,7 +24532,6 @@
         "children": [
           {
             "name": "DebugLog",
-            "kindString": "Namespace",
             "comment": {
               "shortText": "When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,\nwe will emit 'lit-debug' events to window, with live details about the update and render\nlifecycle. These can be useful for writing debug tooling and visualizations.",
               "text": "Please be aware that running with window.emitLitDebugLogEvents has performance overhead,\nmaking certain operations that are normally very cheap (like a no-op render) much slower,\nbecause we must copy data and dispatch events.\n"
@@ -26279,11 +24539,9 @@
             "children": [
               {
                 "name": "Update",
-                "kindString": "Interface",
                 "children": [
                   {
                     "name": "kind",
-                    "kindString": "Property",
                     "sources": [
                       {
                         "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -26298,11 +24556,11 @@
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
-                        "line": 10,
-                        "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                        "line": 1,
                         "moduleSpecifier": "lit"
                       }
                     ],
+                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "ReactiveUnstable.DebugLog.Update.kind"
@@ -26319,11 +24577,11 @@
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "ReactiveUnstable.DebugLog.Update"
@@ -26331,7 +24589,6 @@
               },
               {
                 "name": "Entry",
-                "kindString": "Type alias",
                 "sources": [
                   {
                     "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -26342,19 +24599,17 @@
                 "type": {
                   "type": "reference",
                   "name": "Update",
-                  "location": {
-                    "page": "misc",
-                    "anchor": "ReactiveUnstable.DebugLog.Update"
-                  }
+                  "package": "@lit/reactive-element",
+                  "qualifiedName": "ReactiveUnstable.DebugLog.Update"
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "ReactiveUnstable.DebugLog.Entry"
@@ -26371,11 +24626,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Namespace",
             "location": {
               "page": "misc",
               "anchor": "ReactiveUnstable.DebugLog"
@@ -26392,11 +24647,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Namespace",
         "location": {
           "page": "misc",
           "anchor": "ReactiveUnstable"
@@ -26404,14 +24659,12 @@
       },
       {
         "name": "TemplateInstance",
-        "kindString": "Class",
         "comment": {
           "shortText": "An updateable instance of a Template. Holds references to the Parts used to\nupdate the template instance."
         },
         "children": [
           {
             "name": "constructor",
-            "kindString": "Constructor",
             "sources": [
               {
                 "fileName": "packages/lit-html/development/lit-html.d.ts",
@@ -26421,47 +24674,45 @@
             "signatures": [
               {
                 "name": "new TemplateInstance",
-                "kindString": "Constructor signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 338
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "template",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
-                      "name": "Template"
+                      "name": "Template",
+                      "package": "lit-html"
                     }
                   },
                   {
                     "name": "parent",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "location": {
-                        "page": "custom-directives",
-                        "anchor": "ChildPart"
-                      }
+                      "package": "lit-html"
                     }
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "TemplateInstance",
-                  "location": {
-                    "page": "misc",
-                    "anchor": "TemplateInstance"
-                  }
+                  "package": "lit-html"
                 }
               }
             ],
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Constructor",
             "location": {
               "page": "misc",
               "anchor": "TemplateInstance.constructor"
@@ -26469,7 +24720,6 @@
           },
           {
             "name": "parentNode",
-            "kindString": "Accessor",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26480,27 +24730,30 @@
             "type": {
               "type": "reference",
               "name": "Node",
-              "qualifiedName": "Node",
               "package": "typescript"
             },
             "getSignature": {
               "name": "parentNode",
-              "kindString": "Get signature",
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 339
+                }
+              ],
               "type": {
                 "type": "reference",
                 "name": "Node",
-                "qualifiedName": "Node",
                 "package": "typescript"
               }
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "TemplateInstance.parentNode"
@@ -26518,20 +24771,17 @@
           {
             "type": "reference",
             "name": "Disconnectable",
-            "location": {
-              "page": "misc",
-              "anchor": "Disconnectable"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Class",
         "location": {
           "page": "misc",
           "anchor": "TemplateInstance"
@@ -26539,7 +24789,6 @@
       },
       {
         "name": "Unstable",
-        "kindString": "Namespace",
         "comment": {
           "shortText": "Contains types that are part of the unstable debug API.",
           "text": "Everything in this API is not stable and may change or be removed in the future,\neven on patch releases.\n"
@@ -26547,7 +24796,6 @@
         "children": [
           {
             "name": "DebugLog",
-            "kindString": "Namespace",
             "comment": {
               "shortText": "When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,\nwe will emit 'lit-debug' events to window, with live details about the update and render\nlifecycle. These can be useful for writing debug tooling and visualizations.",
               "text": "Please be aware that running with window.emitLitDebugLogEvents has performance overhead,\nmaking certain operations that are normally very cheap (like a no-op render) much slower,\nbecause we must copy data and dispatch events.\n"
@@ -26555,7 +24803,6 @@
             "children": [
               {
                 "name": "Entry",
-                "kindString": "Type alias",
                 "sources": [
                   {
                     "fileName": "packages/lit-element/src/lit-element.ts",
@@ -26569,29 +24816,23 @@
                     {
                       "type": "reference",
                       "name": "LitUnstable.DebugLog.Entry",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "LitUnstable.DebugLog.Entry"
-                      }
+                      "package": "lit-html"
                     },
                     {
                       "type": "reference",
                       "name": "ReactiveUnstable.DebugLog.Entry",
-                      "location": {
-                        "page": "misc",
-                        "anchor": "ReactiveUnstable.DebugLog.Entry"
-                      }
+                      "package": "@lit/reactive-element"
                     }
                   ]
                 },
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
-                    "line": 10,
-                    "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                    "line": 1,
                     "moduleSpecifier": "lit"
                   }
                 ],
+                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "Unstable.DebugLog.Entry"
@@ -26608,11 +24849,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Namespace",
             "location": {
               "page": "misc",
               "anchor": "Unstable.DebugLog"
@@ -26629,11 +24870,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Namespace",
         "location": {
           "page": "misc",
           "anchor": "Unstable"
@@ -26641,11 +24882,9 @@
       },
       {
         "name": "CompiledTemplate",
-        "kindString": "Interface",
         "children": [
           {
             "name": "el",
-            "kindString": "Property",
             "flags": {
               "isOptional": true
             },
@@ -26659,20 +24898,16 @@
             "type": {
               "type": "reference",
               "name": "HTMLTemplateElement",
-              "qualifiedName": "HTMLTemplateElement",
-              "package": "typescript",
-              "externalLocation": {
-                "url": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
-              }
+              "package": "typescript"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplate.el"
@@ -26680,7 +24915,6 @@
           },
           {
             "name": "h",
-            "kindString": "Property",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26691,17 +24925,16 @@
             "type": {
               "type": "reference",
               "name": "TrustedHTML",
-              "qualifiedName": "TrustedHTML",
               "package": "@types/trusted-types"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplate.h"
@@ -26709,7 +24942,6 @@
           },
           {
             "name": "parts",
-            "kindString": "Property",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26721,7 +24953,8 @@
               "type": "array",
               "elementType": {
                 "type": "reference",
-                "name": "TemplatePart"
+                "name": "TemplatePart",
+                "package": "lit-html"
               }
             },
             "inheritedFrom": {
@@ -26731,11 +24964,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplate.parts"
@@ -26755,7 +24988,8 @@
             "typeArguments": [
               {
                 "type": "reference",
-                "name": "Template"
+                "name": "Template",
+                "package": "lit-html"
               },
               {
                 "type": "literal",
@@ -26763,18 +24997,17 @@
               }
             ],
             "name": "Omit",
-            "qualifiedName": "Omit",
             "package": "typescript"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "CompiledTemplate"
@@ -26785,7 +25018,8 @@
             "typeArguments": [
               {
                 "type": "reference",
-                "name": "Template"
+                "name": "Template",
+                "package": "lit-html"
               },
               {
                 "type": "literal",
@@ -26793,18 +25027,15 @@
               }
             ],
             "name": "Omit",
-            "qualifiedName": "Omit",
             "package": "typescript"
           }
         ]
       },
       {
         "name": "CompiledTemplateResult",
-        "kindString": "Interface",
         "children": [
           {
             "name": "values",
-            "kindString": "Property",
             "sources": [
               {
                 "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26822,11 +25053,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplateResult.values"
@@ -26843,11 +25074,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "CompiledTemplateResult"
@@ -26855,7 +25086,6 @@
       },
       {
         "name": "DirectiveParent",
-        "kindString": "Interface",
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26866,11 +25096,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "DirectiveParent"
@@ -26878,7 +25108,6 @@
       },
       {
         "name": "Disconnectable",
-        "kindString": "Interface",
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
@@ -26889,53 +25118,33 @@
         "implementedBy": [
           {
             "type": "reference",
-            "name": "AttributePart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "AttributePart"
-            }
+            "name": "AttributePart"
           },
           {
             "type": "reference",
-            "name": "ChildPart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "ChildPart"
-            }
+            "name": "ChildPart"
           },
           {
             "type": "reference",
-            "name": "Directive",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "Directive"
-            }
+            "name": "Directive"
           },
           {
             "type": "reference",
-            "name": "ElementPart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "ElementPart"
-            }
+            "name": "ElementPart"
           },
           {
             "type": "reference",
-            "name": "TemplateInstance",
-            "location": {
-              "page": "misc",
-              "anchor": "TemplateInstance"
-            }
+            "name": "TemplateInstance"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "Disconnectable"
@@ -26943,7 +25152,6 @@
       },
       {
         "name": "HasChanged",
-        "kindString": "Interface",
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -26954,11 +25162,15 @@
         "signatures": [
           {
             "name": "HasChanged",
-            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                "line": 152
+              }
+            ],
             "parameters": [
               {
                 "name": "value",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -26966,7 +25178,6 @@
               },
               {
                 "name": "old",
-                "kindString": "Parameter",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
@@ -26982,11 +25193,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "HasChanged"
@@ -26994,7 +25205,6 @@
       },
       {
         "name": "HTMLTemplateResult",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/lit-html/src/lit-html.ts",
@@ -27009,24 +25219,22 @@
               "type": "query",
               "queryType": {
                 "type": "reference",
-                "name": "HTML_RESULT"
+                "name": "HTML_RESULT",
+                "package": "lit-html"
               }
             }
           ],
           "name": "TemplateResult",
-          "location": {
-            "page": "templates",
-            "anchor": "TemplateResult"
-          }
+          "package": "lit-html"
         },
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "HTMLTemplateResult"
@@ -27034,7 +25242,6 @@
       },
       {
         "name": "Initializer",
-        "kindString": "Type alias",
         "sources": [
           {
             "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -27046,7 +25253,6 @@
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
@@ -27056,18 +25262,13 @@
             "signatures": [
               {
                 "name": "__type",
-                "kindString": "Call signature",
                 "parameters": [
                   {
                     "name": "element",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "ReactiveElement",
-                      "location": {
-                        "page": "ReactiveElement",
-                        "anchor": "ReactiveElement"
-                      }
+                      "package": "@lit/reactive-element"
                     }
                   }
                 ],
@@ -27082,11 +25283,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "Initializer"
@@ -27094,14 +25295,12 @@
       },
       {
         "name": "PropertyValueMap",
-        "kindString": "Interface",
         "comment": {
           "shortText": "Do not use, instead prefer [`PropertyValues`](/docs/api/ReactiveElement/#PropertyValues)."
         },
         "children": [
           {
             "name": "delete",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -27112,11 +25311,15 @@
             "signatures": [
               {
                 "name": "delete",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 148
+                  }
+                ],
                 "typeParameter": [
                   {
                     "name": "K",
-                    "kindString": "Type parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -27139,7 +25342,6 @@
                 "parameters": [
                   {
                     "name": "k",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "K"
@@ -27163,11 +25365,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.delete"
@@ -27175,7 +25377,6 @@
           },
           {
             "name": "get",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -27186,11 +25387,15 @@
             "signatures": [
               {
                 "name": "get",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 145
+                  }
+                ],
                 "typeParameter": [
                   {
                     "name": "K",
-                    "kindString": "Type parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -27213,7 +25418,6 @@
                 "parameters": [
                   {
                     "name": "k",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "K"
@@ -27244,11 +25448,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.get"
@@ -27256,7 +25460,6 @@
           },
           {
             "name": "has",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -27267,11 +25470,15 @@
             "signatures": [
               {
                 "name": "has",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 147
+                  }
+                ],
                 "typeParameter": [
                   {
                     "name": "K",
-                    "kindString": "Type parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -27294,7 +25501,6 @@
                 "parameters": [
                   {
                     "name": "k",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "K"
@@ -27318,11 +25524,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.has"
@@ -27330,7 +25536,6 @@
           },
           {
             "name": "set",
-            "kindString": "Method",
             "sources": [
               {
                 "fileName": "packages/reactive-element/src/reactive-element.ts",
@@ -27341,11 +25546,15 @@
             "signatures": [
               {
                 "name": "set",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/reactive-element/development/reactive-element.d.ts",
+                    "line": 146
+                  }
+                ],
                 "typeParameter": [
                   {
                     "name": "K",
-                    "kindString": "Type parameter",
                     "type": {
                       "type": "union",
                       "types": [
@@ -27368,7 +25577,6 @@
                 "parameters": [
                   {
                     "name": "key",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "reference",
                       "name": "K"
@@ -27376,7 +25584,6 @@
                   },
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "type": {
                       "type": "indexedAccess",
                       "indexType": {
@@ -27399,10 +25606,7 @@
                     }
                   ],
                   "name": "PropertyValueMap",
-                  "location": {
-                    "page": "misc",
-                    "anchor": "PropertyValueMap"
-                  }
+                  "package": "@lit/reactive-element"
                 },
                 "overwrites": {
                   "type": "reference",
@@ -27417,11 +25621,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.set"
@@ -27437,8 +25641,7 @@
         ],
         "typeParameters": [
           {
-            "name": "T",
-            "kindString": "Type parameter"
+            "name": "T"
           }
         ],
         "extendedTypes": [
@@ -27448,7 +25651,6 @@
               {
                 "type": "reference",
                 "name": "PropertyKey",
-                "qualifiedName": "PropertyKey",
                 "package": "typescript"
               },
               {
@@ -27457,18 +25659,17 @@
               }
             ],
             "name": "Map",
-            "qualifiedName": "Map",
             "package": "typescript"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "PropertyValueMap"
@@ -27480,7 +25681,6 @@
               {
                 "type": "reference",
                 "name": "PropertyKey",
-                "qualifiedName": "PropertyKey",
                 "package": "typescript"
               },
               {
@@ -27489,21 +25689,18 @@
               }
             ],
             "name": "Map",
-            "qualifiedName": "Map",
             "package": "typescript"
           }
         ]
       },
       {
         "name": "RootPart",
-        "kindString": "Interface",
         "comment": {
           "shortText": "A top-level `ChildPart` returned from `render` that manages the connected\nstate of `AsyncDirective`s created throughout the tree below it."
         },
         "children": [
           {
             "name": "options",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -27524,29 +25721,22 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "location": {
-                    "page": "LitElement",
-                    "anchor": "RenderOptions"
-                  }
+                  "package": "lit-html"
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.options",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart.options"
-              }
+              "name": "ChildPart.options"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "RootPart.options"
@@ -27554,7 +25744,6 @@
           },
           {
             "name": "type",
-            "kindString": "Property",
             "flags": {
               "isReadonly": true
             },
@@ -27572,20 +25761,16 @@
             "defaultValue": "2",
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.type",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart.type"
-              }
+              "name": "ChildPart.type"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "RootPart.type"
@@ -27593,7 +25778,6 @@
           },
           {
             "name": "endNode",
-            "kindString": "Accessor",
             "comment": {
               "shortText": "The part's trailing marker node, if any. See `.parentNode` for more\ninformation."
             },
@@ -27614,17 +25798,21 @@
                 {
                   "type": "reference",
                   "name": "Node",
-                  "qualifiedName": "Node",
                   "package": "typescript"
                 }
               ]
             },
             "getSignature": {
               "name": "endNode",
-              "kindString": "Get signature",
               "comment": {
                 "shortText": "The part's trailing marker node, if any. See `.parentNode` for more\ninformation."
               },
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 406
+                }
+              ],
               "type": {
                 "type": "union",
                 "types": [
@@ -27635,7 +25823,6 @@
                   {
                     "type": "reference",
                     "name": "Node",
-                    "qualifiedName": "Node",
                     "package": "typescript"
                   }
                 ]
@@ -27647,20 +25834,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.endNode",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart.endNode"
-              }
+              "name": "ChildPart.endNode"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "RootPart.endNode"
@@ -27668,7 +25851,6 @@
           },
           {
             "name": "parentNode",
-            "kindString": "Accessor",
             "comment": {
               "shortText": "The parent node into which the part renders its content.",
               "text": "A ChildPart's content consists of a range of adjacent child nodes of\n`.parentNode`, possibly bordered by 'marker nodes' (`.startNode` and\n`.endNode`).\n- If both `.startNode` and `.endNode` are non-null, then the part's content\nconsists of all siblings between `.startNode` and `.endNode`, exclusively.\n- If `.startNode` is non-null but `.endNode` is null, then the part's\ncontent consists of all siblings following `.startNode`, up to and\nincluding the last child of `.parentNode`. If `.endNode` is non-null, then\n`.startNode` will always be non-null.\n- If both `.endNode` and `.startNode` are null, then the part's content\nconsists of all child nodes of `.parentNode`.\n"
@@ -27683,20 +25865,23 @@
             "type": {
               "type": "reference",
               "name": "Node",
-              "qualifiedName": "Node",
               "package": "typescript"
             },
             "getSignature": {
               "name": "parentNode",
-              "kindString": "Get signature",
               "comment": {
                 "shortText": "The parent node into which the part renders its content.",
                 "text": "A ChildPart's content consists of a range of adjacent child nodes of\n`.parentNode`, possibly bordered by 'marker nodes' (`.startNode` and\n`.endNode`).\n- If both `.startNode` and `.endNode` are non-null, then the part's content\nconsists of all siblings between `.startNode` and `.endNode`, exclusively.\n- If `.startNode` is non-null but `.endNode` is null, then the part's\ncontent consists of all siblings following `.startNode`, up to and\nincluding the last child of `.parentNode`. If `.endNode` is non-null, then\n`.startNode` will always be non-null.\n- If both `.endNode` and `.startNode` are null, then the part's content\nconsists of all child nodes of `.parentNode`.\n"
               },
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 396
+                }
+              ],
               "type": {
                 "type": "reference",
                 "name": "Node",
-                "qualifiedName": "Node",
                 "package": "typescript"
               },
               "inheritedFrom": {
@@ -27706,20 +25891,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.parentNode",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart.parentNode"
-              }
+              "name": "ChildPart.parentNode"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "RootPart.parentNode"
@@ -27727,7 +25908,6 @@
           },
           {
             "name": "startNode",
-            "kindString": "Accessor",
             "comment": {
               "shortText": "The part's leading marker node, if any. See `.parentNode` for more\ninformation."
             },
@@ -27748,17 +25928,21 @@
                 {
                   "type": "reference",
                   "name": "Node",
-                  "qualifiedName": "Node",
                   "package": "typescript"
                 }
               ]
             },
             "getSignature": {
               "name": "startNode",
-              "kindString": "Get signature",
               "comment": {
                 "shortText": "The part's leading marker node, if any. See `.parentNode` for more\ninformation."
               },
+              "sources": [
+                {
+                  "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                  "line": 401
+                }
+              ],
               "type": {
                 "type": "union",
                 "types": [
@@ -27769,7 +25953,6 @@
                   {
                     "type": "reference",
                     "name": "Node",
-                    "qualifiedName": "Node",
                     "package": "typescript"
                   }
                 ]
@@ -27781,20 +25964,16 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.startNode",
-              "location": {
-                "page": "custom-directives",
-                "anchor": "ChildPart.startNode"
-              }
+              "name": "ChildPart.startNode"
             },
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "RootPart.startNode"
@@ -27802,7 +25981,6 @@
           },
           {
             "name": "setConnected",
-            "kindString": "Method",
             "comment": {
               "shortText": "Sets the connection state for `AsyncDirective`s contained within this root\nChildPart.",
               "text": "lit-html does not automatically monitor the connectedness of DOM rendered;\nas such, it is the responsibility of the caller to `render` to ensure that\n`part.setConnected(false)` is called before the part object is potentially\ndiscarded, to ensure that `AsyncDirective`s have a chance to dispose of\nany resources being held. If a `RootPart` that was previously\ndisconnected is subsequently re-connected (and its `AsyncDirective`s should\nre-connect), `setConnected(true)` should be called.\n"
@@ -27817,11 +25995,15 @@
             "signatures": [
               {
                 "name": "setConnected",
-                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
+                    "line": 434
+                  }
+                ],
                 "parameters": [
                   {
                     "name": "isConnected",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "Whether directives within this tree should be connected\nor not"
                     },
@@ -27840,11 +26022,11 @@
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
-                "line": 10,
-                "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+                "line": 1,
                 "moduleSpecifier": "lit"
               }
             ],
+            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "RootPart.setConnected"
@@ -27862,20 +26044,17 @@
           {
             "type": "reference",
             "name": "ChildPart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "ChildPart"
-            }
+            "package": "lit-html"
           }
         ],
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "RootPart"
@@ -27884,16 +26063,12 @@
           {
             "type": "reference",
             "name": "ChildPart",
-            "location": {
-              "page": "custom-directives",
-              "anchor": "ChildPart"
-            }
+            "package": "lit-html"
           }
         ]
       },
       {
         "name": "ValueSanitizer",
-        "kindString": "Type alias",
         "comment": {
           "blockTags": [
             {
@@ -27919,7 +26094,6 @@
           "type": "reflection",
           "declaration": {
             "name": "__type",
-            "kindString": "Type literal",
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
@@ -27929,7 +26103,6 @@
             "signatures": [
               {
                 "name": "__type",
-                "kindString": "Call signature",
                 "comment": {
                   "blockTags": [
                     {
@@ -27947,7 +26120,6 @@
                 "parameters": [
                   {
                     "name": "value",
-                    "kindString": "Parameter",
                     "comment": {
                       "shortText": "The value to sanitize. Will be the actual value passed into\n    the lit-html template literal, so this could be of any type."
                     },
@@ -27968,11 +26140,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "ValueSanitizer"
@@ -27980,7 +26152,6 @@
       },
       {
         "name": "WarningKind",
-        "kindString": "Type alias",
         "comment": {
           "shortText": "A string representing one of the supported dev mode warning categories."
         },
@@ -28007,11 +26178,11 @@
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
-            "line": 10,
-            "url": "https://github.com/lit/lit/blob/c134604/packages/lit/src/index.ts#L10",
+            "line": 1,
             "moduleSpecifier": "lit"
           }
         ],
+        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "WarningKind"

--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -1266,12 +1266,14 @@
                         {
                           "type": "reference",
                           "name": "Element",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                         },
                         {
                           "type": "reference",
                           "name": "ShadowRoot",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
                         }
                       ]
                     },
@@ -1394,12 +1396,14 @@
                     {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     {
                       "type": "reference",
                       "name": "ShadowRoot",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
                     }
                   ]
                 },
@@ -1444,7 +1448,8 @@
                 "type": {
                   "type": "reference",
                   "name": "ShadowRootInit",
-                  "package": "typescript"
+                  "package": "typescript",
+                  "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters"
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -2901,7 +2906,8 @@
           {
             "type": "reference",
             "name": "HTMLElement",
-            "package": "typescript"
+            "package": "typescript",
+            "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
           }
         ],
         "extendedBy": [
@@ -2933,7 +2939,8 @@
           {
             "type": "reference",
             "name": "HTMLElement",
-            "package": "typescript"
+            "package": "typescript",
+            "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
           }
         ],
         "expandedCategories": [
@@ -4069,12 +4076,14 @@
                         {
                           "type": "reference",
                           "name": "Element",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                         },
                         {
                           "type": "reference",
                           "name": "ShadowRoot",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
                         }
                       ]
                     },
@@ -4115,12 +4124,14 @@
                     {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     {
                       "type": "reference",
                       "name": "ShadowRoot",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
                     }
                   ]
                 },
@@ -4161,7 +4172,8 @@
                 "type": {
                   "type": "reference",
                   "name": "ShadowRootInit",
-                  "package": "typescript"
+                  "package": "typescript",
+                  "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters"
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -6099,12 +6111,14 @@
                     {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     {
                       "type": "reference",
                       "name": "DocumentFragment",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
                     }
                   ]
                 },
@@ -6518,7 +6532,8 @@
                 "type": {
                   "type": "reference",
                   "name": "ShadowRoot",
-                  "package": "typescript"
+                  "package": "typescript",
+                  "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
                 },
                 "kindString": "Parameter"
               },
@@ -6688,7 +6703,8 @@
                 {
                   "type": "reference",
                   "name": "CSSStyleSheet",
-                  "package": "typescript"
+                  "package": "typescript",
+                  "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet"
                 }
               ]
             },
@@ -6710,7 +6726,8 @@
                   {
                     "type": "reference",
                     "name": "CSSStyleSheet",
-                    "package": "typescript"
+                    "package": "typescript",
+                    "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet"
                   }
                 ]
               },
@@ -7027,7 +7044,8 @@
             {
               "type": "reference",
               "name": "CSSStyleSheet",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet"
             }
           ]
         },
@@ -12222,7 +12240,8 @@
                 "default": {
                   "type": "reference",
                   "name": "Element",
-                  "package": "typescript"
+                  "package": "typescript",
+                  "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                 },
                 "kindString": "Type parameter"
               }
@@ -12335,7 +12354,8 @@
                     "default": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Type parameter"
                   }
@@ -12414,7 +12434,8 @@
             "default": {
               "type": "reference",
               "name": "Element",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
             },
             "kindString": "Type parameter"
           }
@@ -12896,7 +12917,8 @@
                             {
                               "type": "reference",
                               "name": "Element",
-                              "package": "typescript"
+                              "package": "typescript",
+                              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                             },
                             {
                               "type": "intrinsic",
@@ -14431,7 +14453,8 @@
                 "type": {
                   "type": "reference",
                   "name": "HTMLTemplateElement",
-                  "package": "typescript"
+                  "package": "typescript",
+                  "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
                 },
                 "kindString": "Parameter"
               }
@@ -14554,7 +14577,8 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLTemplateElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
                     },
                     "kindString": "Parameter"
                   }
@@ -14565,7 +14589,8 @@
                     {
                       "type": "reference",
                       "name": "DocumentFragment",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
                     },
                     {
                       "type": "query",
@@ -16932,7 +16957,8 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     "kindString": "Parameter"
                   },
@@ -17016,7 +17042,8 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -17286,7 +17313,8 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     "kindString": "Parameter"
                   },
@@ -17378,7 +17406,8 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
             },
             "inheritedFrom": {
               "type": "reference",
@@ -18422,7 +18451,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Parameter"
                   },
@@ -18487,7 +18517,8 @@
             "type": {
               "type": "reference",
               "name": "Element",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18622,7 +18653,8 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     "kindString": "Parameter"
                   },
@@ -18714,7 +18746,8 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
             },
             "inheritedFrom": {
               "type": "reference",
@@ -19185,7 +19218,8 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                     },
                     "kindString": "Parameter"
                   },
@@ -19277,7 +19311,8 @@
             "type": {
               "type": "reference",
               "name": "HTMLElement",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
             },
             "inheritedFrom": {
               "type": "reference",
@@ -22102,12 +22137,14 @@
                         {
                           "type": "reference",
                           "name": "HTMLElement",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                         },
                         {
                           "type": "reference",
                           "name": "DocumentFragment",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
                         }
                       ]
                     },
@@ -22310,7 +22347,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -22475,7 +22513,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -22666,7 +22705,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -23244,7 +23284,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -23548,7 +23589,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Element",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -23690,12 +23732,14 @@
                         {
                           "type": "reference",
                           "name": "HTMLElement",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement"
                         },
                         {
                           "type": "reference",
                           "name": "DocumentFragment",
-                          "package": "typescript"
+                          "package": "typescript",
+                          "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
                         }
                       ]
                     },
@@ -24564,7 +24608,8 @@
                     "type": {
                       "type": "reference",
                       "name": "HTMLTemplateElement",
-                      "package": "typescript"
+                      "package": "typescript",
+                      "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -25558,7 +25603,8 @@
             "type": {
               "type": "reference",
               "name": "HTMLTemplateElement",
-              "package": "typescript"
+              "package": "typescript",
+              "externalUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement"
             },
             "kindString": "Property",
             "entrypointSources": [

--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -25,7 +25,11 @@
           {
             "type": "reference",
             "name": "ReactiveElement",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "ReactiveElement",
+              "anchor": "ReactiveElement"
+            }
           }
         ],
         "kindString": "Class",
@@ -44,7 +48,11 @@
           {
             "type": "reference",
             "name": "ReactiveElement",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "ReactiveElement",
+              "anchor": "ReactiveElement"
+            }
           }
         ],
         "expandedCategories": [
@@ -131,7 +139,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.attributeChangedCallback"
+                  "name": "ReactiveElement.attributeChangedCallback",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.attributeChangedCallback"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -204,7 +216,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.observedAttributes"
+                  "name": "ReactiveElement.observedAttributes",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.observedAttributes"
+                  }
                 },
                 "kindString": "Accessor",
                 "entrypointSources": [
@@ -253,7 +269,11 @@
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "controllers",
+                            "anchor": "ReactiveController"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -271,7 +291,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.addController"
+                  "name": "ReactiveElement.addController",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.addController"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -313,7 +337,11 @@
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "controllers",
+                            "anchor": "ReactiveController"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -331,7 +359,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.removeController"
+                  "name": "ReactiveElement.removeController",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.removeController"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -408,7 +440,11 @@
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "WarningKind"
+                              }
                             },
                             "kindString": "Parameter"
                           }
@@ -425,7 +461,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.disableWarning"
+                  "name": "ReactiveElement.disableWarning",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.disableWarning"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -467,12 +507,20 @@
                   "elementType": {
                     "type": "reference",
                     "name": "WarningKind",
-                    "package": "@lit/reactive-element"
+                    "package": "@lit/reactive-element",
+                    "location": {
+                      "page": "misc",
+                      "anchor": "WarningKind"
+                    }
                   }
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.enabledWarnings"
+                  "name": "ReactiveElement.enabledWarnings",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.enabledWarnings"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -543,7 +591,11 @@
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "WarningKind"
+                              }
                             },
                             "kindString": "Parameter"
                           }
@@ -560,7 +612,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.enableWarning"
+                  "name": "ReactiveElement.enableWarning",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.enableWarning"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -616,7 +672,11 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.connectedCallback"
+                  "name": "ReactiveElement.connectedCallback",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.connectedCallback"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -666,7 +726,11 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.disconnectedCallback"
+                  "name": "ReactiveElement.disconnectedCallback",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.disconnectedCallback"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -723,7 +787,11 @@
                         "type": {
                           "type": "reference",
                           "name": "Initializer",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "Initializer"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -741,7 +809,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.addInitializer"
+                  "name": "ReactiveElement.addInitializer",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.addInitializer"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -799,7 +871,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.finalize"
+                  "name": "ReactiveElement.finalize",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.finalize"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -837,7 +913,11 @@
                 },
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.finalized"
+                  "name": "ReactiveElement.finalized",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.finalized"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -916,7 +996,11 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "ReactiveElement",
+                            "anchor": "PropertyDeclaration"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -934,7 +1018,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.createProperty"
+                  "name": "ReactiveElement.createProperty",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.createProperty"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -976,7 +1064,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.elementProperties"
+                  "name": "ReactiveElement.elementProperties",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.elementProperties"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1064,7 +1156,11 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "ReactiveElement",
+                            "anchor": "PropertyDeclaration"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -1092,7 +1188,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.getPropertyDescriptor"
+                  "name": "ReactiveElement.getPropertyDescriptor",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.getPropertyDescriptor"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1164,7 +1264,11 @@
                         }
                       ],
                       "name": "PropertyDeclaration",
-                      "package": "@lit/reactive-element"
+                      "package": "@lit/reactive-element",
+                      "location": {
+                        "page": "ReactiveElement",
+                        "anchor": "PropertyDeclaration"
+                      }
                     },
                     "inheritedFrom": {
                       "type": "reference",
@@ -1175,7 +1279,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.getPropertyOptions"
+                  "name": "ReactiveElement.getPropertyOptions",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.getPropertyOptions"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1214,11 +1322,19 @@
                 "type": {
                   "type": "reference",
                   "name": "PropertyDeclarations",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "PropertyDeclarations"
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.properties"
+                  "name": "ReactiveElement.properties",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.properties"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1286,7 +1402,11 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.createRenderRoot"
+                  "name": "ReactiveElement.createRenderRoot",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.createRenderRoot"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1360,7 +1480,11 @@
                 "type": {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1409,7 +1533,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.renderRoot"
+                  "name": "ReactiveElement.renderRoot",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.renderRoot"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1453,7 +1581,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.shadowRootOptions"
+                  "name": "ReactiveElement.shadowRootOptions",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.shadowRootOptions"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1499,12 +1631,20 @@
                   "elementType": {
                     "type": "reference",
                     "name": "CSSResultOrNative",
-                    "package": "@lit/reactive-element"
+                    "package": "@lit/reactive-element",
+                    "location": {
+                      "page": "styles",
+                      "anchor": "CSSResultOrNative"
+                    }
                   }
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.elementStyles"
+                  "name": "ReactiveElement.elementStyles",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.elementStyles"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1559,7 +1699,11 @@
                         "type": {
                           "type": "reference",
                           "name": "CSSResultGroup",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "styles",
+                            "anchor": "CSSResultGroup"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -1569,7 +1713,11 @@
                       "elementType": {
                         "type": "reference",
                         "name": "CSSResultOrNative",
-                        "package": "@lit/reactive-element"
+                        "package": "@lit/reactive-element",
+                        "location": {
+                          "page": "styles",
+                          "anchor": "CSSResultOrNative"
+                        }
                       }
                     },
                     "inheritedFrom": {
@@ -1581,7 +1729,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.finalizeStyles"
+                  "name": "ReactiveElement.finalizeStyles",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.finalizeStyles"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1621,11 +1773,19 @@
                 "type": {
                   "type": "reference",
                   "name": "CSSResultGroup",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "styles",
+                    "anchor": "CSSResultGroup"
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.styles"
+                  "name": "ReactiveElement.styles",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.styles"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1693,7 +1853,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.enableUpdating"
+                  "name": "ReactiveElement.enableUpdating",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.enableUpdating"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1767,7 +1931,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -1787,7 +1955,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.firstUpdated"
+                  "name": "ReactiveElement.firstUpdated",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.firstUpdated"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1857,7 +2029,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.getUpdateComplete"
+                  "name": "ReactiveElement.getUpdateComplete",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.getUpdateComplete"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -1890,7 +2066,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.hasUpdated"
+                  "name": "ReactiveElement.hasUpdated",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.hasUpdated"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1923,7 +2103,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.isUpdatePending"
+                  "name": "ReactiveElement.isUpdatePending",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.isUpdatePending"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -1992,7 +2176,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.performUpdate"
+                  "name": "ReactiveElement.performUpdate",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.performUpdate"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2079,7 +2267,11 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "ReactiveElement",
+                            "anchor": "PropertyDeclaration"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -2097,7 +2289,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.requestUpdate"
+                  "name": "ReactiveElement.requestUpdate",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.requestUpdate"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2166,7 +2362,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.scheduleUpdate"
+                  "name": "ReactiveElement.scheduleUpdate",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.scheduleUpdate"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2239,7 +2439,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -2259,7 +2463,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.shouldUpdate"
+                  "name": "ReactiveElement.shouldUpdate",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.shouldUpdate"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2332,7 +2540,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -2352,7 +2564,11 @@
                 ],
                 "overwrites": {
                   "type": "reference",
-                  "name": "ReactiveElement.update"
+                  "name": "ReactiveElement.update",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.update"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2442,7 +2658,11 @@
                 },
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.updateComplete"
+                  "name": "ReactiveElement.updateComplete",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.updateComplete"
+                  }
                 },
                 "kindString": "Accessor",
                 "entrypointSources": [
@@ -2516,7 +2736,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -2536,7 +2760,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.updated"
+                  "name": "ReactiveElement.updated",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.updated"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2607,7 +2835,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -2627,7 +2859,11 @@
                 ],
                 "inheritedFrom": {
                   "type": "reference",
-                  "name": "ReactiveElement.willUpdate"
+                  "name": "ReactiveElement.willUpdate",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "ReactiveElement.willUpdate"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -2913,14 +3149,22 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "LitElement"
+            "name": "LitElement",
+            "location": {
+              "page": "LitElement",
+              "anchor": "LitElement"
+            }
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "ReactiveControllerHost",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "controllers",
+              "anchor": "ReactiveControllerHost"
+            }
           }
         ],
         "kindString": "Class",
@@ -3133,7 +3377,11 @@
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "controllers",
+                            "anchor": "ReactiveController"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -3151,7 +3399,11 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.addController"
+                  "name": "ReactiveControllerHost.addController",
+                  "location": {
+                    "page": "controllers",
+                    "anchor": "ReactiveControllerHost.addController"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -3193,7 +3445,11 @@
                         "type": {
                           "type": "reference",
                           "name": "ReactiveController",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "controllers",
+                            "anchor": "ReactiveController"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -3211,7 +3467,11 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.removeController"
+                  "name": "ReactiveControllerHost.removeController",
+                  "location": {
+                    "page": "controllers",
+                    "anchor": "ReactiveControllerHost.removeController"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -3288,7 +3548,11 @@
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "WarningKind"
+                              }
                             },
                             "kindString": "Parameter"
                           }
@@ -3343,7 +3607,11 @@
                   "elementType": {
                     "type": "reference",
                     "name": "WarningKind",
-                    "package": "@lit/reactive-element"
+                    "package": "@lit/reactive-element",
+                    "location": {
+                      "page": "misc",
+                      "anchor": "WarningKind"
+                    }
                   }
                 },
                 "kindString": "Property",
@@ -3415,7 +3683,11 @@
                             "type": {
                               "type": "reference",
                               "name": "WarningKind",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "WarningKind"
+                              }
                             },
                             "kindString": "Parameter"
                           }
@@ -3573,7 +3845,11 @@
                         "type": {
                           "type": "reference",
                           "name": "Initializer",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "Initializer"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -3745,7 +4021,11 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "ReactiveElement",
+                            "anchor": "PropertyDeclaration"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -3881,7 +4161,11 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "ReactiveElement",
+                            "anchor": "PropertyDeclaration"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -3973,7 +4257,11 @@
                         }
                       ],
                       "name": "PropertyDeclaration",
-                      "package": "@lit/reactive-element"
+                      "package": "@lit/reactive-element",
+                      "location": {
+                        "page": "ReactiveElement",
+                        "anchor": "PropertyDeclaration"
+                      }
                     },
                     "kindString": "Call signature"
                   }
@@ -4015,7 +4303,11 @@
                 "type": {
                   "type": "reference",
                   "name": "PropertyDeclarations",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "PropertyDeclarations"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -4219,7 +4511,11 @@
                   "elementType": {
                     "type": "reference",
                     "name": "CSSResultOrNative",
-                    "package": "@lit/reactive-element"
+                    "package": "@lit/reactive-element",
+                    "location": {
+                      "page": "styles",
+                      "anchor": "CSSResultOrNative"
+                    }
                   }
                 },
                 "kindString": "Property",
@@ -4275,7 +4571,11 @@
                         "type": {
                           "type": "reference",
                           "name": "CSSResultGroup",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "styles",
+                            "anchor": "CSSResultGroup"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -4285,7 +4585,11 @@
                       "elementType": {
                         "type": "reference",
                         "name": "CSSResultOrNative",
-                        "package": "@lit/reactive-element"
+                        "package": "@lit/reactive-element",
+                        "location": {
+                          "page": "styles",
+                          "anchor": "CSSResultOrNative"
+                        }
                       }
                     },
                     "kindString": "Call signature"
@@ -4329,7 +4633,11 @@
                 "type": {
                   "type": "reference",
                   "name": "CSSResultGroup",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "styles",
+                    "anchor": "CSSResultGroup"
+                  }
                 },
                 "kindString": "Property",
                 "entrypointSources": [
@@ -4463,7 +4771,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -4743,7 +5055,11 @@
                             }
                           ],
                           "name": "PropertyDeclaration",
-                          "package": "@lit/reactive-element"
+                          "package": "@lit/reactive-element",
+                          "location": {
+                            "page": "ReactiveElement",
+                            "anchor": "PropertyDeclaration"
+                          }
                         },
                         "kindString": "Parameter"
                       }
@@ -4761,7 +5077,11 @@
                 ],
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.requestUpdate"
+                  "name": "ReactiveControllerHost.requestUpdate",
+                  "location": {
+                    "page": "controllers",
+                    "anchor": "ReactiveControllerHost.requestUpdate"
+                  }
                 },
                 "kindString": "Method",
                 "entrypointSources": [
@@ -4895,7 +5215,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -4980,7 +5304,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -5076,13 +5404,21 @@
                   },
                   "implementationOf": {
                     "type": "reference",
-                    "name": "ReactiveControllerHost.updateComplete"
+                    "name": "ReactiveControllerHost.updateComplete",
+                    "location": {
+                      "page": "controllers",
+                      "anchor": "ReactiveControllerHost.updateComplete"
+                    }
                   },
                   "kindString": "Get signature"
                 },
                 "implementationOf": {
                   "type": "reference",
-                  "name": "ReactiveControllerHost.updateComplete"
+                  "name": "ReactiveControllerHost.updateComplete",
+                  "location": {
+                    "page": "controllers",
+                    "anchor": "ReactiveControllerHost.updateComplete"
+                  }
                 },
                 "kindString": "Accessor",
                 "entrypointSources": [
@@ -5156,7 +5492,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -5239,7 +5579,11 @@
                                 }
                               ],
                               "name": "PropertyValueMap",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "misc",
+                                "anchor": "PropertyValueMap"
+                              }
                             }
                           ]
                         },
@@ -5287,7 +5631,11 @@
           "queryType": {
             "type": "reference",
             "name": "ReactiveElement",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "ReactiveElement",
+              "anchor": "ReactiveElement"
+            }
           }
         },
         "kindString": "Variable",
@@ -5846,7 +6194,11 @@
           "type": {
             "type": "reference",
             "name": "PropertyDeclaration",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "ReactiveElement",
+              "anchor": "PropertyDeclaration"
+            }
           },
           "kindString": "Index signature"
         },
@@ -5905,7 +6257,11 @@
               }
             ],
             "name": "PropertyValueMap",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "misc",
+              "anchor": "PropertyValueMap"
+            }
           },
           "falseType": {
             "type": "reference",
@@ -6004,7 +6360,11 @@
                 }
               ],
               "name": "TemplateResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "templates",
+                "anchor": "TemplateResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -6135,7 +6495,11 @@
                 "type": {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -6143,7 +6507,11 @@
             "type": {
               "type": "reference",
               "name": "RootPart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "misc",
+                "anchor": "RootPart"
+              }
             },
             "kindString": "Call signature"
           }
@@ -6217,7 +6585,11 @@
                 }
               ],
               "name": "TemplateResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "templates",
+                "anchor": "TemplateResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -6333,7 +6705,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ValueSanitizer",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "ValueSanitizer"
+                  }
                 },
                 "kindString": "Call signature"
               }
@@ -6376,7 +6752,11 @@
             }
           ],
           "name": "TemplateResult",
-          "package": "lit-html"
+          "package": "lit-html",
+          "location": {
+            "page": "templates",
+            "anchor": "TemplateResult"
+          }
         },
         "kindString": "Type alias",
         "entrypointSources": [
@@ -6544,7 +6924,11 @@
                   "elementType": {
                     "type": "reference",
                     "name": "CSSResultOrNative",
-                    "package": "@lit/reactive-element"
+                    "package": "@lit/reactive-element",
+                    "location": {
+                      "page": "styles",
+                      "anchor": "CSSResultOrNative"
+                    }
                   }
                 },
                 "kindString": "Parameter"
@@ -6619,7 +7003,11 @@
                       {
                         "type": "reference",
                         "name": "CSSResultGroup",
-                        "package": "@lit/reactive-element"
+                        "package": "@lit/reactive-element",
+                        "location": {
+                          "page": "styles",
+                          "anchor": "CSSResultGroup"
+                        }
                       }
                     ]
                   }
@@ -6630,7 +7018,11 @@
             "type": {
               "type": "reference",
               "name": "CSSResult",
-              "package": "@lit/reactive-element"
+              "package": "@lit/reactive-element",
+              "location": {
+                "page": "styles",
+                "anchor": "CSSResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -6829,7 +7221,11 @@
                 "type": {
                   "type": "reference",
                   "name": "CSSResultOrNative",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "styles",
+                    "anchor": "CSSResultOrNative"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -6837,7 +7233,11 @@
             "type": {
               "type": "reference",
               "name": "CSSResultOrNative",
-              "package": "@lit/reactive-element"
+              "package": "@lit/reactive-element",
+              "location": {
+                "page": "styles",
+                "anchor": "CSSResultOrNative"
+              }
             },
             "kindString": "Call signature"
           }
@@ -6922,7 +7322,11 @@
             "type": {
               "type": "reference",
               "name": "CSSResult",
-              "package": "@lit/reactive-element"
+              "package": "@lit/reactive-element",
+              "location": {
+                "page": "styles",
+                "anchor": "CSSResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -6957,12 +7361,20 @@
               {
                 "type": "reference",
                 "name": "CSSResultOrNative",
-                "package": "@lit/reactive-element"
+                "package": "@lit/reactive-element",
+                "location": {
+                  "page": "styles",
+                  "anchor": "CSSResultOrNative"
+                }
               },
               {
                 "type": "reference",
                 "name": "CSSResultArray",
-                "package": "@lit/reactive-element"
+                "package": "@lit/reactive-element",
+                "location": {
+                  "page": "styles",
+                  "anchor": "CSSResultArray"
+                }
               }
             ]
           }
@@ -6998,12 +7410,20 @@
             {
               "type": "reference",
               "name": "CSSResultOrNative",
-              "package": "@lit/reactive-element"
+              "package": "@lit/reactive-element",
+              "location": {
+                "page": "styles",
+                "anchor": "CSSResultOrNative"
+              }
             },
             {
               "type": "reference",
               "name": "CSSResultArray",
-              "package": "@lit/reactive-element"
+              "package": "@lit/reactive-element",
+              "location": {
+                "page": "styles",
+                "anchor": "CSSResultArray"
+              }
             }
           ]
         },
@@ -7039,7 +7459,11 @@
             {
               "type": "reference",
               "name": "CSSResult",
-              "package": "@lit/reactive-element"
+              "package": "@lit/reactive-element",
+              "location": {
+                "page": "styles",
+                "anchor": "CSSResult"
+              }
             },
             {
               "type": "reference",
@@ -7232,7 +7656,11 @@
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "ReactiveElement",
+                                "anchor": "ReactiveElement"
+                              }
                             },
                             {
                               "type": "reference",
@@ -7328,7 +7756,11 @@
                     }
                   ],
                   "name": "PropertyDeclaration",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "ReactiveElement",
+                    "anchor": "PropertyDeclaration"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -7476,7 +7908,11 @@
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "ReactiveElement",
+                                "anchor": "ReactiveElement"
+                              }
                             },
                             {
                               "type": "reference",
@@ -7583,7 +8019,11 @@
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "ReactiveElement",
+                                "anchor": "ReactiveElement"
+                              }
                             },
                             {
                               "type": "reference",
@@ -7664,7 +8104,11 @@
                 "type": {
                   "type": "reference",
                   "name": "QueryAssignedElementsOptions",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "decorators",
+                    "anchor": "QueryAssignedElementsOptions"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -7691,7 +8135,11 @@
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "ReactiveElement",
+                                "anchor": "ReactiveElement"
+                              }
                             },
                             {
                               "type": "reference",
@@ -7777,7 +8225,11 @@
                 "type": {
                   "type": "reference",
                   "name": "QueryAssignedNodesOptions",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "decorators",
+                    "anchor": "QueryAssignedNodesOptions"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -7969,7 +8421,11 @@
                             {
                               "type": "reference",
                               "name": "ReactiveElement",
-                              "package": "@lit/reactive-element"
+                              "package": "@lit/reactive-element",
+                              "location": {
+                                "page": "ReactiveElement",
+                                "anchor": "ReactiveElement"
+                              }
                             },
                             {
                               "type": "reference",
@@ -8056,7 +8512,11 @@
                     }
                   ],
                   "name": "InternalPropertyDeclaration",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "decorators",
+                    "anchor": "InternalPropertyDeclaration"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -8300,7 +8760,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "QueryAssignedNodesOptions.slot"
+              "name": "QueryAssignedNodesOptions.slot",
+              "location": {
+                "page": "decorators",
+                "anchor": "QueryAssignedNodesOptions.slot"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -8327,7 +8791,11 @@
           {
             "type": "reference",
             "name": "QueryAssignedNodesOptions",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "decorators",
+              "anchor": "QueryAssignedNodesOptions"
+            }
           }
         ],
         "kindString": "Interface",
@@ -8346,7 +8814,11 @@
           {
             "type": "reference",
             "name": "QueryAssignedNodesOptions",
-            "package": "@lit/reactive-element"
+            "package": "@lit/reactive-element",
+            "location": {
+              "page": "decorators",
+              "anchor": "QueryAssignedNodesOptions"
+            }
           }
         ]
       },
@@ -8406,7 +8878,11 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "QueryAssignedElementsOptions"
+            "name": "QueryAssignedElementsOptions",
+            "location": {
+              "page": "decorators",
+              "anchor": "QueryAssignedElementsOptions"
+            }
           }
         ],
         "kindString": "Interface",
@@ -8547,12 +9023,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "AsyncAppendDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "AsyncAppendDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -8600,7 +9085,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -8608,7 +9097,12 @@
                 "type": {
                   "type": "reference",
                   "name": "AsyncAppendDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "AsyncAppendDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -8619,7 +9113,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.constructor"
+              "name": "AsyncReplaceDirective.constructor",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -8652,7 +9150,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.isConnected"
+              "name": "AsyncReplaceDirective.isConnected",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.isConnected"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -8719,7 +9221,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.commitValue"
+              "name": "AsyncReplaceDirective.commitValue",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.commitValue"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -8768,7 +9274,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.disconnected"
+              "name": "AsyncReplaceDirective.disconnected",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.disconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -8814,7 +9324,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.reconnected"
+              "name": "AsyncReplaceDirective.reconnected",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.reconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -8901,7 +9415,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.render"
+              "name": "AsyncReplaceDirective.render",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -8964,7 +9482,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.setValue"
+              "name": "AsyncReplaceDirective.setValue",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.setValue"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9003,7 +9525,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -9061,7 +9587,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     }
                   ]
@@ -9075,7 +9605,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncReplaceDirective.update"
+              "name": "AsyncReplaceDirective.update",
+              "location": {
+                "page": "directives",
+                "anchor": "AsyncReplaceDirective.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9102,7 +9636,12 @@
           {
             "type": "reference",
             "name": "AsyncReplaceDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "directives",
+              "anchor": "AsyncReplaceDirective",
+              "excludeFromTOC": true
+            }
           }
         ],
         "kindString": "Class",
@@ -9122,7 +9661,12 @@
           {
             "type": "reference",
             "name": "AsyncReplaceDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "directives",
+              "anchor": "AsyncReplaceDirective",
+              "excludeFromTOC": true
+            }
           }
         ]
       },
@@ -9194,12 +9738,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "AsyncReplaceDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "AsyncReplaceDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -9247,7 +9800,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -9255,7 +9812,12 @@
                 "type": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "AsyncReplaceDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -9266,7 +9828,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.constructor"
+              "name": "AsyncDirective.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -9299,7 +9865,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.isConnected"
+              "name": "AsyncDirective.isConnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.isConnected"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -9407,7 +9977,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.disconnected"
+              "name": "AsyncDirective.disconnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.disconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9453,7 +10027,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.reconnected"
+              "name": "AsyncDirective.reconnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.reconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9540,7 +10118,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.render"
+              "name": "AsyncDirective.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9603,7 +10185,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.setValue"
+              "name": "AsyncDirective.setValue",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.setValue"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9642,7 +10228,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -9700,7 +10290,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     }
                   ]
@@ -9714,7 +10308,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.update"
+              "name": "AsyncDirective.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9741,13 +10339,22 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "AsyncAppendDirective"
+            "name": "AsyncAppendDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "AsyncAppendDirective",
+              "excludeFromTOC": true
+            }
           }
         ],
         "kindString": "Class",
@@ -9767,7 +10374,11 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           }
         ]
       },
@@ -9811,12 +10422,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "CacheDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "CacheDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -9863,7 +10483,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -9871,7 +10495,12 @@
                 "type": {
                   "type": "reference",
                   "name": "CacheDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "CacheDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -9882,7 +10511,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -9941,7 +10574,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -9980,7 +10617,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -10019,7 +10660,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -10046,7 +10691,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -10066,7 +10715,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -10260,7 +10913,12 @@
                 "type": {
                   "type": "reference",
                   "name": "ClassInfo",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ClassInfo",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -10273,12 +10931,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "ClassMapDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "ClassMapDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -10325,7 +10992,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -10333,7 +11004,12 @@
                 "type": {
                   "type": "reference",
                   "name": "ClassMapDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ClassMapDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -10344,7 +11020,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -10383,7 +11063,12 @@
                     "type": {
                       "type": "reference",
                       "name": "ClassInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ClassInfo",
+                        "excludeFromTOC": true
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -10401,7 +11086,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -10440,7 +11129,11 @@
                     "type": {
                       "type": "reference",
                       "name": "AttributePart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "AttributePart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -10456,7 +11149,12 @@
                           "element": {
                             "type": "reference",
                             "name": "ClassInfo",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "directives",
+                              "anchor": "ClassInfo",
+                              "excludeFromTOC": true
+                            }
                           }
                         }
                       ]
@@ -10476,7 +11174,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     }
                   ]
@@ -10490,7 +11192,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -10517,7 +11223,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -10537,7 +11247,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -10680,12 +11394,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "GuardDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "GuardDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -10732,7 +11455,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -10740,7 +11467,12 @@
                 "type": {
                   "type": "reference",
                   "name": "GuardDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "GuardDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -10751,7 +11483,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -10840,7 +11576,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -10879,7 +11619,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -10949,7 +11693,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -10976,7 +11724,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -10996,7 +11748,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -11046,7 +11802,11 @@
                   "queryType": {
                     "type": "reference",
                     "name": "nothing",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "templates",
+                      "anchor": "nothing"
+                    }
                   }
                 },
                 {
@@ -11351,12 +12111,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "Keyed",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "Keyed",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -11403,7 +12172,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -11411,7 +12184,12 @@
                 "type": {
                   "type": "reference",
                   "name": "Keyed",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "Keyed",
+                    "excludeFromTOC": true
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -11422,7 +12200,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -11512,7 +12294,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -11551,7 +12337,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -11596,7 +12386,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -11623,7 +12417,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -11643,7 +12441,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -11687,12 +12489,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "LiveDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "LiveDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -11739,7 +12550,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -11747,7 +12562,12 @@
                 "type": {
                   "type": "reference",
                   "name": "LiveDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "LiveDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -11758,7 +12578,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -11814,7 +12638,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -11853,7 +12681,11 @@
                     "type": {
                       "type": "reference",
                       "name": "AttributePart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "AttributePart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -11889,7 +12721,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -11916,7 +12752,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -11936,7 +12776,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -12255,7 +13099,12 @@
                 }
               ],
               "name": "Ref",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "directives",
+                "anchor": "Ref",
+                "excludeFromTOC": true
+              }
             },
             "kindString": "Call signature"
           }
@@ -12301,7 +13150,12 @@
                 "type": {
                   "type": "reference",
                   "name": "RefOrCallback",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "RefOrCallback",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -12314,12 +13168,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "RefDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "RefDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -12369,7 +13232,12 @@
                     }
                   ],
                   "name": "Ref",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "Ref",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -12484,7 +13352,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -12492,7 +13364,12 @@
                 "type": {
                   "type": "reference",
                   "name": "RefDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "RefDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -12503,7 +13380,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.constructor"
+              "name": "AsyncDirective.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -12536,7 +13417,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.isConnected"
+              "name": "AsyncDirective.isConnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.isConnected"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -12585,7 +13470,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.disconnected"
+              "name": "AsyncDirective.disconnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.disconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -12631,7 +13520,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.reconnected"
+              "name": "AsyncDirective.reconnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.reconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -12670,7 +13563,12 @@
                     "type": {
                       "type": "reference",
                       "name": "RefOrCallback",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "RefOrCallback",
+                        "excludeFromTOC": true
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -12688,7 +13586,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.render"
+              "name": "AsyncDirective.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -12751,7 +13653,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.setValue"
+              "name": "AsyncDirective.setValue",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.setValue"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -12790,7 +13696,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ElementPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ElementPart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -12806,7 +13716,12 @@
                           "element": {
                             "type": "reference",
                             "name": "RefOrCallback",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "directives",
+                              "anchor": "RefOrCallback",
+                              "excludeFromTOC": true
+                            }
                           }
                         }
                       ]
@@ -12827,7 +13742,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.update"
+              "name": "AsyncDirective.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -12854,7 +13773,11 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           }
         ],
         "kindString": "Class",
@@ -12874,7 +13797,11 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           }
         ]
       },
@@ -12893,7 +13820,12 @@
             {
               "type": "reference",
               "name": "Ref",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "directives",
+                "anchor": "Ref",
+                "excludeFromTOC": true
+              }
             },
             {
               "type": "reflection",
@@ -13013,7 +13945,12 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
+                      }
                     },
                     {
                       "type": "reference",
@@ -13024,7 +13961,12 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
+                      }
                     }
                   ]
                 },
@@ -13044,7 +13986,12 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -13100,7 +14047,12 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -13159,7 +14111,12 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
+                      }
                     },
                     {
                       "type": "reference",
@@ -13170,7 +14127,12 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
+                      }
                     }
                   ]
                 },
@@ -13187,7 +14149,12 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -13241,7 +14208,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -13249,7 +14220,12 @@
                 "type": {
                   "type": "reference",
                   "name": "RepeatDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "RepeatDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -13260,7 +14236,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -13331,7 +14311,12 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -13393,7 +14378,12 @@
                             }
                           ],
                           "name": "KeyFn",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "directives",
+                            "anchor": "KeyFn",
+                            "excludeFromTOC": true
+                          }
                         },
                         {
                           "type": "reference",
@@ -13404,7 +14394,12 @@
                             }
                           ],
                           "name": "ItemTemplate",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "directives",
+                            "anchor": "ItemTemplate",
+                            "excludeFromTOC": true
+                          }
                         }
                       ]
                     },
@@ -13421,7 +14416,12 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -13442,7 +14442,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -13487,7 +14491,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -13519,7 +14527,12 @@
                                 }
                               ],
                               "name": "KeyFn",
-                              "package": "lit-html"
+                              "package": "lit-html",
+                              "location": {
+                                "page": "directives",
+                                "anchor": "KeyFn",
+                                "excludeFromTOC": true
+                              }
                             },
                             {
                               "type": "reference",
@@ -13530,7 +14543,12 @@
                                 }
                               ],
                               "name": "ItemTemplate",
-                              "package": "lit-html"
+                              "package": "lit-html",
+                              "location": {
+                                "page": "directives",
+                                "anchor": "ItemTemplate",
+                                "excludeFromTOC": true
+                              }
                             }
                           ]
                         },
@@ -13543,7 +14561,12 @@
                             }
                           ],
                           "name": "ItemTemplate",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "directives",
+                            "anchor": "ItemTemplate",
+                            "excludeFromTOC": true
+                          }
                         }
                       ]
                     },
@@ -13565,7 +14588,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     }
                   ]
@@ -13579,7 +14606,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -13606,7 +14637,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -13626,7 +14661,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -13824,7 +14863,12 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
+                      }
                     },
                     {
                       "type": "reference",
@@ -13835,7 +14879,12 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
+                      }
                     }
                   ]
                 },
@@ -13855,7 +14904,12 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -13907,7 +14961,12 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -13962,7 +15021,12 @@
                         }
                       ],
                       "name": "KeyFn",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "KeyFn",
+                        "excludeFromTOC": true
+                      }
                     },
                     {
                       "type": "reference",
@@ -13973,7 +15037,12 @@
                         }
                       ],
                       "name": "ItemTemplate",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "ItemTemplate",
+                        "excludeFromTOC": true
+                      }
                     }
                   ]
                 },
@@ -13990,7 +15059,12 @@
                     }
                   ],
                   "name": "ItemTemplate",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "ItemTemplate",
+                    "excludeFromTOC": true
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -14058,7 +15132,12 @@
                     {
                       "type": "reference",
                       "name": "StyleInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "directives",
+                        "anchor": "StyleInfo",
+                        "excludeFromTOC": true
+                      }
                     }
                   ],
                   "name": "Readonly",
@@ -14075,12 +15154,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "StyleMapDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "StyleMapDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -14127,7 +15215,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -14135,7 +15227,12 @@
                 "type": {
                   "type": "reference",
                   "name": "StyleMapDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "StyleMapDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -14146,7 +15243,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -14188,7 +15289,12 @@
                         {
                           "type": "reference",
                           "name": "StyleInfo",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "directives",
+                            "anchor": "StyleInfo",
+                            "excludeFromTOC": true
+                          }
                         }
                       ],
                       "name": "Readonly",
@@ -14210,7 +15316,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -14249,7 +15359,11 @@
                     "type": {
                       "type": "reference",
                       "name": "AttributePart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "AttributePart"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -14268,7 +15382,12 @@
                               {
                                 "type": "reference",
                                 "name": "StyleInfo",
-                                "package": "lit-html"
+                                "package": "lit-html",
+                                "location": {
+                                  "page": "directives",
+                                  "anchor": "StyleInfo",
+                                  "excludeFromTOC": true
+                                }
                               }
                             ],
                             "name": "Readonly",
@@ -14292,7 +15411,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     }
                   ]
@@ -14306,7 +15429,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -14333,7 +15460,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -14353,7 +15484,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -14467,12 +15602,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "TemplateContentDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "TemplateContentDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -14519,7 +15663,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -14527,7 +15675,12 @@
                 "type": {
                   "type": "reference",
                   "name": "TemplateContentDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "TemplateContentDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -14538,7 +15691,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -14597,7 +15754,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     }
                   ]
@@ -14611,7 +15772,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -14650,7 +15815,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -14679,7 +15848,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -14706,7 +15879,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "kindString": "Class",
@@ -14726,7 +15903,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -14775,7 +15956,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     },
                     {
@@ -14783,7 +15968,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "templates",
+                          "anchor": "nothing"
+                        }
                       }
                     }
                   ]
@@ -14799,12 +15988,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "UnsafeHTMLDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "UnsafeHTMLDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -14851,7 +16049,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -14859,7 +16061,12 @@
                 "type": {
                   "type": "reference",
                   "name": "UnsafeHTMLDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "UnsafeHTMLDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -14870,7 +16077,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -14984,7 +16195,11 @@
                           "queryType": {
                             "type": "reference",
                             "name": "noChange",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "noChange"
+                            }
                           }
                         },
                         {
@@ -14992,7 +16207,11 @@
                           "queryType": {
                             "type": "reference",
                             "name": "nothing",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "templates",
+                              "anchor": "nothing"
+                            }
                           }
                         }
                       ]
@@ -15016,7 +16235,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     },
                     {
@@ -15024,7 +16247,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "templates",
+                          "anchor": "nothing"
+                        }
                       }
                     },
                     {
@@ -15045,7 +16272,11 @@
                         }
                       ],
                       "name": "TemplateResult",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "templates",
+                        "anchor": "TemplateResult"
+                      }
                     }
                   ]
                 },
@@ -15058,7 +16289,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -15097,7 +16332,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -15126,7 +16365,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -15153,13 +16396,22 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "UnsafeSVGDirective"
+            "name": "UnsafeSVGDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "UnsafeSVGDirective",
+              "excludeFromTOC": true
+            }
           }
         ],
         "kindString": "Class",
@@ -15179,7 +16431,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -15228,7 +16484,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     },
                     {
@@ -15236,7 +16496,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "templates",
+                          "anchor": "nothing"
+                        }
                       }
                     }
                   ]
@@ -15252,12 +16516,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "UnsafeSVGDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "UnsafeSVGDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -15304,7 +16577,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -15312,7 +16589,12 @@
                 "type": {
                   "type": "reference",
                   "name": "UnsafeSVGDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "UnsafeSVGDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -15323,7 +16605,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.constructor"
+              "name": "UnsafeHTMLDirective.constructor",
+              "location": {
+                "page": "directives",
+                "anchor": "UnsafeHTMLDirective.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -15356,7 +16642,11 @@
             },
             "overwrites": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.directiveName"
+              "name": "UnsafeHTMLDirective.directiveName",
+              "location": {
+                "page": "directives",
+                "anchor": "UnsafeHTMLDirective.directiveName"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -15389,7 +16679,11 @@
             },
             "overwrites": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.resultType"
+              "name": "UnsafeHTMLDirective.resultType",
+              "location": {
+                "page": "directives",
+                "anchor": "UnsafeHTMLDirective.resultType"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -15445,7 +16739,11 @@
                           "queryType": {
                             "type": "reference",
                             "name": "noChange",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "noChange"
+                            }
                           }
                         },
                         {
@@ -15453,7 +16751,11 @@
                           "queryType": {
                             "type": "reference",
                             "name": "nothing",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "templates",
+                              "anchor": "nothing"
+                            }
                           }
                         }
                       ]
@@ -15477,7 +16779,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "noChange",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "custom-directives",
+                          "anchor": "noChange"
+                        }
                       }
                     },
                     {
@@ -15485,7 +16791,11 @@
                       "queryType": {
                         "type": "reference",
                         "name": "nothing",
-                        "package": "lit-html"
+                        "package": "lit-html",
+                        "location": {
+                          "page": "templates",
+                          "anchor": "nothing"
+                        }
                       }
                     },
                     {
@@ -15506,7 +16816,11 @@
                         }
                       ],
                       "name": "TemplateResult",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "templates",
+                        "anchor": "TemplateResult"
+                      }
                     }
                   ]
                 },
@@ -15519,7 +16833,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.render"
+              "name": "UnsafeHTMLDirective.render",
+              "location": {
+                "page": "directives",
+                "anchor": "UnsafeHTMLDirective.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -15558,7 +16876,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -15587,7 +16909,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "UnsafeHTMLDirective.update"
+              "name": "UnsafeHTMLDirective.update",
+              "location": {
+                "page": "directives",
+                "anchor": "UnsafeHTMLDirective.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -15614,7 +16940,12 @@
           {
             "type": "reference",
             "name": "UnsafeHTMLDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "directives",
+              "anchor": "UnsafeHTMLDirective",
+              "excludeFromTOC": true
+            }
           }
         ],
         "kindString": "Class",
@@ -15634,7 +16965,12 @@
           {
             "type": "reference",
             "name": "UnsafeHTMLDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "directives",
+              "anchor": "UnsafeHTMLDirective",
+              "excludeFromTOC": true
+            }
           }
         ]
       },
@@ -15684,12 +17020,21 @@
                   "queryType": {
                     "type": "reference",
                     "name": "UntilDirective",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "directives",
+                      "anchor": "UntilDirective",
+                      "excludeFromTOC": true
+                    }
                   }
                 }
               ],
               "name": "DirectiveResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -15737,7 +17082,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -15745,7 +17094,12 @@
                 "type": {
                   "type": "reference",
                   "name": "UntilDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "directives",
+                    "anchor": "UntilDirective",
+                    "excludeFromTOC": true
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -15756,7 +17110,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.constructor"
+              "name": "AsyncDirective.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -15789,7 +17147,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.isConnected"
+              "name": "AsyncDirective.isConnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.isConnected"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -15838,7 +17200,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.disconnected"
+              "name": "AsyncDirective.disconnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.disconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -15884,7 +17250,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.reconnected"
+              "name": "AsyncDirective.reconnected",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.reconnected"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -15946,7 +17316,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.render"
+              "name": "AsyncDirective.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -16009,7 +17383,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AsyncDirective.setValue"
+              "name": "AsyncDirective.setValue",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.setValue"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -16048,7 +17426,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -16077,7 +17459,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AsyncDirective.update"
+              "name": "AsyncDirective.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AsyncDirective.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -16104,7 +17490,11 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           }
         ],
         "kindString": "Class",
@@ -16124,7 +17514,11 @@
           {
             "type": "reference",
             "name": "AsyncDirective",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           }
         ]
       },
@@ -16546,7 +17940,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -16554,7 +17952,11 @@
                 "type": {
                   "type": "reference",
                   "name": "AsyncDirective",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "AsyncDirective"
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -16565,7 +17967,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.constructor"
+              "name": "Directive.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -16744,7 +18150,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.render"
+              "name": "Directive.render",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.render"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -16838,7 +18248,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -16867,7 +18281,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "Directive.update"
+              "name": "Directive.update",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive.update"
+              }
             },
             "kindString": "Method",
             "entrypointSources": [
@@ -16894,21 +18312,40 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ],
         "extendedBy": [
           {
             "type": "reference",
-            "name": "AsyncReplaceDirective"
+            "name": "AsyncReplaceDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "AsyncReplaceDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "RefDirective"
+            "name": "RefDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "RefDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "UntilDirective"
+            "name": "UntilDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "UntilDirective",
+              "excludeFromTOC": true
+            }
           }
         ],
         "kindString": "Class",
@@ -16927,7 +18364,11 @@
           {
             "type": "reference",
             "name": "Directive",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           }
         ]
       },
@@ -16983,7 +18424,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "Disconnectable"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -16999,7 +18444,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -17009,7 +18458,11 @@
                 "type": {
                   "type": "reference",
                   "name": "AttributePart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "AttributePart"
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -17109,7 +18562,11 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
@@ -17256,22 +18713,38 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "BooleanAttributePart"
+            "name": "BooleanAttributePart",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "BooleanAttributePart"
+            }
           },
           {
             "type": "reference",
-            "name": "EventPart"
+            "name": "EventPart",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "EventPart"
+            }
           },
           {
             "type": "reference",
-            "name": "PropertyPart"
+            "name": "PropertyPart",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "PropertyPart"
+            }
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "Disconnectable",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "misc",
+              "anchor": "Disconnectable"
+            }
           }
         ],
         "kindString": "Class",
@@ -17339,7 +18812,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "Disconnectable"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -17355,7 +18832,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -17365,7 +18846,11 @@
                 "type": {
                   "type": "reference",
                   "name": "BooleanAttributePart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "BooleanAttributePart"
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -17376,7 +18861,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.constructor"
+              "name": "AttributePart.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -17411,7 +18900,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.element"
+              "name": "AttributePart.element",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.element"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -17444,7 +18937,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.name"
+              "name": "AttributePart.name",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.name"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -17481,13 +18978,21 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.options"
+              "name": "AttributePart.options",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.options"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -17524,7 +19029,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.strings"
+              "name": "AttributePart.strings",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.strings"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -17558,7 +19067,11 @@
             "defaultValue": "4",
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.type"
+              "name": "AttributePart.type",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.type"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -17606,7 +19119,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.tagName"
+              "name": "AttributePart.tagName",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.tagName"
+              }
             },
             "kindString": "Accessor",
             "entrypointSources": [
@@ -17633,7 +19150,11 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           }
         ],
         "kindString": "Class",
@@ -17652,7 +19173,11 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           }
         ]
       },
@@ -17716,12 +19241,20 @@
                         {
                           "type": "reference",
                           "name": "ChildPart",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "custom-directives",
+                            "anchor": "ChildPart"
+                          }
                         },
                         {
                           "type": "reference",
                           "name": "TemplateInstance",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "TemplateInstance"
+                          }
                         }
                       ]
                     },
@@ -17739,7 +19272,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -17749,7 +19286,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -17789,7 +19330,11 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
@@ -18029,14 +19574,22 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "RootPart"
+            "name": "RootPart",
+            "location": {
+              "page": "misc",
+              "anchor": "RootPart"
+            }
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "Disconnectable",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "misc",
+              "anchor": "Disconnectable"
+            }
           }
         ],
         "kindString": "Class",
@@ -18079,7 +19632,11 @@
                 "type": {
                   "type": "reference",
                   "name": "DirectiveClass",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "DirectiveClass"
+                  }
                 },
                 "kindString": "Type parameter"
               }
@@ -18156,7 +19713,11 @@
                         }
                       ],
                       "name": "DirectiveResult",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "DirectiveResult"
+                      }
                     },
                     "kindString": "Call signature"
                   }
@@ -18212,7 +19773,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -18220,7 +19785,11 @@
                 "type": {
                   "type": "reference",
                   "name": "Directive",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "Directive"
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -18319,7 +19888,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -18366,50 +19939,103 @@
         "extendedBy": [
           {
             "type": "reference",
-            "name": "AsyncDirective"
+            "name": "AsyncDirective",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AsyncDirective"
+            }
           },
           {
             "type": "reference",
-            "name": "CacheDirective"
+            "name": "CacheDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "CacheDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "ClassMapDirective"
+            "name": "ClassMapDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "ClassMapDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "GuardDirective"
+            "name": "GuardDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "GuardDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "Keyed"
+            "name": "Keyed",
+            "location": {
+              "page": "directives",
+              "anchor": "Keyed",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "LiveDirective"
+            "name": "LiveDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "LiveDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "RepeatDirective"
+            "name": "RepeatDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "RepeatDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "StyleMapDirective"
+            "name": "StyleMapDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "StyleMapDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "TemplateContentDirective"
+            "name": "TemplateContentDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "TemplateContentDirective",
+              "excludeFromTOC": true
+            }
           },
           {
             "type": "reference",
-            "name": "UnsafeHTMLDirective"
+            "name": "UnsafeHTMLDirective",
+            "location": {
+              "page": "directives",
+              "anchor": "UnsafeHTMLDirective",
+              "excludeFromTOC": true
+            }
           }
         ],
         "implementedTypes": [
           {
             "type": "reference",
             "name": "Disconnectable",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "misc",
+              "anchor": "Disconnectable"
+            }
           }
         ],
         "kindString": "Class",
@@ -18461,7 +20087,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "Disconnectable"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -18477,7 +20107,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -18487,7 +20121,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ElementPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ElementPart"
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -18552,7 +20190,11 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
@@ -18611,7 +20253,11 @@
           {
             "type": "reference",
             "name": "Disconnectable",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "misc",
+              "anchor": "Disconnectable"
+            }
           }
         ],
         "kindString": "Class",
@@ -18679,7 +20325,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "Disconnectable"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -18695,7 +20345,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -18705,7 +20359,11 @@
                 "type": {
                   "type": "reference",
                   "name": "EventPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "EventPart"
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -18716,7 +20374,11 @@
             ],
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.constructor"
+              "name": "AttributePart.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -18751,7 +20413,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.element"
+              "name": "AttributePart.element",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.element"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18784,7 +20450,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.name"
+              "name": "AttributePart.name",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.name"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18821,13 +20491,21 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.options"
+              "name": "AttributePart.options",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.options"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18864,7 +20542,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.strings"
+              "name": "AttributePart.strings",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.strings"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18898,7 +20580,11 @@
             "defaultValue": "5",
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.type"
+              "name": "AttributePart.type",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.type"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18946,7 +20632,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.tagName"
+              "name": "AttributePart.tagName",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.tagName"
+              }
             },
             "kindString": "Accessor",
             "entrypointSources": [
@@ -19022,7 +20712,11 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           }
         ],
         "kindString": "Class",
@@ -19041,7 +20735,11 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           }
         ]
       },
@@ -19244,7 +20942,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Disconnectable",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "Disconnectable"
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -19260,7 +20962,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -19270,7 +20976,11 @@
                 "type": {
                   "type": "reference",
                   "name": "PropertyPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "PropertyPart"
+                  }
                 },
                 "inheritedFrom": {
                   "type": "reference",
@@ -19281,7 +20991,11 @@
             ],
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.constructor"
+              "name": "AttributePart.constructor",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.constructor"
+              }
             },
             "kindString": "Constructor",
             "entrypointSources": [
@@ -19316,7 +21030,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.element"
+              "name": "AttributePart.element",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.element"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -19349,7 +21067,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.name"
+              "name": "AttributePart.name",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.name"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -19386,13 +21108,21 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.options"
+              "name": "AttributePart.options",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.options"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -19429,7 +21159,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.strings"
+              "name": "AttributePart.strings",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.strings"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -19463,7 +21197,11 @@
             "defaultValue": "3",
             "overwrites": {
               "type": "reference",
-              "name": "AttributePart.type"
+              "name": "AttributePart.type",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.type"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -19511,7 +21249,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "AttributePart.tagName"
+              "name": "AttributePart.tagName",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart.tagName"
+              }
             },
             "kindString": "Accessor",
             "entrypointSources": [
@@ -19538,7 +21280,11 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           }
         ],
         "kindString": "Class",
@@ -19557,7 +21303,11 @@
           {
             "type": "reference",
             "name": "AttributePart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           }
         ]
       },
@@ -19799,7 +21549,11 @@
                     "type": {
                       "type": "reference",
                       "name": "PartInfo",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "PartInfo"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -19807,7 +21561,11 @@
                 "type": {
                   "type": "reference",
                   "name": "Directive",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "Directive"
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -19864,7 +21622,11 @@
             "type": {
               "type": "reference",
               "name": "Directive",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "Directive"
+              }
             },
             "kindString": "Type parameter"
           }
@@ -19918,12 +21680,20 @@
             "type": {
               "type": "reference",
               "name": "DirectiveClass",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveClass"
+              }
             },
             "default": {
               "type": "reference",
               "name": "DirectiveClass",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "DirectiveClass"
+              }
             },
             "kindString": "Type parameter"
           }
@@ -20009,32 +21779,56 @@
             {
               "type": "reference",
               "name": "ChildPart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart"
+              }
             },
             {
               "type": "reference",
               "name": "AttributePart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePart"
+              }
             },
             {
               "type": "reference",
               "name": "PropertyPart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "PropertyPart"
+              }
             },
             {
               "type": "reference",
               "name": "BooleanAttributePart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "BooleanAttributePart"
+              }
             },
             {
               "type": "reference",
               "name": "ElementPart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ElementPart"
+              }
             },
             {
               "type": "reference",
               "name": "EventPart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "EventPart"
+              }
             }
           ]
         },
@@ -20070,17 +21864,29 @@
             {
               "type": "reference",
               "name": "ChildPartInfo",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPartInfo"
+              }
             },
             {
               "type": "reference",
               "name": "AttributePartInfo",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "AttributePartInfo"
+              }
             },
             {
               "type": "reference",
               "name": "ElementPartInfo",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ElementPartInfo"
+              }
             }
           ]
         },
@@ -20121,7 +21927,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20174,7 +21984,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20240,7 +22054,11 @@
                 {
                   "type": "reference",
                   "name": "DirectiveClass",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "DirectiveClass"
+                  }
                 }
               ]
             },
@@ -20291,7 +22109,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Parameter"
               },
@@ -20306,7 +22128,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Parameter"
               },
@@ -20321,7 +22147,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20329,7 +22159,11 @@
             "type": {
               "type": "reference",
               "name": "ChildPart",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart"
+              }
             },
             "kindString": "Call signature"
           }
@@ -20388,11 +22222,19 @@
                   {
                     "type": "reference",
                     "name": "DirectiveClass",
-                    "package": "lit-html"
+                    "package": "lit-html",
+                    "location": {
+                      "page": "custom-directives",
+                      "anchor": "DirectiveClass"
+                    }
                   }
                 ],
                 "name": "DirectiveResult",
-                "package": "lit-html"
+                "package": "lit-html",
+                "location": {
+                  "page": "custom-directives",
+                  "anchor": "DirectiveResult"
+                }
               }
             },
             "kindString": "Call signature"
@@ -20497,7 +22339,11 @@
                 "type": {
                   "type": "reference",
                   "name": "PartInfo",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "PartInfo"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20560,7 +22406,11 @@
                 "type": {
                   "type": "reference",
                   "name": "TemplateResultType",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "TemplateResultType"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20587,7 +22437,11 @@
                   }
                 ],
                 "name": "TemplateResult",
-                "package": "lit-html"
+                "package": "lit-html",
+                "location": {
+                  "page": "templates",
+                  "anchor": "TemplateResult"
+                }
               }
             },
             "kindString": "Call signature"
@@ -20636,7 +22490,11 @@
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20695,7 +22553,11 @@
                     }
                   ],
                   "name": "ChildPart",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "ChildPart"
+                  }
                 },
                 "kindString": "Type parameter"
               }
@@ -20734,7 +22596,11 @@
                 "type": {
                   "type": "reference",
                   "name": "DirectiveParent",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "DirectiveParent"
+                  }
                 },
                 "kindString": "Parameter"
               }
@@ -20787,7 +22653,11 @@
                 "type": {
                   "type": "reference",
                   "name": "Part",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "custom-directives",
+                    "anchor": "Part"
+                  }
                 },
                 "kindString": "Parameter"
               },
@@ -21002,7 +22872,11 @@
                 }
               ],
               "name": "TemplateResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "templates",
+                "anchor": "TemplateResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -21070,7 +22944,11 @@
             "type": {
               "type": "reference",
               "name": "StaticValue",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "static-html",
+                "anchor": "StaticValue"
+              }
             },
             "kindString": "Call signature"
           }
@@ -21145,7 +23023,11 @@
                 }
               ],
               "name": "TemplateResult",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "templates",
+                "anchor": "TemplateResult"
+              }
             },
             "kindString": "Call signature"
           }
@@ -21198,7 +23080,11 @@
             "type": {
               "type": "reference",
               "name": "StaticValue",
-              "package": "lit-html"
+              "package": "lit-html",
+              "location": {
+                "page": "static-html",
+                "anchor": "StaticValue"
+              }
             },
             "kindString": "Call signature"
           }
@@ -21315,7 +23201,11 @@
                                 }
                               ],
                               "name": "TemplateResult",
-                              "package": "lit-html"
+                              "package": "lit-html",
+                              "location": {
+                                "page": "templates",
+                                "anchor": "TemplateResult"
+                              }
                             },
                             "kindString": "Call signature"
                           }
@@ -21380,7 +23270,11 @@
                                 {
                                   "tag": "@linkcode",
                                   "text": "html",
-                                  "tsLinkText": ""
+                                  "tsLinkText": "",
+                                  "location": {
+                                    "page": "templates",
+                                    "anchor": "html"
+                                  }
                                 },
                                 {
                                   "text": " tag function.\n\nIn LitElement usage, it's invalid to return an SVG fragment from the\n"
@@ -21439,7 +23333,11 @@
                                 }
                               ],
                               "name": "TemplateResult",
-                              "package": "lit-html"
+                              "package": "lit-html",
+                              "location": {
+                                "page": "templates",
+                                "anchor": "TemplateResult"
+                              }
                             },
                             "kindString": "Call signature"
                           }
@@ -21506,7 +23404,11 @@
                         }
                       ],
                       "name": "TemplateResult",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "templates",
+                        "anchor": "TemplateResult"
+                      }
                     },
                     "kindString": "Call signature"
                   }
@@ -21885,7 +23787,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ReactiveController",
-                      "package": "@lit/reactive-element"
+                      "package": "@lit/reactive-element",
+                      "location": {
+                        "page": "controllers",
+                        "anchor": "ReactiveController"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -21937,7 +23843,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ReactiveController",
-                      "package": "@lit/reactive-element"
+                      "package": "@lit/reactive-element",
+                      "location": {
+                        "page": "controllers",
+                        "anchor": "ReactiveController"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -22014,7 +23924,11 @@
         "implementedBy": [
           {
             "type": "reference",
-            "name": "ReactiveElement"
+            "name": "ReactiveElement",
+            "location": {
+              "page": "ReactiveElement",
+              "anchor": "ReactiveElement"
+            }
           }
         ],
         "kindString": "Interface",
@@ -22056,7 +23970,11 @@
         "type": {
           "type": "reference",
           "name": "ComplexAttributeConverter",
-          "package": "@lit/reactive-element"
+          "package": "@lit/reactive-element",
+          "location": {
+            "page": "ReactiveElement",
+            "anchor": "ComplexAttributeConverter"
+          }
         },
         "kindString": "Variable",
         "entrypointSources": [
@@ -22232,7 +24150,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -22268,7 +24190,11 @@
                         {
                           "type": "reference",
                           "name": "ChildPart",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "custom-directives",
+                            "anchor": "ChildPart"
+                          }
                         }
                       ]
                     },
@@ -22434,7 +24360,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -22600,7 +24530,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -22818,7 +24752,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -22956,7 +24894,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -22992,7 +24934,11 @@
                         {
                           "type": "reference",
                           "name": "Disconnectable",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "Disconnectable"
+                          }
                         }
                       ]
                     },
@@ -23168,7 +25114,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -23204,7 +25154,11 @@
                         {
                           "type": "reference",
                           "name": "Disconnectable",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "Disconnectable"
+                          }
                         }
                       ]
                     },
@@ -23371,7 +25325,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -23510,7 +25468,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -23650,7 +25612,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -23827,7 +25793,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -23856,7 +25826,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -23959,7 +25933,11 @@
                     "type": {
                       "type": "reference",
                       "name": "Part",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "Part"
+                      }
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -23986,7 +25964,11 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "TemplateInstance"
+                      }
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -24145,7 +26127,11 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "TemplateInstance"
+                      }
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -24205,7 +26191,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -24243,7 +26233,11 @@
                           {
                             "type": "reference",
                             "name": "Part",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "Part"
+                            }
                           }
                         ]
                       }
@@ -24281,7 +26275,11 @@
                         {
                           "type": "reference",
                           "name": "CompiledTemplate",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "CompiledTemplate"
+                          }
                         }
                       ]
                     },
@@ -24390,7 +26388,11 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "TemplateInstance"
+                      }
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -24450,7 +26452,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -24488,7 +26494,11 @@
                           {
                             "type": "reference",
                             "name": "Part",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "Part"
+                            }
                           }
                         ]
                       }
@@ -24526,7 +26536,11 @@
                         {
                           "type": "reference",
                           "name": "CompiledTemplate",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "CompiledTemplate"
+                          }
                         }
                       ]
                     },
@@ -24770,7 +26784,11 @@
                     "type": {
                       "type": "reference",
                       "name": "TemplateInstance",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "TemplateInstance"
+                      }
                     },
                     "kindString": "Property",
                     "entrypointSources": [
@@ -24830,7 +26848,11 @@
                         {
                           "type": "reference",
                           "name": "RenderOptions",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "LitElement",
+                            "anchor": "RenderOptions"
+                          }
                         }
                       ]
                     },
@@ -24868,7 +26890,11 @@
                           {
                             "type": "reference",
                             "name": "Part",
-                            "package": "lit-html"
+                            "package": "lit-html",
+                            "location": {
+                              "page": "custom-directives",
+                              "anchor": "Part"
+                            }
                           }
                         ]
                       }
@@ -24906,7 +26932,11 @@
                         {
                           "type": "reference",
                           "name": "CompiledTemplate",
-                          "package": "lit-html"
+                          "package": "lit-html",
+                          "location": {
+                            "page": "misc",
+                            "anchor": "CompiledTemplate"
+                          }
                         }
                       ]
                     },
@@ -24989,49 +27019,81 @@
                       "type": "reference",
                       "name": "CommitNothingToChildEntry",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitNothingToChildEntry"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitNothingToChildEntry",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitText",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitText"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitText",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitText"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitNode",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitNode"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitNode",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitNode"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitAttribute",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitAttribute"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitAttribute",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitAttribute"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitProperty",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitProperty"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitProperty",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitProperty"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitBooleanAttribute",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitBooleanAttribute"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitBooleanAttribute",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitEventListener",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitEventListener"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitEventListener",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitEventListener"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitToElementBinding",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitToElementBinding"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitToElementBinding",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
+                      }
                     }
                   ]
                 },
@@ -25064,49 +27126,81 @@
                       "type": "reference",
                       "name": "TemplatePrep",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.TemplatePrep"
+                      "qualifiedName": "LitUnstable.DebugLog.TemplatePrep",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplatePrep"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "TemplateInstantiated",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.TemplateInstantiated"
+                      "qualifiedName": "LitUnstable.DebugLog.TemplateInstantiated",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "TemplateInstantiatedAndUpdated",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
+                      "qualifiedName": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "TemplateUpdating",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.TemplateUpdating"
+                      "qualifiedName": "LitUnstable.DebugLog.TemplateUpdating",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.TemplateUpdating"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "BeginRender",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.BeginRender"
+                      "qualifiedName": "LitUnstable.DebugLog.BeginRender",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.BeginRender"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "EndRender",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.EndRender"
+                      "qualifiedName": "LitUnstable.DebugLog.EndRender",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.EndRender"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "CommitPartEntry",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.CommitPartEntry"
+                      "qualifiedName": "LitUnstable.DebugLog.CommitPartEntry",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.CommitPartEntry"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "SetPartValue",
                       "package": "lit-html",
-                      "qualifiedName": "LitUnstable.DebugLog.SetPartValue"
+                      "qualifiedName": "LitUnstable.DebugLog.SetPartValue",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.SetPartValue"
+                      }
                     }
                   ]
                 },
@@ -25301,7 +27395,11 @@
                   "type": "reference",
                   "name": "Update",
                   "package": "@lit/reactive-element",
-                  "qualifiedName": "ReactiveUnstable.DebugLog.Update"
+                  "qualifiedName": "ReactiveUnstable.DebugLog.Update",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "ReactiveUnstable.DebugLog.Update"
+                  }
                 },
                 "kindString": "Type alias",
                 "entrypointSources": [
@@ -25396,7 +27494,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ChildPart",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "custom-directives",
+                        "anchor": "ChildPart"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -25404,7 +27506,11 @@
                 "type": {
                   "type": "reference",
                   "name": "TemplateInstance",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "TemplateInstance"
+                  }
                 },
                 "kindString": "Constructor signature"
               }
@@ -25476,7 +27582,11 @@
           {
             "type": "reference",
             "name": "Disconnectable",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "misc",
+              "anchor": "Disconnectable"
+            }
           }
         ],
         "kindString": "Class",
@@ -25521,12 +27631,20 @@
                     {
                       "type": "reference",
                       "name": "LitUnstable.DebugLog.Entry",
-                      "package": "lit-html"
+                      "package": "lit-html",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "LitUnstable.DebugLog.Entry"
+                      }
                     },
                     {
                       "type": "reference",
                       "name": "ReactiveUnstable.DebugLog.Entry",
-                      "package": "@lit/reactive-element"
+                      "package": "@lit/reactive-element",
+                      "location": {
+                        "page": "misc",
+                        "anchor": "ReactiveUnstable.DebugLog.Entry"
+                      }
                     }
                   ]
                 },
@@ -25824,23 +27942,43 @@
         "implementedBy": [
           {
             "type": "reference",
-            "name": "AttributePart"
+            "name": "AttributePart",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "AttributePart"
+            }
           },
           {
             "type": "reference",
-            "name": "ChildPart"
+            "name": "ChildPart",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "ChildPart"
+            }
           },
           {
             "type": "reference",
-            "name": "Directive"
+            "name": "Directive",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "Directive"
+            }
           },
           {
             "type": "reference",
-            "name": "ElementPart"
+            "name": "ElementPart",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "ElementPart"
+            }
           },
           {
             "type": "reference",
-            "name": "TemplateInstance"
+            "name": "TemplateInstance",
+            "location": {
+              "page": "misc",
+              "anchor": "TemplateInstance"
+            }
           }
         ],
         "kindString": "Interface",
@@ -25934,7 +28072,11 @@
             }
           ],
           "name": "TemplateResult",
-          "package": "lit-html"
+          "package": "lit-html",
+          "location": {
+            "page": "templates",
+            "anchor": "TemplateResult"
+          }
         },
         "kindString": "Type alias",
         "entrypointSources": [
@@ -25977,7 +28119,11 @@
                     "type": {
                       "type": "reference",
                       "name": "ReactiveElement",
-                      "package": "@lit/reactive-element"
+                      "package": "@lit/reactive-element",
+                      "location": {
+                        "page": "ReactiveElement",
+                        "anchor": "ReactiveElement"
+                      }
                     },
                     "kindString": "Parameter"
                   }
@@ -26330,7 +28476,11 @@
                     }
                   ],
                   "name": "PropertyValueMap",
-                  "package": "@lit/reactive-element"
+                  "package": "@lit/reactive-element",
+                  "location": {
+                    "page": "misc",
+                    "anchor": "PropertyValueMap"
+                  }
                 },
                 "overwrites": {
                   "type": "reference",
@@ -26447,13 +28597,21 @@
                 {
                   "type": "reference",
                   "name": "RenderOptions",
-                  "package": "lit-html"
+                  "package": "lit-html",
+                  "location": {
+                    "page": "LitElement",
+                    "anchor": "RenderOptions"
+                  }
                 }
               ]
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.options"
+              "name": "ChildPart.options",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart.options"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -26487,7 +28645,11 @@
             "defaultValue": "2",
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.type"
+              "name": "ChildPart.type",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart.type"
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -26561,7 +28723,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.endNode"
+              "name": "ChildPart.endNode",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart.endNode"
+              }
             },
             "kindString": "Accessor",
             "entrypointSources": [
@@ -26619,7 +28785,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.parentNode"
+              "name": "ChildPart.parentNode",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart.parentNode"
+              }
             },
             "kindString": "Accessor",
             "entrypointSources": [
@@ -26693,7 +28863,11 @@
             },
             "inheritedFrom": {
               "type": "reference",
-              "name": "ChildPart.startNode"
+              "name": "ChildPart.startNode",
+              "location": {
+                "page": "custom-directives",
+                "anchor": "ChildPart.startNode"
+              }
             },
             "kindString": "Accessor",
             "entrypointSources": [
@@ -26775,7 +28949,11 @@
           {
             "type": "reference",
             "name": "ChildPart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "ChildPart"
+            }
           }
         ],
         "kindString": "Interface",
@@ -26794,7 +28972,11 @@
           {
             "type": "reference",
             "name": "ChildPart",
-            "package": "lit-html"
+            "package": "lit-html",
+            "location": {
+              "page": "custom-directives",
+              "anchor": "ChildPart"
+            }
           }
         ]
       },

--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -28,6 +28,7 @@
             "package": "@lit/reactive-element"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -35,7 +36,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "LitElement",
           "anchor": "LitElement"
@@ -80,7 +80,8 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "string"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "_old",
@@ -96,7 +97,8 @@
                               "name": "string"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "value",
@@ -112,7 +114,8 @@
                               "name": "string"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -122,13 +125,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.attributeChangedCallback"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.attributeChangedCallback"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -136,7 +141,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.attributeChangedCallback"
@@ -195,12 +199,14 @@
                   "inheritedFrom": {
                     "type": "reference",
                     "name": "ReactiveElement.observedAttributes"
-                  }
+                  },
+                  "kindString": "Get signature"
                 },
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.observedAttributes"
                 },
+                "kindString": "Accessor",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -208,7 +214,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Accessor",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.observedAttributes"
@@ -249,7 +254,8 @@
                           "type": "reference",
                           "name": "ReactiveController",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -259,13 +265,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.addController"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.addController"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -273,7 +281,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.addController"
@@ -307,7 +314,8 @@
                           "type": "reference",
                           "name": "ReactiveController",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -317,13 +325,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.removeController"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.removeController"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -331,7 +341,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.removeController"
@@ -400,21 +409,25 @@
                               "type": "reference",
                               "name": "WarningKind",
                               "package": "@lit/reactive-element"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "intrinsic",
                           "name": "void"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
                 },
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.disableWarning"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -422,7 +435,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.disableWarning"
@@ -462,6 +474,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.enabledWarnings"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -469,7 +482,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.enabledWarnings"
@@ -532,21 +544,25 @@
                               "type": "reference",
                               "name": "WarningKind",
                               "package": "@lit/reactive-element"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "intrinsic",
                           "name": "void"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
                 },
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.enableWarning"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -554,7 +570,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.enableWarning"
@@ -595,13 +610,15 @@
                     "overwrites": {
                       "type": "reference",
                       "name": "ReactiveElement.connectedCallback"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
                   "name": "ReactiveElement.connectedCallback"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -609,7 +626,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.connectedCallback"
@@ -644,13 +660,15 @@
                     "overwrites": {
                       "type": "reference",
                       "name": "ReactiveElement.disconnectedCallback"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
                   "name": "ReactiveElement.disconnectedCallback"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -658,7 +676,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.disconnectedCallback"
@@ -707,7 +724,8 @@
                           "type": "reference",
                           "name": "Initializer",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -717,13 +735,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.addInitializer"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.addInitializer"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -731,7 +751,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.addInitializer"
@@ -774,13 +793,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.finalize"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.finalize"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -788,7 +809,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.finalize"
@@ -819,6 +839,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.finalized"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -826,7 +847,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.finalized"
@@ -875,7 +895,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "options",
@@ -896,7 +917,8 @@
                           ],
                           "name": "PropertyDeclaration",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -906,13 +928,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.createProperty"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.createProperty"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -920,7 +944,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.createProperty"
@@ -955,6 +978,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.elementProperties"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -962,7 +986,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.elementProperties"
@@ -1006,7 +1029,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "key",
@@ -1022,7 +1046,8 @@
                               "name": "symbol"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "options",
@@ -1040,7 +1065,8 @@
                           ],
                           "name": "PropertyDeclaration",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -1060,13 +1086,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.getPropertyDescriptor"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.getPropertyDescriptor"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1074,7 +1102,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.getPropertyDescriptor"
@@ -1120,7 +1147,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -1141,13 +1169,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.getPropertyOptions"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.getPropertyOptions"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1155,7 +1185,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.getPropertyOptions"
@@ -1191,6 +1220,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.properties"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1198,7 +1228,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.properties"
@@ -1249,13 +1278,15 @@
                     "overwrites": {
                       "type": "reference",
                       "name": "ReactiveElement.createRenderRoot"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
                   "name": "ReactiveElement.createRenderRoot"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1263,7 +1294,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.createRenderRoot"
@@ -1296,9 +1326,11 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1306,7 +1338,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.render"
@@ -1329,6 +1360,7 @@
                   "name": "RenderOptions",
                   "package": "lit-html"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1336,7 +1368,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.renderOptions"
@@ -1376,6 +1407,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.renderRoot"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1383,7 +1415,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.renderRoot"
@@ -1419,6 +1450,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.shadowRootOptions"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1426,7 +1458,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.shadowRootOptions"
@@ -1470,6 +1501,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.elementStyles"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1477,7 +1509,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.elementStyles"
@@ -1524,7 +1555,8 @@
                           "type": "reference",
                           "name": "CSSResultGroup",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -1538,13 +1570,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.finalizeStyles"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.finalizeStyles"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1552,7 +1586,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.finalizeStyles"
@@ -1589,6 +1622,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.styles"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1596,7 +1630,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.styles"
@@ -1638,7 +1671,8 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "boolean"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -1648,13 +1682,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.enableUpdating"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.enableUpdating"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1662,7 +1698,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.enableUpdating"
@@ -1730,7 +1765,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -1740,13 +1776,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.firstUpdated"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.firstUpdated"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1754,7 +1792,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.firstUpdated"
@@ -1809,13 +1846,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.getUpdateComplete"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.getUpdateComplete"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1823,7 +1862,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.getUpdateComplete"
@@ -1849,6 +1887,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.hasUpdated"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1856,7 +1895,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.hasUpdated"
@@ -1882,6 +1920,7 @@
                   "type": "reference",
                   "name": "ReactiveElement.isUpdatePending"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1889,7 +1928,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.isUpdatePending"
@@ -1943,13 +1981,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.performUpdate"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.performUpdate"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -1957,7 +1997,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.performUpdate"
@@ -1997,7 +2036,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "oldValue",
@@ -2010,7 +2050,8 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "unknown"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "options",
@@ -2034,7 +2075,8 @@
                           ],
                           "name": "PropertyDeclaration",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -2044,13 +2086,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.requestUpdate"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.requestUpdate"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2058,7 +2102,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.requestUpdate"
@@ -2112,13 +2155,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.scheduleUpdate"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.scheduleUpdate"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2126,7 +2171,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.scheduleUpdate"
@@ -2193,7 +2237,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -2203,13 +2248,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.shouldUpdate"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.shouldUpdate"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2217,7 +2264,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.shouldUpdate"
@@ -2284,7 +2330,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -2294,13 +2341,15 @@
                     "overwrites": {
                       "type": "reference",
                       "name": "ReactiveElement.update"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "overwrites": {
                   "type": "reference",
                   "name": "ReactiveElement.update"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2308,7 +2357,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.update"
@@ -2384,12 +2432,14 @@
                   "inheritedFrom": {
                     "type": "reference",
                     "name": "ReactiveElement.updateComplete"
-                  }
+                  },
+                  "kindString": "Get signature"
                 },
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.updateComplete"
                 },
+                "kindString": "Accessor",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2397,7 +2447,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Accessor",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.updateComplete"
@@ -2465,7 +2514,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -2475,13 +2525,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.updated"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.updated"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2489,7 +2541,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.updated"
@@ -2554,7 +2605,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -2564,13 +2616,15 @@
                     "inheritedFrom": {
                       "type": "reference",
                       "name": "ReactiveElement.willUpdate"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "ReactiveElement.willUpdate"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2578,7 +2632,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "LitElement",
                   "anchor": "LitElement.willUpdate"
@@ -2638,7 +2691,8 @@
                               "type": "reference",
                               "name": "Node",
                               "package": "typescript"
-                            }
+                            },
+                            "kindString": "Parameter"
                           },
                           {
                             "name": "deep",
@@ -2648,16 +2702,19 @@
                             "type": {
                               "type": "intrinsic",
                               "name": "boolean"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "reference",
                           "name": "Node",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Method"
                   }
                 ],
                 "sources": [
@@ -2665,9 +2722,11 @@
                     "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
                     "line": 299
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -2675,7 +2734,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.creationScope"
@@ -2700,6 +2758,7 @@
               "type": "intrinsic",
               "name": "object"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -2707,7 +2766,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.host"
@@ -2732,6 +2790,7 @@
               "type": "intrinsic",
               "name": "boolean"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -2739,7 +2798,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.isConnected"
@@ -2774,6 +2832,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -2781,7 +2840,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "LitElement",
               "anchor": "RenderOptions.renderBefore"
@@ -2795,6 +2853,7 @@
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -2802,7 +2861,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "LitElement",
           "anchor": "RenderOptions"
@@ -2859,6 +2917,7 @@
             "package": "@lit/reactive-element"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -2866,7 +2925,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "ReactiveElement",
           "anchor": "ReactiveElement"
@@ -2911,7 +2969,8 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "string"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "_old",
@@ -2927,7 +2986,8 @@
                               "name": "string"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "value",
@@ -2943,15 +3003,18 @@
                               "name": "string"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -2959,7 +3022,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.attributeChangedCallback"
@@ -3014,8 +3076,10 @@
                       "type": "intrinsic",
                       "name": "string"
                     }
-                  }
+                  },
+                  "kindString": "Get signature"
                 },
+                "kindString": "Accessor",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3023,7 +3087,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Accessor",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.observedAttributes"
@@ -3064,7 +3127,8 @@
                           "type": "reference",
                           "name": "ReactiveController",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -3074,13 +3138,15 @@
                     "implementationOf": {
                       "type": "reference",
                       "name": "ReactiveControllerHost.addController"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "implementationOf": {
                   "type": "reference",
                   "name": "ReactiveControllerHost.addController"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3088,7 +3154,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.addController"
@@ -3122,7 +3187,8 @@
                           "type": "reference",
                           "name": "ReactiveController",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -3132,13 +3198,15 @@
                     "implementationOf": {
                       "type": "reference",
                       "name": "ReactiveControllerHost.removeController"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "implementationOf": {
                   "type": "reference",
                   "name": "ReactiveControllerHost.removeController"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3146,7 +3214,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.removeController"
@@ -3215,17 +3282,21 @@
                               "type": "reference",
                               "name": "WarningKind",
                               "package": "@lit/reactive-element"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "intrinsic",
                           "name": "void"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3233,7 +3304,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.disableWarning"
@@ -3269,6 +3339,7 @@
                     "package": "@lit/reactive-element"
                   }
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3276,7 +3347,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.enabledWarnings"
@@ -3339,17 +3409,21 @@
                               "type": "reference",
                               "name": "WarningKind",
                               "package": "@lit/reactive-element"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "intrinsic",
                           "name": "void"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3357,7 +3431,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.enableWarning"
@@ -3393,9 +3466,11 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3403,7 +3478,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.connectedCallback"
@@ -3433,9 +3507,11 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3443,7 +3519,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.disconnectedCallback"
@@ -3492,15 +3567,18 @@
                           "type": "reference",
                           "name": "Initializer",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3508,7 +3586,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.addInitializer"
@@ -3547,9 +3624,11 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "boolean"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3557,7 +3636,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.finalize"
@@ -3583,6 +3661,7 @@
                   "type": "intrinsic",
                   "name": "boolean"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3590,7 +3669,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.finalized"
@@ -3639,7 +3717,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "options",
@@ -3660,15 +3739,18 @@
                           ],
                           "name": "PropertyDeclaration",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3676,7 +3758,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.createProperty"
@@ -3707,6 +3788,7 @@
                   "name": "PropertyDeclarationMap",
                   "package": "@lit/reactive-element"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3714,7 +3796,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.elementProperties"
@@ -3758,7 +3839,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "key",
@@ -3774,7 +3856,8 @@
                               "name": "symbol"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "options",
@@ -3792,7 +3875,8 @@
                           ],
                           "name": "PropertyDeclaration",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -3808,9 +3892,11 @@
                           "package": "typescript"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3818,7 +3904,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.getPropertyDescriptor"
@@ -3864,7 +3949,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -3881,9 +3967,11 @@
                       ],
                       "name": "PropertyDeclaration",
                       "package": "@lit/reactive-element"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3891,7 +3979,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.getPropertyOptions"
@@ -3923,6 +4010,7 @@
                   "name": "PropertyDeclarations",
                   "package": "@lit/reactive-element"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -3930,7 +4018,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.properties"
@@ -3990,9 +4077,11 @@
                           "package": "typescript"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4000,7 +4089,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.createRenderRoot"
@@ -4036,6 +4124,7 @@
                     }
                   ]
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4043,7 +4132,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.renderRoot"
@@ -4075,6 +4163,7 @@
                   "name": "ShadowRootInit",
                   "package": "typescript"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4082,7 +4171,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.shadowRootOptions"
@@ -4122,6 +4210,7 @@
                     "package": "@lit/reactive-element"
                   }
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4129,7 +4218,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.elementStyles"
@@ -4176,7 +4264,8 @@
                           "type": "reference",
                           "name": "CSSResultGroup",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -4186,9 +4275,11 @@
                         "name": "CSSResultOrNative",
                         "package": "@lit/reactive-element"
                       }
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4196,7 +4287,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.finalizeStyles"
@@ -4229,6 +4319,7 @@
                   "name": "CSSResultGroup",
                   "package": "@lit/reactive-element"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4236,7 +4327,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.styles"
@@ -4278,15 +4368,18 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "boolean"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4294,7 +4387,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.enableUpdating"
@@ -4362,15 +4454,18 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4378,7 +4473,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.firstUpdated"
@@ -4429,9 +4523,11 @@
                       ],
                       "name": "Promise",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4439,7 +4535,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.getUpdateComplete"
@@ -4461,6 +4556,7 @@
                   "type": "intrinsic",
                   "name": "boolean"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4468,7 +4564,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.hasUpdated"
@@ -4490,6 +4585,7 @@
                   "type": "intrinsic",
                   "name": "boolean"
                 },
+                "kindString": "Property",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4497,7 +4593,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Property",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.isUpdatePending"
@@ -4547,9 +4642,11 @@
                           "package": "typescript"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4557,7 +4654,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.performUpdate"
@@ -4597,7 +4693,8 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "oldValue",
@@ -4610,7 +4707,8 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "unknown"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "options",
@@ -4634,7 +4732,8 @@
                           ],
                           "name": "PropertyDeclaration",
                           "package": "@lit/reactive-element"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -4644,13 +4743,15 @@
                     "implementationOf": {
                       "type": "reference",
                       "name": "ReactiveControllerHost.requestUpdate"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
                 "implementationOf": {
                   "type": "reference",
                   "name": "ReactiveControllerHost.requestUpdate"
                 },
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4658,7 +4759,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.requestUpdate"
@@ -4708,9 +4808,11 @@
                           "package": "typescript"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4718,7 +4820,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.scheduleUpdate"
@@ -4785,15 +4886,18 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "boolean"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4801,7 +4905,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.shouldUpdate"
@@ -4868,15 +4971,18 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4884,7 +4990,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.update"
@@ -4960,12 +5065,14 @@
                   "implementationOf": {
                     "type": "reference",
                     "name": "ReactiveControllerHost.updateComplete"
-                  }
+                  },
+                  "kindString": "Get signature"
                 },
                 "implementationOf": {
                   "type": "reference",
                   "name": "ReactiveControllerHost.updateComplete"
                 },
+                "kindString": "Accessor",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -4973,7 +5080,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Accessor",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.updateComplete"
@@ -5041,15 +5147,18 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -5057,7 +5166,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.updated"
@@ -5122,15 +5230,18 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
                 ],
+                "kindString": "Method",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -5138,7 +5249,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Method",
                 "location": {
                   "page": "ReactiveElement",
                   "anchor": "ReactiveElement.willUpdate"
@@ -5168,6 +5278,7 @@
             "package": "@lit/reactive-element"
           }
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5175,7 +5286,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "ReactiveElement",
           "anchor": "UpdatingElement"
@@ -5226,7 +5336,8 @@
                           "name": "string"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "type",
@@ -5236,15 +5347,18 @@
                     "type": {
                       "type": "reference",
                       "name": "TypeHint"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "Type"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5252,7 +5366,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "ReactiveElement",
               "anchor": "ComplexAttributeConverter.fromAttribute"
@@ -5289,7 +5402,8 @@
                     "type": {
                       "type": "reference",
                       "name": "Type"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "type",
@@ -5299,15 +5413,18 @@
                     "type": {
                       "type": "reference",
                       "name": "TypeHint"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5315,7 +5432,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "ReactiveElement",
               "anchor": "ComplexAttributeConverter.toAttribute"
@@ -5335,16 +5451,19 @@
             "default": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Type parameter"
           },
           {
             "name": "TypeHint",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5352,7 +5471,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "ReactiveElement",
           "anchor": "ComplexAttributeConverter"
@@ -5393,6 +5511,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5400,7 +5519,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.attribute"
@@ -5437,6 +5555,7 @@
               "name": "AttributeConverter",
               "package": "@lit/reactive-element"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5444,7 +5563,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.converter"
@@ -5470,6 +5588,7 @@
               "type": "intrinsic",
               "name": "boolean"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5477,7 +5596,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.noAccessor"
@@ -5503,6 +5621,7 @@
               "type": "intrinsic",
               "name": "boolean"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5510,7 +5629,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.reflect"
@@ -5536,6 +5654,7 @@
               "type": "intrinsic",
               "name": "boolean"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5543,7 +5662,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.state"
@@ -5569,6 +5687,7 @@
               "type": "reference",
               "name": "TypeHint"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5576,7 +5695,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.type"
@@ -5612,22 +5730,26 @@
                     "type": {
                       "type": "reference",
                       "name": "Type"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "oldValue",
                     "type": {
                       "type": "reference",
                       "name": "Type"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "boolean"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -5635,7 +5757,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "ReactiveElement",
               "anchor": "PropertyDeclaration.hasChanged"
@@ -5655,16 +5776,19 @@
             "default": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Type parameter"
           },
           {
             "name": "TypeHint",
             "default": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5672,7 +5796,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyDeclaration"
@@ -5704,15 +5827,18 @@
               "type": {
                 "type": "intrinsic",
                 "name": "string"
-              }
+              },
+              "kindString": "Parameter"
             }
           ],
           "type": {
             "type": "reference",
             "name": "PropertyDeclaration",
             "package": "@lit/reactive-element"
-          }
+          },
+          "kindString": "Index signature"
         },
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5720,7 +5846,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyDeclarations"
@@ -5745,7 +5870,8 @@
             "default": {
               "type": "intrinsic",
               "name": "any"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
         "type": {
@@ -5786,6 +5912,7 @@
             "package": "typescript"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5793,7 +5920,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "ReactiveElement",
           "anchor": "PropertyValues"
@@ -5839,7 +5965,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "values",
@@ -5852,7 +5979,8 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -5865,9 +5993,11 @@
               ],
               "name": "TemplateResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5875,7 +6005,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "templates",
           "anchor": "html"
@@ -5901,6 +6030,7 @@
           "type": "typeOperator",
           "operator": "unique"
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -5908,7 +6038,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "templates",
           "anchor": "nothing"
@@ -5956,7 +6085,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "container",
@@ -5977,7 +6107,8 @@
                       "package": "typescript"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "options",
@@ -5991,16 +6122,19 @@
                   "type": "reference",
                   "name": "RenderOptions",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "RootPart",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6008,7 +6142,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "templates",
           "anchor": "render"
@@ -6043,7 +6176,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "values",
@@ -6056,7 +6190,8 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -6069,9 +6204,11 @@
               ],
               "name": "TemplateResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6079,7 +6216,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "templates",
           "anchor": "svg"
@@ -6145,7 +6281,8 @@
                       "type": "reference",
                       "name": "Node",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "name",
@@ -6155,7 +6292,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "type",
@@ -6174,18 +6312,22 @@
                           "value": "attribute"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "ValueSanitizer",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Call signature"
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6193,7 +6335,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "templates",
           "anchor": "SanitizerFactory"
@@ -6223,6 +6364,7 @@
           "name": "TemplateResult",
           "package": "lit-html"
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6230,7 +6372,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "templates",
           "anchor": "SVGTemplateResult"
@@ -6261,7 +6402,8 @@
               "type": "reference",
               "name": "ResultType",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
         "type": {
@@ -6280,7 +6422,8 @@
                 "type": {
                   "type": "reference",
                   "name": "T"
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "strings",
@@ -6294,7 +6437,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "values",
@@ -6310,7 +6454,8 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Property"
               }
             ],
             "sources": [
@@ -6318,9 +6463,11 @@
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/lit-html.d.ts",
                 "line": 198
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6328,7 +6475,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "templates",
           "anchor": "TemplateResult"
@@ -6373,7 +6519,8 @@
                   "type": "reference",
                   "name": "ShadowRoot",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "styles",
@@ -6384,15 +6531,18 @@
                     "name": "CSSResultOrNative",
                     "package": "@lit/reactive-element"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "void"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6400,7 +6550,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "adoptStyles"
@@ -6435,7 +6584,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "values",
@@ -6458,16 +6608,19 @@
                       }
                     ]
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "CSSResult",
               "package": "@lit/reactive-element"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6475,7 +6628,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "css"
@@ -6504,6 +6656,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -6511,7 +6664,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "styles",
               "anchor": "CSSResult.cssText"
@@ -6561,8 +6713,10 @@
                     "package": "typescript"
                   }
                 ]
-              }
+              },
+              "kindString": "Get signature"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -6570,7 +6724,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "styles",
               "anchor": "CSSResult.styleSheet"
@@ -6597,9 +6750,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -6607,7 +6762,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "styles",
               "anchor": "CSSResult.toString"
@@ -6621,6 +6775,7 @@
             "moduleSpecifier": "reactive-element/css-tag.js"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6628,7 +6783,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "styles",
           "anchor": "CSSResult"
@@ -6659,16 +6813,19 @@
                   "type": "reference",
                   "name": "CSSResultOrNative",
                   "package": "@lit/reactive-element"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "CSSResultOrNative",
               "package": "@lit/reactive-element"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6676,7 +6833,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "getCompatibleStyle"
@@ -6701,6 +6857,7 @@
           "type": "intrinsic",
           "name": "boolean"
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6708,7 +6865,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "styles",
           "anchor": "supportsAdoptingStyleSheets"
@@ -6742,16 +6898,19 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "CSSResult",
               "package": "@lit/reactive-element"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6759,7 +6918,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "styles",
           "anchor": "unsafeCSS"
@@ -6792,6 +6950,7 @@
             ]
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6799,7 +6958,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "styles",
           "anchor": "CSSResultArray"
@@ -6832,6 +6990,7 @@
             }
           ]
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6839,7 +6998,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "styles",
           "anchor": "CSSResultGroup"
@@ -6873,6 +7031,7 @@
             }
           ]
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -6880,7 +7039,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "styles",
           "anchor": "CSSResultOrNative"
@@ -6928,7 +7086,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -6967,19 +7126,24 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -6987,7 +7151,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "customElement"
@@ -7025,7 +7188,8 @@
                   "type": "reference",
                   "name": "AddEventListenerOptions",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7058,7 +7222,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7069,19 +7234,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7089,7 +7259,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "eventOptions"
@@ -7142,7 +7311,8 @@
                   ],
                   "name": "PropertyDeclaration",
                   "package": "@lit/reactive-element"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7175,7 +7345,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7186,19 +7357,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7206,7 +7382,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "property"
@@ -7242,7 +7417,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "cache",
@@ -7256,7 +7432,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "boolean"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7289,7 +7466,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7300,19 +7478,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7320,7 +7503,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "query"
@@ -7357,7 +7539,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7390,7 +7573,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7401,19 +7585,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7421,7 +7610,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAll"
@@ -7459,7 +7647,8 @@
                   "type": "reference",
                   "name": "QueryAssignedElementsOptions",
                   "package": "@lit/reactive-element"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7492,7 +7681,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7503,19 +7693,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7523,7 +7718,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAssignedElements"
@@ -7566,14 +7760,16 @@
                   "type": "reference",
                   "name": "QueryAssignedNodesOptions",
                   "package": "@lit/reactive-element"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "TSDecoratorReturnType",
               "package": "@lit/reactive-element"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "queryAssignedNodes",
@@ -7645,7 +7841,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "flatten",
@@ -7658,7 +7855,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "boolean"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "selector",
@@ -7671,16 +7869,19 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "TSDecoratorReturnType",
               "package": "@lit/reactive-element"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7688,7 +7889,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAssignedNodes"
@@ -7725,7 +7925,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7758,7 +7959,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7769,19 +7971,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7789,7 +7996,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "queryAsync"
@@ -7833,7 +8039,8 @@
                   ],
                   "name": "InternalPropertyDeclaration",
                   "package": "@lit/reactive-element"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -7866,7 +8073,8 @@
                               "package": "@lit/reactive-element"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "name",
@@ -7877,19 +8085,24 @@
                           "type": "reference",
                           "name": "PropertyKey",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "any"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -7897,7 +8110,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "decorators",
           "anchor": "state"
@@ -7948,22 +8160,26 @@
                     "type": {
                       "type": "reference",
                       "name": "Type"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "oldValue",
                     "type": {
                       "type": "reference",
                       "name": "Type"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "boolean"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
@@ -7971,7 +8187,6 @@
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "decorators",
               "anchor": "InternalPropertyDeclaration.hasChanged"
@@ -7991,9 +8206,11 @@
             "default": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -8001,7 +8218,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "decorators",
           "anchor": "InternalPropertyDeclaration"
@@ -8032,6 +8248,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
@@ -8039,7 +8256,6 @@
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "decorators",
               "anchor": "QueryAssignedElementsOptions.selector"
@@ -8068,6 +8284,7 @@
               "type": "reference",
               "name": "QueryAssignedNodesOptions.slot"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
@@ -8075,7 +8292,6 @@
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "decorators",
               "anchor": "QueryAssignedElementsOptions.slot"
@@ -8096,6 +8312,7 @@
             "package": "@lit/reactive-element"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -8103,7 +8320,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "decorators",
           "anchor": "QueryAssignedElementsOptions"
@@ -8141,6 +8357,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/decorators.ts",
@@ -8148,7 +8365,6 @@
                 "moduleSpecifier": "lit/decorators.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "decorators",
               "anchor": "QueryAssignedNodesOptions.slot"
@@ -8175,6 +8391,7 @@
             "name": "QueryAssignedElementsOptions"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/decorators.ts",
@@ -8182,7 +8399,6 @@
             "moduleSpecifier": "lit/decorators.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "decorators",
           "anchor": "QueryAssignedNodesOptions"
@@ -8244,7 +8460,8 @@
                   ],
                   "name": "AsyncIterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "_mapper",
@@ -8276,7 +8493,8 @@
                             "type": {
                               "type": "intrinsic",
                               "name": "unknown"
-                            }
+                            },
+                            "kindString": "Parameter"
                           },
                           {
                             "name": "index",
@@ -8286,17 +8504,21 @@
                             "type": {
                               "type": "intrinsic",
                               "name": "number"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "intrinsic",
                           "name": "unknown"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -8313,9 +8535,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8323,7 +8547,6 @@
             "moduleSpecifier": "lit/directives/async-append.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "asyncAppend"
@@ -8360,7 +8583,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -8371,13 +8595,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncReplaceDirective.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8385,7 +8611,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.constructor"
@@ -8411,6 +8636,7 @@
               "type": "reference",
               "name": "AsyncReplaceDirective.isConnected"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8418,7 +8644,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.isConnected"
@@ -8451,14 +8676,16 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "index",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -8468,13 +8695,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.commitValue"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncReplaceDirective.commitValue"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8482,7 +8711,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.commitValue"
@@ -8516,13 +8744,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.disconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncReplaceDirective.disconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8530,7 +8760,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.disconnected"
@@ -8561,13 +8790,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.reconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncReplaceDirective.reconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8575,7 +8806,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.reconnected"
@@ -8601,7 +8831,8 @@
                 ],
                 "typeParameter": [
                   {
-                    "name": "T"
+                    "name": "T",
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -8617,7 +8848,8 @@
                       ],
                       "name": "AsyncIterable",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "_mapper",
@@ -8634,7 +8866,8 @@
                       ],
                       "name": "Mapper",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -8644,13 +8877,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncReplaceDirective.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8658,7 +8893,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.render"
@@ -8695,7 +8929,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -8705,13 +8940,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.setValue"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncReplaceDirective.setValue"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8719,7 +8956,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.setValue"
@@ -8750,7 +8986,8 @@
                       "type": "reference",
                       "name": "ChildPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "params",
@@ -8790,7 +9027,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -8813,13 +9051,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncReplaceDirective.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncReplaceDirective.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8827,7 +9067,6 @@
                 "moduleSpecifier": "lit/directives/async-append.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncAppendDirective.update"
@@ -8848,6 +9087,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-append.ts",
@@ -8855,7 +9095,6 @@
             "moduleSpecifier": "lit/directives/async-append.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "AsyncAppendDirective",
@@ -8907,7 +9146,8 @@
                   ],
                   "name": "AsyncIterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "_mapper",
@@ -8924,7 +9164,8 @@
                   ],
                   "name": "Mapper",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -8941,9 +9182,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -8951,7 +9194,6 @@
             "moduleSpecifier": "lit/directives/async-replace.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "asyncReplace"
@@ -8988,7 +9230,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -8999,13 +9242,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncDirective.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncDirective.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9013,7 +9258,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.constructor"
@@ -9039,6 +9283,7 @@
               "type": "reference",
               "name": "AsyncDirective.isConnected"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9046,7 +9291,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.isConnected"
@@ -9079,22 +9323,26 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "_index",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9102,7 +9350,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.commitValue"
@@ -9136,13 +9383,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.disconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.disconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9150,7 +9399,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.disconnected"
@@ -9181,13 +9429,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.reconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.reconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9195,7 +9445,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.reconnected"
@@ -9221,7 +9470,8 @@
                 ],
                 "typeParameter": [
                   {
-                    "name": "T"
+                    "name": "T",
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -9237,7 +9487,8 @@
                       ],
                       "name": "AsyncIterable",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "_mapper",
@@ -9254,7 +9505,8 @@
                       ],
                       "name": "Mapper",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -9264,13 +9516,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9278,7 +9532,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.render"
@@ -9315,7 +9568,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -9325,13 +9579,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncDirective.setValue"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncDirective.setValue"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9339,7 +9595,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.setValue"
@@ -9370,7 +9625,8 @@
                       "type": "reference",
                       "name": "ChildPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -9410,7 +9666,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -9433,13 +9690,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9447,7 +9706,6 @@
                 "moduleSpecifier": "lit/directives/async-replace.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "AsyncReplaceDirective.update"
@@ -9474,6 +9732,7 @@
             "name": "AsyncAppendDirective"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/async-replace.ts",
@@ -9481,7 +9740,6 @@
             "moduleSpecifier": "lit/directives/async-replace.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "AsyncReplaceDirective",
@@ -9523,7 +9781,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -9540,9 +9799,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/cache.ts",
@@ -9550,7 +9811,6 @@
             "moduleSpecifier": "lit/directives/cache.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "cache"
@@ -9586,7 +9846,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -9597,13 +9858,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/cache.ts",
@@ -9611,7 +9874,6 @@
                 "moduleSpecifier": "lit/directives/cache.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "CacheDirective.constructor"
@@ -9641,7 +9903,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -9654,13 +9917,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/cache.ts",
@@ -9668,7 +9933,6 @@
                 "moduleSpecifier": "lit/directives/cache.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "CacheDirective.render"
@@ -9699,7 +9963,8 @@
                       "type": "reference",
                       "name": "ChildPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -9716,7 +9981,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -9729,13 +9995,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/cache.ts",
@@ -9743,7 +10011,6 @@
                 "moduleSpecifier": "lit/directives/cache.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "CacheDirective.update"
@@ -9764,6 +10031,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/cache.ts",
@@ -9771,7 +10039,6 @@
             "moduleSpecifier": "lit/directives/cache.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "CacheDirective",
@@ -9819,10 +10086,12 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               },
               {
-                "name": "V"
+                "name": "V",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -9831,7 +10100,8 @@
                 "type": {
                   "type": "reference",
                   "name": "T"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "cases",
@@ -9866,14 +10136,17 @@
                               "type": {
                                 "type": "reference",
                                 "name": "V"
-                              }
+                              },
+                              "kindString": "Call signature"
                             }
-                          ]
+                          ],
+                          "kindString": "Type literal"
                         }
                       }
                     ]
                   }
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "defaultCase",
@@ -9902,11 +10175,14 @@
                         "type": {
                           "type": "reference",
                           "name": "V"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -9921,9 +10197,11 @@
                   "name": "V"
                 }
               ]
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/choose.ts",
@@ -9931,7 +10209,6 @@
             "moduleSpecifier": "lit/directives/choose.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "choose"
@@ -9966,7 +10243,8 @@
                   "type": "reference",
                   "name": "ClassInfo",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -9983,9 +10261,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/class-map.ts",
@@ -9993,7 +10273,6 @@
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "classMap"
@@ -10029,7 +10308,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -10040,13 +10320,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/class-map.ts",
@@ -10054,7 +10336,6 @@
                 "moduleSpecifier": "lit/directives/class-map.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "ClassMapDirective.constructor"
@@ -10085,7 +10366,8 @@
                       "type": "reference",
                       "name": "ClassInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -10095,13 +10377,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/class-map.ts",
@@ -10109,7 +10393,6 @@
                 "moduleSpecifier": "lit/directives/class-map.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "ClassMapDirective.render"
@@ -10140,7 +10423,8 @@
                       "type": "reference",
                       "name": "AttributePart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -10158,7 +10442,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -10181,13 +10466,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/class-map.ts",
@@ -10195,7 +10482,6 @@
                 "moduleSpecifier": "lit/directives/class-map.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "ClassMapDirective.update"
@@ -10216,6 +10502,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/class-map.ts",
@@ -10223,7 +10510,6 @@
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "ClassMapDirective",
@@ -10263,7 +10549,8 @@
               "type": {
                 "type": "intrinsic",
                 "name": "string"
-              }
+              },
+              "kindString": "Parameter"
             }
           ],
           "type": {
@@ -10282,8 +10569,10 @@
                 "name": "number"
               }
             ]
-          }
+          },
+          "kindString": "Index signature"
         },
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/class-map.ts",
@@ -10291,7 +10580,6 @@
             "moduleSpecifier": "lit/directives/class-map.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "directives",
           "anchor": "ClassInfo",
@@ -10326,7 +10614,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "f",
@@ -10355,11 +10644,14 @@
                         "type": {
                           "type": "intrinsic",
                           "name": "unknown"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -10376,9 +10668,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/guard.ts",
@@ -10386,7 +10680,6 @@
             "moduleSpecifier": "lit/directives/guard.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "guard"
@@ -10422,7 +10715,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -10433,13 +10727,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/guard.ts",
@@ -10447,7 +10743,6 @@
                 "moduleSpecifier": "lit/directives/guard.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "GuardDirective.constructor"
@@ -10477,7 +10772,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "f",
@@ -10503,11 +10799,14 @@
                             "type": {
                               "type": "intrinsic",
                               "name": "unknown"
-                            }
+                            },
+                            "kindString": "Call signature"
                           }
-                        ]
+                        ],
+                        "kindString": "Type literal"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -10517,13 +10816,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/guard.ts",
@@ -10531,7 +10832,6 @@
                 "moduleSpecifier": "lit/directives/guard.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "GuardDirective.render"
@@ -10562,7 +10862,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -10604,14 +10905,17 @@
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "unknown"
-                                  }
+                                  },
+                                  "kindString": "Call signature"
                                 }
-                              ]
+                              ],
+                              "kindString": "Type literal"
                             }
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -10621,13 +10925,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/guard.ts",
@@ -10635,7 +10941,6 @@
                 "moduleSpecifier": "lit/directives/guard.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "GuardDirective.update"
@@ -10656,6 +10961,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/guard.ts",
@@ -10663,7 +10969,6 @@
             "moduleSpecifier": "lit/directives/guard.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "GuardDirective",
@@ -10701,7 +11006,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -10710,7 +11016,8 @@
                 "type": {
                   "type": "reference",
                   "name": "T"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -10736,9 +11043,11 @@
                   "package": "typescript"
                 }
               ]
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/if-defined.ts",
@@ -10746,7 +11055,6 @@
             "moduleSpecifier": "lit/directives/if-defined.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "ifDefined"
@@ -10790,10 +11098,12 @@
             ],
             "typeParameter": [
               {
-                "name": "I"
+                "name": "I",
+                "kindString": "Type parameter"
               },
               {
-                "name": "J"
+                "name": "J",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -10818,7 +11128,8 @@
                       "package": "typescript"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "joiner",
@@ -10847,17 +11158,21 @@
                             "type": {
                               "type": "intrinsic",
                               "name": "number"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "reference",
                           "name": "J"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -10879,7 +11194,8 @@
               ],
               "name": "Iterable",
               "package": "typescript"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "join",
@@ -10891,10 +11207,12 @@
             ],
             "typeParameter": [
               {
-                "name": "I"
+                "name": "I",
+                "kindString": "Type parameter"
               },
               {
-                "name": "J"
+                "name": "J",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -10919,14 +11237,16 @@
                       "package": "typescript"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "joiner",
                 "type": {
                   "type": "reference",
                   "name": "J"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -10948,9 +11268,11 @@
               ],
               "name": "Iterable",
               "package": "typescript"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/join.ts",
@@ -10958,7 +11280,6 @@
             "moduleSpecifier": "lit/directives/join.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "join"
@@ -10992,14 +11313,16 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "v",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -11016,9 +11339,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/keyed.ts",
@@ -11026,7 +11351,6 @@
             "moduleSpecifier": "lit/directives/keyed.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "keyed"
@@ -11062,7 +11386,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -11073,13 +11398,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
@@ -11087,7 +11414,6 @@
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "Keyed.constructor"
@@ -11106,6 +11432,7 @@
               "type": "intrinsic",
               "name": "unknown"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
@@ -11113,7 +11440,6 @@
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "Keyed.key"
@@ -11143,14 +11469,16 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "v",
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -11160,13 +11488,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
@@ -11174,7 +11504,6 @@
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "Keyed.render"
@@ -11205,7 +11534,8 @@
                       "type": "reference",
                       "name": "ChildPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -11231,7 +11561,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -11241,13 +11572,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/keyed.ts",
@@ -11255,7 +11588,6 @@
                 "moduleSpecifier": "lit/directives/keyed.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "Keyed.update"
@@ -11276,6 +11608,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/keyed.ts",
@@ -11283,7 +11616,6 @@
             "moduleSpecifier": "lit/directives/keyed.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "Keyed",
@@ -11325,7 +11657,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -11342,9 +11675,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/live.ts",
@@ -11352,7 +11687,6 @@
             "moduleSpecifier": "lit/directives/live.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "live"
@@ -11388,7 +11722,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -11399,13 +11734,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/live.ts",
@@ -11413,7 +11750,6 @@
                 "moduleSpecifier": "lit/directives/live.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "LiveDirective.constructor"
@@ -11443,7 +11779,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -11453,13 +11790,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/live.ts",
@@ -11467,7 +11806,6 @@
                 "moduleSpecifier": "lit/directives/live.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "LiveDirective.render"
@@ -11498,7 +11836,8 @@
                       "type": "reference",
                       "name": "AttributePart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -11515,7 +11854,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -11525,13 +11865,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/live.ts",
@@ -11539,7 +11881,6 @@
                 "moduleSpecifier": "lit/directives/live.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "LiveDirective.update"
@@ -11560,6 +11901,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/live.ts",
@@ -11567,7 +11909,6 @@
             "moduleSpecifier": "lit/directives/live.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "LiveDirective",
@@ -11614,7 +11955,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -11639,7 +11981,8 @@
                       "package": "typescript"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "f",
@@ -11668,24 +12011,29 @@
                             "type": {
                               "type": "reference",
                               "name": "T"
-                            }
+                            },
+                            "kindString": "Parameter"
                           },
                           {
                             "name": "index",
                             "type": {
                               "type": "intrinsic",
                               "name": "number"
-                            }
+                            },
+                            "kindString": "Parameter"
                           }
                         ],
                         "type": {
                           "type": "intrinsic",
                           "name": "unknown"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -11706,9 +12054,11 @@
               ],
               "name": "Generator",
               "package": "typescript"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/map.ts",
@@ -11716,7 +12066,6 @@
             "moduleSpecifier": "lit/directives/map.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "map"
@@ -11765,7 +12114,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -11778,7 +12128,8 @@
               ],
               "name": "Iterable",
               "package": "typescript"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "range",
@@ -11794,14 +12145,16 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "end",
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "step",
@@ -11811,7 +12164,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "number"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -11824,9 +12178,11 @@
               ],
               "name": "Iterable",
               "package": "typescript"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/range.ts",
@@ -11834,7 +12190,6 @@
             "moduleSpecifier": "lit/directives/range.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "range"
@@ -11868,7 +12223,8 @@
                   "type": "reference",
                   "name": "Element",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Type parameter"
               }
             ],
             "type": {
@@ -11881,9 +12237,11 @@
               ],
               "name": "Ref",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
@@ -11891,7 +12249,6 @@
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "createRef"
@@ -11926,7 +12283,8 @@
                   "type": "reference",
                   "name": "RefOrCallback",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -11943,9 +12301,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
@@ -11953,7 +12313,6 @@
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "ref"
@@ -11977,7 +12336,8 @@
                       "type": "reference",
                       "name": "Element",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Type parameter"
                   }
                 ],
                 "type": {
@@ -11990,9 +12350,11 @@
                   ],
                   "name": "Ref",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12000,7 +12362,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "Ref.constructor"
@@ -12026,6 +12387,7 @@
               "type": "reference",
               "name": "T"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12033,7 +12395,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "Ref.value"
@@ -12054,9 +12415,11 @@
               "type": "reference",
               "name": "Element",
               "package": "typescript"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
@@ -12064,7 +12427,6 @@
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "Ref",
@@ -12102,7 +12464,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -12113,13 +12476,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncDirective.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncDirective.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12127,7 +12492,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.constructor"
@@ -12153,6 +12517,7 @@
               "type": "reference",
               "name": "AsyncDirective.isConnected"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12160,7 +12525,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.isConnected"
@@ -12194,13 +12558,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.disconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.disconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12208,7 +12574,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.disconnected"
@@ -12239,13 +12604,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.reconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.reconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12253,7 +12620,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.reconnected"
@@ -12284,7 +12650,8 @@
                       "type": "reference",
                       "name": "RefOrCallback",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -12294,13 +12661,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12308,7 +12677,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.render"
@@ -12345,7 +12713,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -12355,13 +12724,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncDirective.setValue"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncDirective.setValue"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12369,7 +12740,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.setValue"
@@ -12400,7 +12770,8 @@
                       "type": "reference",
                       "name": "ElementPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -12418,7 +12789,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -12428,13 +12800,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/ref.ts",
@@ -12442,7 +12816,6 @@
                 "moduleSpecifier": "lit/directives/ref.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RefDirective.update"
@@ -12463,6 +12836,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
@@ -12470,7 +12844,6 @@
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "RefDirective",
@@ -12530,19 +12903,23 @@
                               "name": "undefined"
                             }
                           ]
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
                       "type": "intrinsic",
                       "name": "void"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
             }
           ]
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/ref.ts",
@@ -12550,7 +12927,6 @@
             "moduleSpecifier": "lit/directives/ref.js"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "directives",
           "anchor": "RefOrCallback",
@@ -12581,7 +12957,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -12597,7 +12974,8 @@
                   ],
                   "name": "Iterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "keyFnOrTemplate",
@@ -12627,7 +13005,8 @@
                       "package": "lit-html"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "template",
@@ -12644,13 +13023,15 @@
                   ],
                   "name": "ItemTemplate",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "repeat",
@@ -12666,7 +13047,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -12682,7 +13064,8 @@
                   ],
                   "name": "Iterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "template",
@@ -12696,13 +13079,15 @@
                   ],
                   "name": "ItemTemplate",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "repeat",
@@ -12718,7 +13103,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -12734,7 +13120,8 @@
                   ],
                   "name": "Iterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "keyFn",
@@ -12764,7 +13151,8 @@
                       "package": "lit-html"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "template",
@@ -12778,15 +13166,18 @@
                   ],
                   "name": "ItemTemplate",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
@@ -12794,7 +13185,6 @@
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "repeat"
@@ -12830,7 +13220,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -12841,13 +13232,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/repeat.ts",
@@ -12855,7 +13248,6 @@
                 "moduleSpecifier": "lit/directives/repeat.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "RepeatDirective.constructor"
@@ -12886,7 +13278,8 @@
                 ],
                 "typeParameter": [
                   {
-                    "name": "T"
+                    "name": "T",
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -12902,7 +13295,8 @@
                       ],
                       "name": "Iterable",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "template",
@@ -12916,7 +13310,8 @@
                       ],
                       "name": "ItemTemplate",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -12929,7 +13324,8 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               },
               {
                 "name": "render",
@@ -12941,7 +13337,8 @@
                 ],
                 "typeParameter": [
                   {
-                    "name": "T"
+                    "name": "T",
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -12957,7 +13354,8 @@
                       ],
                       "name": "Iterable",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "keyFn",
@@ -12987,7 +13385,8 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "template",
@@ -13001,7 +13400,8 @@
                       ],
                       "name": "ItemTemplate",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -13014,13 +13414,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/repeat.ts",
@@ -13028,7 +13430,6 @@
                 "moduleSpecifier": "lit/directives/repeat.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RepeatDirective.render"
@@ -13054,7 +13455,8 @@
                 ],
                 "typeParameter": [
                   {
-                    "name": "T"
+                    "name": "T",
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -13064,7 +13466,8 @@
                       "type": "reference",
                       "name": "ChildPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -13121,7 +13524,8 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -13147,13 +13551,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/repeat.ts",
@@ -13161,7 +13567,6 @@
                 "moduleSpecifier": "lit/directives/repeat.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "RepeatDirective.update"
@@ -13182,6 +13587,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
@@ -13189,7 +13595,6 @@
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "RepeatDirective",
@@ -13214,7 +13619,8 @@
         ],
         "typeParameters": [
           {
-            "name": "T"
+            "name": "T",
+            "kindString": "Type parameter"
           }
         ],
         "type": {
@@ -13236,24 +13642,29 @@
                     "type": {
                       "type": "reference",
                       "name": "T"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "index",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Call signature"
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
@@ -13261,7 +13672,6 @@
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "directives",
           "anchor": "ItemTemplate",
@@ -13279,7 +13689,8 @@
         ],
         "typeParameters": [
           {
-            "name": "T"
+            "name": "T",
+            "kindString": "Type parameter"
           }
         ],
         "type": {
@@ -13301,24 +13712,29 @@
                     "type": {
                       "type": "reference",
                       "name": "T"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "index",
                     "type": {
                       "type": "intrinsic",
                       "name": "number"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Call signature"
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
@@ -13326,7 +13742,6 @@
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "directives",
           "anchor": "KeyFn",
@@ -13353,7 +13768,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -13369,7 +13785,8 @@
                   ],
                   "name": "Iterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "keyFnOrTemplate",
@@ -13399,7 +13816,8 @@
                       "package": "lit-html"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "template",
@@ -13416,13 +13834,15 @@
                   ],
                   "name": "ItemTemplate",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "RepeatDirectiveFn",
@@ -13434,7 +13854,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -13450,7 +13871,8 @@
                   ],
                   "name": "Iterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "template",
@@ -13464,13 +13886,15 @@
                   ],
                   "name": "ItemTemplate",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "RepeatDirectiveFn",
@@ -13482,7 +13906,8 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -13498,7 +13923,8 @@
                   ],
                   "name": "Iterable",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "keyFn",
@@ -13528,7 +13954,8 @@
                       "package": "lit-html"
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "template",
@@ -13542,15 +13969,18 @@
                   ],
                   "name": "ItemTemplate",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/repeat.ts",
@@ -13558,7 +13988,6 @@
             "moduleSpecifier": "lit/directives/repeat.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "directives",
           "anchor": "RepeatDirectiveFn",
@@ -13612,7 +14041,8 @@
                   ],
                   "name": "Readonly",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -13629,9 +14059,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/style-map.ts",
@@ -13639,7 +14071,6 @@
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "styleMap"
@@ -13675,7 +14106,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -13686,13 +14118,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/style-map.ts",
@@ -13700,7 +14134,6 @@
                 "moduleSpecifier": "lit/directives/style-map.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "StyleMapDirective.constructor"
@@ -13738,7 +14171,8 @@
                       ],
                       "name": "Readonly",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -13748,13 +14182,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/style-map.ts",
@@ -13762,7 +14198,6 @@
                 "moduleSpecifier": "lit/directives/style-map.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "StyleMapDirective.render"
@@ -13793,7 +14228,8 @@
                       "type": "reference",
                       "name": "AttributePart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "__namedParameters",
@@ -13818,7 +14254,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -13841,13 +14278,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/style-map.ts",
@@ -13855,7 +14294,6 @@
                 "moduleSpecifier": "lit/directives/style-map.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "StyleMapDirective.update"
@@ -13876,6 +14314,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/style-map.ts",
@@ -13883,7 +14322,6 @@
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "StyleMapDirective",
@@ -13924,7 +14362,8 @@
               "type": {
                 "type": "intrinsic",
                 "name": "string"
-              }
+              },
+              "kindString": "Parameter"
             }
           ],
           "type": {
@@ -13947,8 +14386,10 @@
                 "value": null
               }
             ]
-          }
+          },
+          "kindString": "Index signature"
         },
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/style-map.ts",
@@ -13956,7 +14397,6 @@
             "moduleSpecifier": "lit/directives/style-map.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "directives",
           "anchor": "StyleInfo",
@@ -13992,7 +14432,8 @@
                   "type": "reference",
                   "name": "HTMLTemplateElement",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -14009,9 +14450,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/template-content.ts",
@@ -14019,7 +14462,6 @@
             "moduleSpecifier": "lit/directives/template-content.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "templateContent"
@@ -14055,7 +14497,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14066,13 +14509,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/template-content.ts",
@@ -14080,7 +14525,6 @@
                 "moduleSpecifier": "lit/directives/template-content.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "TemplateContentDirective.constructor"
@@ -14111,7 +14555,8 @@
                       "type": "reference",
                       "name": "HTMLTemplateElement",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14135,13 +14580,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/template-content.ts",
@@ -14149,7 +14596,6 @@
                 "moduleSpecifier": "lit/directives/template-content.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "TemplateContentDirective.render"
@@ -14180,7 +14626,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "props",
@@ -14190,7 +14637,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14200,13 +14648,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/template-content.ts",
@@ -14214,7 +14664,6 @@
                 "moduleSpecifier": "lit/directives/template-content.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "TemplateContentDirective.update"
@@ -14235,6 +14684,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/template-content.ts",
@@ -14242,7 +14692,6 @@
             "moduleSpecifier": "lit/directives/template-content.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "TemplateContentDirective",
@@ -14313,7 +14762,8 @@
                       }
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -14330,9 +14780,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14340,7 +14792,6 @@
             "moduleSpecifier": "lit/directives/unsafe-html.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "unsafeHTML"
@@ -14376,7 +14827,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14387,13 +14839,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14401,7 +14855,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.constructor"
@@ -14423,6 +14876,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14430,7 +14884,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.directiveName"
@@ -14452,6 +14905,7 @@
               "type": "intrinsic",
               "name": "number"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14459,7 +14913,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.resultType"
@@ -14518,7 +14971,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14573,13 +15027,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14587,7 +15043,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.render"
@@ -14618,7 +15073,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "props",
@@ -14628,7 +15084,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14638,13 +15095,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14652,7 +15111,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-html.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeHTMLDirective.update"
@@ -14679,6 +15137,7 @@
             "name": "UnsafeSVGDirective"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-html.ts",
@@ -14686,7 +15145,6 @@
             "moduleSpecifier": "lit/directives/unsafe-html.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "UnsafeHTMLDirective",
@@ -14757,7 +15215,8 @@
                       }
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -14774,9 +15233,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -14784,7 +15245,6 @@
             "moduleSpecifier": "lit/directives/unsafe-svg.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "unsafeSVG"
@@ -14820,7 +15280,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -14831,13 +15292,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "UnsafeHTMLDirective.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "UnsafeHTMLDirective.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -14845,7 +15308,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.constructor"
@@ -14871,6 +15333,7 @@
               "type": "reference",
               "name": "UnsafeHTMLDirective.directiveName"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -14878,7 +15341,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.directiveName"
@@ -14904,6 +15366,7 @@
               "type": "reference",
               "name": "UnsafeHTMLDirective.resultType"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -14911,7 +15374,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.resultType"
@@ -14970,7 +15432,8 @@
                           }
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -15025,13 +15488,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "UnsafeHTMLDirective.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "UnsafeHTMLDirective.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -15039,7 +15504,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.render"
@@ -15070,7 +15534,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "props",
@@ -15080,7 +15545,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -15090,13 +15556,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "UnsafeHTMLDirective.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "UnsafeHTMLDirective.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -15104,7 +15572,6 @@
                 "moduleSpecifier": "lit/directives/unsafe-svg.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UnsafeSVGDirective.update"
@@ -15125,6 +15592,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/unsafe-svg.ts",
@@ -15132,7 +15600,6 @@
             "moduleSpecifier": "lit/directives/unsafe-svg.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "UnsafeSVGDirective",
@@ -15180,7 +15647,8 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -15197,9 +15665,11 @@
               ],
               "name": "DirectiveResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/until.ts",
@@ -15207,7 +15677,6 @@
             "moduleSpecifier": "lit/directives/until.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "until"
@@ -15244,7 +15713,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -15255,13 +15725,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncDirective.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncDirective.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15269,7 +15741,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.constructor"
@@ -15295,6 +15766,7 @@
               "type": "reference",
               "name": "AsyncDirective.isConnected"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15302,7 +15774,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.isConnected"
@@ -15336,13 +15807,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.disconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.disconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15350,7 +15823,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.disconnected"
@@ -15381,13 +15853,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.reconnected"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.reconnected"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15395,7 +15869,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.reconnected"
@@ -15431,7 +15904,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -15441,13 +15915,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15455,7 +15931,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.render"
@@ -15492,7 +15967,8 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -15502,13 +15978,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AsyncDirective.setValue"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AsyncDirective.setValue"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15516,7 +15994,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.setValue"
@@ -15547,7 +16024,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "args",
@@ -15557,7 +16035,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -15567,13 +16046,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AsyncDirective.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AsyncDirective.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/directives/until.ts",
@@ -15581,7 +16062,6 @@
                 "moduleSpecifier": "lit/directives/until.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "directives",
               "anchor": "UntilDirective.update"
@@ -15602,6 +16082,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/until.ts",
@@ -15609,7 +16090,6 @@
             "moduleSpecifier": "lit/directives/until.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "directives",
           "anchor": "UntilDirective",
@@ -15667,10 +16147,12 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               },
               {
-                "name": "F"
+                "name": "F",
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -15679,7 +16161,8 @@
                 "type": {
                   "type": "literal",
                   "value": true
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "trueCase",
@@ -15705,11 +16188,14 @@
                         "type": {
                           "type": "reference",
                           "name": "T"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "falseCase",
@@ -15738,17 +16224,21 @@
                         "type": {
                           "type": "reference",
                           "name": "F"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "T"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "when",
@@ -15760,14 +16250,16 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               },
               {
                 "name": "F",
                 "default": {
                   "type": "intrinsic",
                   "name": "undefined"
-                }
+                },
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -15776,7 +16268,8 @@
                 "type": {
                   "type": "literal",
                   "value": false
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "trueCase",
@@ -15802,11 +16295,14 @@
                         "type": {
                           "type": "reference",
                           "name": "T"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "falseCase",
@@ -15835,17 +16331,21 @@
                         "type": {
                           "type": "reference",
                           "name": "F"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "F"
-            }
+            },
+            "kindString": "Call signature"
           },
           {
             "name": "when",
@@ -15857,14 +16357,16 @@
             ],
             "typeParameter": [
               {
-                "name": "T"
+                "name": "T",
+                "kindString": "Type parameter"
               },
               {
                 "name": "F",
                 "default": {
                   "type": "intrinsic",
                   "name": "undefined"
-                }
+                },
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -15873,7 +16375,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "trueCase",
@@ -15899,11 +16402,14 @@
                         "type": {
                           "type": "reference",
                           "name": "T"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "falseCase",
@@ -15932,11 +16438,14 @@
                         "type": {
                           "type": "reference",
                           "name": "F"
-                        }
+                        },
+                        "kindString": "Call signature"
                       }
-                    ]
+                    ],
+                    "kindString": "Type literal"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -15951,9 +16460,11 @@
                   "name": "F"
                 }
               ]
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directives/when.ts",
@@ -15961,7 +16472,6 @@
             "moduleSpecifier": "lit/directives/when.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "directives",
           "anchor": "when"
@@ -16012,7 +16522,8 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -16023,13 +16534,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16037,7 +16550,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.constructor"
@@ -16059,6 +16571,7 @@
               "type": "intrinsic",
               "name": "boolean"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16066,7 +16579,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.isConnected"
@@ -16099,9 +16611,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16109,7 +16623,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.disconnected"
@@ -16139,9 +16652,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16149,7 +16664,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.reconnected"
@@ -16188,7 +16702,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -16198,13 +16713,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.render"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.render"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16212,7 +16729,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.render"
@@ -16249,15 +16765,18 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16265,7 +16784,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.setValue"
@@ -16296,7 +16814,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "props",
@@ -16306,7 +16825,8 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -16316,13 +16836,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "Directive.update"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "Directive.update"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16330,7 +16852,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "AsyncDirective.update"
@@ -16365,6 +16886,7 @@
             "name": "UntilDirective"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -16372,7 +16894,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "AsyncDirective"
@@ -16412,21 +16933,24 @@
                       "type": "reference",
                       "name": "HTMLElement",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "name",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -16434,7 +16958,8 @@
                       "type": "reference",
                       "name": "Disconnectable",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "options",
@@ -16451,16 +16976,19 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "AttributePart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16468,7 +16996,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.constructor"
@@ -16491,6 +17018,7 @@
               "name": "HTMLElement",
               "package": "typescript"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16498,7 +17026,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.element"
@@ -16520,6 +17047,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16527,7 +17055,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.name"
@@ -16559,6 +17086,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16566,7 +17094,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.options"
@@ -16592,6 +17119,7 @@
               "type": "typeOperator",
               "operator": "readonly"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16599,7 +17127,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.strings"
@@ -16638,6 +17165,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16645,7 +17173,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.type"
@@ -16675,8 +17202,10 @@
               "type": {
                 "type": "intrinsic",
                 "name": "string"
-              }
+              },
+              "kindString": "Get signature"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16684,7 +17213,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePart.tagName"
@@ -16719,6 +17247,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -16726,7 +17255,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "AttributePart"
@@ -16759,21 +17287,24 @@
                       "type": "reference",
                       "name": "HTMLElement",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "name",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -16781,7 +17312,8 @@
                       "type": "reference",
                       "name": "Disconnectable",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "options",
@@ -16798,7 +17330,8 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -16809,13 +17342,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AttributePart.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AttributePart.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16823,7 +17358,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.constructor"
@@ -16850,6 +17384,7 @@
               "type": "reference",
               "name": "AttributePart.element"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16857,7 +17392,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.element"
@@ -16883,6 +17417,7 @@
               "type": "reference",
               "name": "AttributePart.name"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16890,7 +17425,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.name"
@@ -16926,6 +17460,7 @@
               "type": "reference",
               "name": "AttributePart.options"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16933,7 +17468,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.options"
@@ -16963,6 +17497,7 @@
               "type": "reference",
               "name": "AttributePart.strings"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -16970,7 +17505,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.strings"
@@ -16997,6 +17531,7 @@
               "type": "reference",
               "name": "AttributePart.type"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17004,7 +17539,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.type"
@@ -17038,12 +17572,14 @@
               "inheritedFrom": {
                 "type": "reference",
                 "name": "AttributePart.tagName"
-              }
+              },
+              "kindString": "Get signature"
             },
             "inheritedFrom": {
               "type": "reference",
               "name": "AttributePart.tagName"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17051,7 +17587,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "BooleanAttributePart.tagName"
@@ -17072,6 +17607,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -17079,7 +17615,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "BooleanAttributePart"
@@ -17119,7 +17654,8 @@
                       "type": "reference",
                       "name": "ChildNode",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "endNode",
@@ -17136,7 +17672,8 @@
                           "package": "typescript"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -17158,7 +17695,8 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "options",
@@ -17175,16 +17713,19 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17192,7 +17733,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.constructor"
@@ -17224,6 +17764,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17231,7 +17772,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.options"
@@ -17254,6 +17794,7 @@
               "value": 2
             },
             "defaultValue": "2",
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17261,7 +17802,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.type"
@@ -17317,8 +17857,10 @@
                     "package": "typescript"
                   }
                 ]
-              }
+              },
+              "kindString": "Get signature"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17326,7 +17868,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.endNode"
@@ -17366,8 +17907,10 @@
                 "type": "reference",
                 "name": "Node",
                 "package": "typescript"
-              }
+              },
+              "kindString": "Get signature"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17375,7 +17918,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.parentNode"
@@ -17431,8 +17973,10 @@
                     "package": "typescript"
                   }
                 ]
-              }
+              },
+              "kindString": "Get signature"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17440,7 +17984,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPart.startNode"
@@ -17467,6 +18010,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -17474,7 +18018,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "ChildPart"
@@ -17508,7 +18051,8 @@
                   "type": "reference",
                   "name": "DirectiveClass",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -17517,7 +18061,8 @@
                 "type": {
                   "type": "reference",
                   "name": "C"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -17569,7 +18114,8 @@
                           ],
                           "name": "Parameters",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -17582,13 +18128,17 @@
                       ],
                       "name": "DirectiveResult",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -17596,7 +18146,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "directive"
@@ -17635,16 +18184,19 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "Directive",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17652,7 +18204,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "Directive.constructor"
@@ -17691,15 +18242,18 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17707,7 +18261,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "Directive.render"
@@ -17738,7 +18291,8 @@
                       "type": "reference",
                       "name": "Part",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "props",
@@ -17748,15 +18302,18 @@
                         "type": "intrinsic",
                         "name": "unknown"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17764,7 +18321,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "Directive.update"
@@ -17827,6 +18383,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -17834,7 +18391,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "Directive"
@@ -17867,7 +18423,8 @@
                       "type": "reference",
                       "name": "Element",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -17875,7 +18432,8 @@
                       "type": "reference",
                       "name": "Disconnectable",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "options",
@@ -17892,16 +18450,19 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "ElementPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17909,7 +18470,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.constructor"
@@ -17929,6 +18489,7 @@
               "name": "Element",
               "package": "typescript"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17936,7 +18497,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.element"
@@ -17965,6 +18525,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -17972,7 +18533,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.options"
@@ -17995,6 +18555,7 @@
               "value": 6
             },
             "defaultValue": "6",
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18002,7 +18563,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPart.type"
@@ -18023,6 +18583,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -18030,7 +18591,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "ElementPart"
@@ -18063,21 +18623,24 @@
                       "type": "reference",
                       "name": "HTMLElement",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "name",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -18085,7 +18648,8 @@
                       "type": "reference",
                       "name": "Disconnectable",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "options",
@@ -18102,7 +18666,8 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -18113,13 +18678,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "AttributePart.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "AttributePart.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18127,7 +18694,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.constructor"
@@ -18154,6 +18720,7 @@
               "type": "reference",
               "name": "AttributePart.element"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18161,7 +18728,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.element"
@@ -18187,6 +18753,7 @@
               "type": "reference",
               "name": "AttributePart.name"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18194,7 +18761,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.name"
@@ -18230,6 +18796,7 @@
               "type": "reference",
               "name": "AttributePart.options"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18237,7 +18804,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.options"
@@ -18267,6 +18833,7 @@
               "type": "reference",
               "name": "AttributePart.strings"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18274,7 +18841,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.strings"
@@ -18301,6 +18867,7 @@
               "type": "reference",
               "name": "AttributePart.type"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18308,7 +18875,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.type"
@@ -18342,12 +18908,14 @@
               "inheritedFrom": {
                 "type": "reference",
                 "name": "AttributePart.tagName"
-              }
+              },
+              "kindString": "Get signature"
             },
             "inheritedFrom": {
               "type": "reference",
               "name": "AttributePart.tagName"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18355,7 +18923,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.tagName"
@@ -18386,15 +18953,18 @@
                       "type": "reference",
                       "name": "Event",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18402,7 +18972,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "custom-directives",
               "anchor": "EventPart.handleEvent"
@@ -18423,6 +18992,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -18430,7 +19000,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "EventPart"
@@ -18479,7 +19048,8 @@
                 "type": {
                   "type": "literal",
                   "value": 1
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "BOOLEAN_ATTRIBUTE",
@@ -18495,7 +19065,8 @@
                 "type": {
                   "type": "literal",
                   "value": 4
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "CHILD",
@@ -18511,7 +19082,8 @@
                 "type": {
                   "type": "literal",
                   "value": 2
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "ELEMENT",
@@ -18527,7 +19099,8 @@
                 "type": {
                   "type": "literal",
                   "value": 6
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "EVENT",
@@ -18543,7 +19116,8 @@
                 "type": {
                   "type": "literal",
                   "value": 5
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "PROPERTY",
@@ -18559,7 +19133,8 @@
                 "type": {
                   "type": "literal",
                   "value": 3
-                }
+                },
+                "kindString": "Property"
               }
             ],
             "sources": [
@@ -18567,9 +19142,11 @@
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive.d.ts",
                 "line": 22
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -18577,7 +19154,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "custom-directives",
           "anchor": "PartType"
@@ -18610,21 +19186,24 @@
                       "type": "reference",
                       "name": "HTMLElement",
                       "package": "typescript"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "name",
                     "type": {
                       "type": "intrinsic",
                       "name": "string"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
                       "operator": "readonly"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -18632,7 +19211,8 @@
                       "type": "reference",
                       "name": "Disconnectable",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "options",
@@ -18649,7 +19229,8 @@
                           "package": "lit-html"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -18660,13 +19241,15 @@
                 "inheritedFrom": {
                   "type": "reference",
                   "name": "AttributePart.constructor"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
             "inheritedFrom": {
               "type": "reference",
               "name": "AttributePart.constructor"
             },
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18674,7 +19257,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.constructor"
@@ -18701,6 +19283,7 @@
               "type": "reference",
               "name": "AttributePart.element"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18708,7 +19291,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.element"
@@ -18734,6 +19316,7 @@
               "type": "reference",
               "name": "AttributePart.name"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18741,7 +19324,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.name"
@@ -18777,6 +19359,7 @@
               "type": "reference",
               "name": "AttributePart.options"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18784,7 +19367,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.options"
@@ -18814,6 +19396,7 @@
               "type": "reference",
               "name": "AttributePart.strings"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18821,7 +19404,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.strings"
@@ -18848,6 +19430,7 @@
               "type": "reference",
               "name": "AttributePart.type"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18855,7 +19438,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.type"
@@ -18889,12 +19471,14 @@
               "inheritedFrom": {
                 "type": "reference",
                 "name": "AttributePart.tagName"
-              }
+              },
+              "kindString": "Get signature"
             },
             "inheritedFrom": {
               "type": "reference",
               "name": "AttributePart.tagName"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18902,7 +19486,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "custom-directives",
               "anchor": "PropertyPart.tagName"
@@ -18923,6 +19506,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -18930,7 +19514,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "custom-directives",
           "anchor": "PropertyPart"
@@ -18962,6 +19545,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18969,7 +19553,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.name"
@@ -18992,6 +19575,7 @@
               "type": "typeOperator",
               "operator": "readonly"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -18999,7 +19583,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.strings"
@@ -19021,6 +19604,7 @@
               "type": "intrinsic",
               "name": "string"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -19028,7 +19612,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.tagName"
@@ -19067,6 +19650,7 @@
                 }
               ]
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -19074,7 +19658,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "AttributePartInfo.type"
@@ -19088,6 +19671,7 @@
             "moduleSpecifier": "lit-html/directive.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19095,7 +19679,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "AttributePartInfo"
@@ -19120,6 +19703,7 @@
               "type": "literal",
               "value": 2
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -19127,7 +19711,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ChildPartInfo.type"
@@ -19141,6 +19724,7 @@
             "moduleSpecifier": "lit-html/directive.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19148,7 +19732,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "ChildPartInfo"
@@ -19182,16 +19765,19 @@
                       "type": "reference",
                       "name": "PartInfo",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "Directive",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -19199,7 +19785,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "custom-directives",
               "anchor": "DirectiveClass.constructor"
@@ -19213,6 +19798,7 @@
             "moduleSpecifier": "lit-html/directive.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19220,7 +19806,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "DirectiveClass"
@@ -19245,7 +19830,8 @@
               "type": "reference",
               "name": "Directive",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
         "type": {
@@ -19266,6 +19852,7 @@
           "name": "Parameters",
           "package": "typescript"
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19273,7 +19860,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "custom-directives",
           "anchor": "DirectiveParameters"
@@ -19303,9 +19889,11 @@
               "type": "reference",
               "name": "DirectiveClass",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Type parameter"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19313,7 +19901,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "DirectiveResult"
@@ -19338,6 +19925,7 @@
               "type": "literal",
               "value": 6
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/async-directive.ts",
@@ -19345,7 +19933,6 @@
                 "moduleSpecifier": "lit/async-directive.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "custom-directives",
               "anchor": "ElementPartInfo.type"
@@ -19359,6 +19946,7 @@
             "moduleSpecifier": "lit-html/directive.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19366,7 +19954,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "custom-directives",
           "anchor": "ElementPartInfo"
@@ -19416,6 +20003,7 @@
             }
           ]
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19423,7 +20011,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "custom-directives",
           "anchor": "Part"
@@ -19462,6 +20049,7 @@
             }
           ]
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/async-directive.ts",
@@ -19469,7 +20057,6 @@
             "moduleSpecifier": "lit/async-directive.js"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "custom-directives",
           "anchor": "PartInfo"
@@ -19500,15 +20087,18 @@
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "void"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19516,7 +20106,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "clearPart"
@@ -19551,15 +20140,18 @@
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19567,7 +20159,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "getCommittedValue"
@@ -19600,7 +20191,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -19616,9 +20208,11 @@
                   "package": "lit-html"
                 }
               ]
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19626,7 +20220,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "getDirectiveClass"
@@ -19664,7 +20257,8 @@
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "refPart",
@@ -19678,7 +20272,8 @@
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "part",
@@ -19692,16 +20287,19 @@
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "ChildPart",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19709,7 +20307,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "insertPart"
@@ -19742,7 +20339,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -19761,9 +20359,11 @@
                 "name": "DirectiveResult",
                 "package": "lit-html"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19771,7 +20371,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isDirectiveResult"
@@ -19805,7 +20404,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -19817,9 +20417,11 @@
                 "name": "Primitive",
                 "package": "lit-html"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19827,7 +20429,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isPrimitive"
@@ -19862,15 +20463,18 @@
                   "type": "reference",
                   "name": "PartInfo",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "boolean"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19878,7 +20482,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isSingleExpression"
@@ -19911,7 +20514,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "type",
@@ -19922,7 +20526,8 @@
                   "type": "reference",
                   "name": "TemplateResultType",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -19949,9 +20554,11 @@
                 "name": "TemplateResult",
                 "package": "lit-html"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -19959,7 +20566,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "isTemplateResult"
@@ -19996,15 +20602,18 @@
                   "type": "reference",
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "void"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -20012,7 +20621,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "removePart"
@@ -20053,7 +20661,8 @@
                   ],
                   "name": "ChildPart",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Type parameter"
               }
             ],
             "parameters": [
@@ -20065,7 +20674,8 @@
                 "type": {
                   "type": "reference",
                   "name": "T"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "value",
@@ -20075,7 +20685,8 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "directiveParent",
@@ -20089,15 +20700,18 @@
                   "type": "reference",
                   "name": "DirectiveParent",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "T"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -20105,7 +20719,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "setChildPartValue"
@@ -20140,7 +20753,8 @@
                   "type": "reference",
                   "name": "Part",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "value",
@@ -20150,15 +20764,18 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "unknown"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -20166,7 +20783,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "custom-directives",
           "anchor": "setCommittedValue"
@@ -20208,7 +20824,8 @@
                 "type": {
                   "type": "literal",
                   "value": 1
-                }
+                },
+                "kindString": "Property"
               },
               {
                 "name": "SVG",
@@ -20224,7 +20841,8 @@
                 "type": {
                   "type": "literal",
                   "value": 2
-                }
+                },
+                "kindString": "Property"
               }
             ],
             "sources": [
@@ -20232,9 +20850,11 @@
                 "fileName": "packages/lit-dev-api/api-data/lit-2/repo/packages/lit-html/development/directive-helpers.d.ts",
                 "line": 15
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/directive-helpers.ts",
@@ -20242,7 +20862,6 @@
             "moduleSpecifier": "lit/directive-helpers.js"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "custom-directives",
           "anchor": "TemplateResultType"
@@ -20267,6 +20886,7 @@
           "type": "typeOperator",
           "operator": "unique"
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -20274,7 +20894,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "custom-directives",
           "anchor": "noChange"
@@ -20320,7 +20939,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "values",
@@ -20333,7 +20953,8 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -20347,9 +20968,11 @@
               ],
               "name": "TemplateResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
@@ -20357,7 +20980,6 @@
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "html"
@@ -20392,7 +21014,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "values",
@@ -20405,16 +21028,19 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "StaticValue",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
@@ -20422,7 +21048,6 @@
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "literal"
@@ -20457,7 +21082,8 @@
                   "type": "reference",
                   "name": "TemplateStringsArray",
                   "package": "typescript"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "values",
@@ -20470,7 +21096,8 @@
                     "type": "intrinsic",
                     "name": "unknown"
                   }
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -20484,9 +21111,11 @@
               ],
               "name": "TemplateResult",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
@@ -20494,7 +21123,6 @@
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "svg"
@@ -20528,16 +21156,19 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "string"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "reference",
               "name": "StaticValue",
               "package": "lit-html"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
@@ -20545,7 +21176,6 @@
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "unsafeStatic"
@@ -20623,7 +21253,8 @@
                                   "type": "reference",
                                   "name": "TemplateStringsArray",
                                   "package": "typescript"
-                                }
+                                },
+                                "kindString": "Parameter"
                               },
                               {
                                 "name": "values",
@@ -20636,7 +21267,8 @@
                                     "type": "intrinsic",
                                     "name": "unknown"
                                   }
-                                }
+                                },
+                                "kindString": "Parameter"
                               }
                             ],
                             "type": {
@@ -20649,9 +21281,11 @@
                               ],
                               "name": "TemplateResult",
                               "package": "lit-html"
-                            }
+                            },
+                            "kindString": "Call signature"
                           }
-                        ]
+                        ],
+                        "kindString": "Type literal"
                       }
                     },
                     {
@@ -20743,7 +21377,8 @@
                                   "type": "reference",
                                   "name": "TemplateStringsArray",
                                   "package": "typescript"
-                                }
+                                },
+                                "kindString": "Parameter"
                               },
                               {
                                 "name": "values",
@@ -20756,7 +21391,8 @@
                                     "type": "intrinsic",
                                     "name": "unknown"
                                   }
-                                }
+                                },
+                                "kindString": "Parameter"
                               }
                             ],
                             "type": {
@@ -20769,13 +21405,16 @@
                               ],
                               "name": "TemplateResult",
                               "package": "lit-html"
-                            }
+                            },
+                            "kindString": "Call signature"
                           }
-                        ]
+                        ],
+                        "kindString": "Type literal"
                       }
                     }
                   ]
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
@@ -20804,7 +21443,8 @@
                           "type": "reference",
                           "name": "TemplateStringsArray",
                           "package": "typescript"
-                        }
+                        },
+                        "kindString": "Parameter"
                       },
                       {
                         "name": "values",
@@ -20817,7 +21457,8 @@
                             "type": "intrinsic",
                             "name": "unknown"
                           }
-                        }
+                        },
+                        "kindString": "Parameter"
                       }
                     ],
                     "type": {
@@ -20831,13 +21472,17 @@
                       ],
                       "name": "TemplateResult",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Call signature"
                   }
-                ]
+                ],
+                "kindString": "Type literal"
               }
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
@@ -20845,7 +21490,6 @@
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "static-html",
           "anchor": "withStatic"
@@ -20874,6 +21518,7 @@
                 "package": "lit-html"
               }
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/static-html.ts",
@@ -20881,7 +21526,6 @@
                 "moduleSpecifier": "lit/static-html.js"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "static-html",
               "anchor": "StaticValue.r"
@@ -20895,6 +21539,7 @@
             "moduleSpecifier": "lit-html/static.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/static-html.ts",
@@ -20902,7 +21547,6 @@
             "moduleSpecifier": "lit/static-html.js"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "static-html",
           "anchor": "StaticValue"
@@ -20953,9 +21597,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -20963,7 +21609,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostConnected"
@@ -20996,9 +21641,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21006,7 +21653,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostDisconnected"
@@ -21040,9 +21686,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21050,7 +21698,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostUpdate"
@@ -21083,9 +21730,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21093,7 +21742,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveController.hostUpdated"
@@ -21107,6 +21755,7 @@
             "moduleSpecifier": "reactive-element/reactive-controller.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -21114,7 +21763,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "controllers",
           "anchor": "ReactiveController"
@@ -21162,6 +21810,7 @@
               "name": "Promise",
               "package": "typescript"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21169,7 +21818,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.updateComplete"
@@ -21203,15 +21851,18 @@
                       "type": "reference",
                       "name": "ReactiveController",
                       "package": "@lit/reactive-element"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21219,7 +21870,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.addController"
@@ -21253,15 +21903,18 @@
                       "type": "reference",
                       "name": "ReactiveController",
                       "package": "@lit/reactive-element"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21269,7 +21922,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.removeController"
@@ -21299,9 +21951,11 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -21309,7 +21963,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "controllers",
               "anchor": "ReactiveControllerHost.requestUpdate"
@@ -21329,6 +21982,7 @@
             "name": "ReactiveElement"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -21336,7 +21990,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "controllers",
           "anchor": "ReactiveControllerHost"
@@ -21370,6 +22023,7 @@
           "name": "ComplexAttributeConverter",
           "package": "@lit/reactive-element"
         },
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -21377,7 +22031,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "misc",
           "anchor": "defaultConverter"
@@ -21404,6 +22057,7 @@
           "value": false
         },
         "defaultValue": "false",
+        "kindString": "Variable",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -21411,7 +22065,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Variable",
         "location": {
           "page": "misc",
           "anchor": "isServer"
@@ -21458,6 +22111,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21465,7 +22119,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.container"
@@ -21484,6 +22137,7 @@
                       "type": "intrinsic",
                       "name": "number"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21491,7 +22145,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.id"
@@ -21510,6 +22163,7 @@
                       "type": "literal",
                       "value": "begin render"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21517,7 +22171,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.kind"
@@ -21546,6 +22199,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21553,7 +22207,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.options"
@@ -21582,6 +22235,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21589,7 +22243,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.part"
@@ -21608,6 +22261,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21615,7 +22269,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.BeginRender.value"
@@ -21629,6 +22282,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -21636,7 +22290,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.BeginRender"
@@ -21659,6 +22312,7 @@
                       "name": "Element",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21666,7 +22320,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.element"
@@ -21685,6 +22338,7 @@
                       "type": "literal",
                       "value": "commit attribute"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21692,7 +22346,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.kind"
@@ -21711,6 +22364,7 @@
                       "type": "intrinsic",
                       "name": "string"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21718,7 +22372,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.name"
@@ -21747,6 +22400,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21754,7 +22408,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.options"
@@ -21773,6 +22426,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21780,7 +22434,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitAttribute.value"
@@ -21794,6 +22447,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -21801,7 +22455,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitAttribute"
@@ -21824,6 +22477,7 @@
                       "name": "Element",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21831,7 +22485,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.element"
@@ -21850,6 +22503,7 @@
                       "type": "literal",
                       "value": "commit boolean attribute"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21857,7 +22511,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.kind"
@@ -21876,6 +22529,7 @@
                       "type": "intrinsic",
                       "name": "string"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21883,7 +22537,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.name"
@@ -21912,6 +22565,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21919,7 +22573,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.options"
@@ -21938,6 +22591,7 @@
                       "type": "intrinsic",
                       "name": "boolean"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21945,7 +22599,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute.value"
@@ -21959,6 +22612,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -21966,7 +22620,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitBooleanAttribute"
@@ -21988,6 +22641,7 @@
                       "type": "intrinsic",
                       "name": "boolean"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -21995,7 +22649,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.addListener"
@@ -22015,6 +22668,7 @@
                       "name": "Element",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22022,7 +22676,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.element"
@@ -22041,6 +22694,7 @@
                       "type": "literal",
                       "value": "commit event listener"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22048,7 +22702,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.kind"
@@ -22067,6 +22720,7 @@
                       "type": "intrinsic",
                       "name": "string"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22074,7 +22728,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.name"
@@ -22093,6 +22746,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22100,7 +22754,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.oldListener"
@@ -22129,6 +22782,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22136,7 +22790,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.options"
@@ -22155,6 +22808,7 @@
                       "type": "intrinsic",
                       "name": "boolean"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22162,7 +22816,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.removeListener"
@@ -22181,6 +22834,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22188,7 +22842,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitEventListener.value"
@@ -22202,6 +22855,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -22209,7 +22863,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitEventListener"
@@ -22231,6 +22884,7 @@
                       "type": "literal",
                       "value": "commit node"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22238,7 +22892,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.kind"
@@ -22267,6 +22920,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22274,7 +22928,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.options"
@@ -22303,6 +22956,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22310,7 +22964,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.parent"
@@ -22330,6 +22983,7 @@
                       "name": "Node",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22337,7 +22991,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.start"
@@ -22357,6 +23010,7 @@
                       "name": "Node",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22364,7 +23018,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNode.value"
@@ -22378,6 +23031,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -22385,7 +23039,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitNode"
@@ -22417,6 +23070,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22424,7 +23078,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.end"
@@ -22443,6 +23096,7 @@
                       "type": "literal",
                       "value": "commit nothing to child"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22450,7 +23104,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.kind"
@@ -22479,6 +23132,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22486,7 +23140,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.options"
@@ -22515,6 +23168,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22522,7 +23176,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.parent"
@@ -22542,6 +23195,7 @@
                       "name": "ChildNode",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22549,7 +23203,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry.start"
@@ -22563,6 +23216,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -22570,7 +23224,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitNothingToChildEntry"
@@ -22593,6 +23246,7 @@
                       "name": "Element",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22600,7 +23254,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.element"
@@ -22619,6 +23272,7 @@
                       "type": "literal",
                       "value": "commit property"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22626,7 +23280,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.kind"
@@ -22645,6 +23298,7 @@
                       "type": "intrinsic",
                       "name": "string"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22652,7 +23306,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.name"
@@ -22681,6 +23334,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22688,7 +23342,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.options"
@@ -22707,6 +23360,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22714,7 +23368,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitProperty.value"
@@ -22728,6 +23381,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -22735,7 +23389,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitProperty"
@@ -22757,6 +23410,7 @@
                       "type": "literal",
                       "value": "commit text"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22764,7 +23418,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.kind"
@@ -22784,6 +23437,7 @@
                       "name": "Text",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22791,7 +23445,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.node"
@@ -22820,6 +23473,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22827,7 +23481,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.options"
@@ -22846,6 +23499,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22853,7 +23507,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitText.value"
@@ -22867,6 +23520,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -22874,7 +23528,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitText"
@@ -22897,6 +23550,7 @@
                       "name": "Element",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22904,7 +23558,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.element"
@@ -22923,6 +23576,7 @@
                       "type": "literal",
                       "value": "commit to element binding"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22930,7 +23584,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.kind"
@@ -22959,6 +23612,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22966,7 +23620,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.options"
@@ -22985,6 +23638,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -22992,7 +23646,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.CommitToElementBinding.value"
@@ -23006,6 +23659,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -23013,7 +23667,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitToElementBinding"
@@ -23046,6 +23699,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23053,7 +23707,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.container"
@@ -23072,6 +23725,7 @@
                       "type": "intrinsic",
                       "name": "number"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23079,7 +23733,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.id"
@@ -23098,6 +23751,7 @@
                       "type": "literal",
                       "value": "end render"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23105,7 +23759,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.kind"
@@ -23134,6 +23787,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23141,7 +23795,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.options"
@@ -23161,6 +23814,7 @@
                       "name": "ChildPart",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23168,7 +23822,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.part"
@@ -23187,6 +23840,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23194,7 +23848,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.EndRender.value"
@@ -23208,6 +23861,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -23215,7 +23869,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.EndRender"
@@ -23237,6 +23890,7 @@
                       "type": "literal",
                       "value": "set part"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23244,7 +23898,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.kind"
@@ -23264,6 +23917,7 @@
                       "name": "Part",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23271,7 +23925,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.part"
@@ -23291,6 +23944,7 @@
                       "name": "TemplateInstance",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23298,7 +23952,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.templateInstance"
@@ -23317,6 +23970,7 @@
                       "type": "intrinsic",
                       "name": "unknown"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23324,7 +23978,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.value"
@@ -23343,6 +23996,7 @@
                       "type": "intrinsic",
                       "name": "number"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23350,7 +24004,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.valueIndex"
@@ -23372,6 +24025,7 @@
                         "name": "unknown"
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23379,7 +24033,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.SetPartValue.values"
@@ -23393,6 +24046,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -23400,7 +24054,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.SetPartValue"
@@ -23423,6 +24076,7 @@
                       "name": "Node",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23430,7 +24084,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.fragment"
@@ -23450,6 +24103,7 @@
                       "name": "TemplateInstance",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23457,7 +24111,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.instance"
@@ -23476,6 +24129,7 @@
                       "type": "literal",
                       "value": "template instantiated"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23483,7 +24137,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.kind"
@@ -23512,6 +24165,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23519,7 +24173,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.options"
@@ -23551,6 +24204,7 @@
                         ]
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23558,7 +24212,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.parts"
@@ -23588,6 +24241,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23595,7 +24249,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.template"
@@ -23617,6 +24270,7 @@
                         "name": "unknown"
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23624,7 +24278,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiated.values"
@@ -23638,6 +24291,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -23645,7 +24299,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplateInstantiated"
@@ -23668,6 +24321,7 @@
                       "name": "Node",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23675,7 +24329,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.fragment"
@@ -23695,6 +24348,7 @@
                       "name": "TemplateInstance",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23702,7 +24356,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.instance"
@@ -23721,6 +24374,7 @@
                       "type": "literal",
                       "value": "template instantiated and updated"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23728,7 +24382,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.kind"
@@ -23757,6 +24410,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23764,7 +24418,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.options"
@@ -23796,6 +24449,7 @@
                         ]
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23803,7 +24457,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.parts"
@@ -23833,6 +24486,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23840,7 +24494,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.template"
@@ -23862,6 +24515,7 @@
                         "name": "unknown"
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23869,7 +24523,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated.values"
@@ -23883,6 +24536,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -23890,7 +24544,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplateInstantiatedAndUpdated"
@@ -23913,6 +24566,7 @@
                       "name": "HTMLTemplateElement",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23920,7 +24574,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.clonableTemplate"
@@ -23939,6 +24592,7 @@
                       "type": "literal",
                       "value": "template prep"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23946,7 +24600,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.kind"
@@ -23969,6 +24622,7 @@
                         "package": "lit-html"
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -23976,7 +24630,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.parts"
@@ -23996,6 +24649,7 @@
                       "name": "TemplateStringsArray",
                       "package": "typescript"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24003,7 +24657,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.strings"
@@ -24023,6 +24676,7 @@
                       "name": "Template",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24030,7 +24684,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplatePrep.template"
@@ -24044,6 +24697,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24051,7 +24705,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplatePrep"
@@ -24074,6 +24727,7 @@
                       "name": "TemplateInstance",
                       "package": "lit-html"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24081,7 +24735,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.instance"
@@ -24100,6 +24753,7 @@
                       "type": "literal",
                       "value": "template updating"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24107,7 +24761,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.kind"
@@ -24136,6 +24789,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24143,7 +24797,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.options"
@@ -24175,6 +24828,7 @@
                         ]
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24182,7 +24836,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.parts"
@@ -24212,6 +24865,7 @@
                         }
                       ]
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24219,7 +24873,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.template"
@@ -24241,6 +24894,7 @@
                         "name": "unknown"
                       }
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24248,7 +24902,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "LitUnstable.DebugLog.TemplateUpdating.values"
@@ -24262,6 +24915,7 @@
                     "moduleSpecifier": "lit-html/lit-html.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24269,7 +24923,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.TemplateUpdating"
@@ -24337,6 +24990,7 @@
                     }
                   ]
                 },
+                "kindString": "Type alias",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24344,7 +24998,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.CommitPartEntry"
@@ -24412,6 +25065,7 @@
                     }
                   ]
                 },
+                "kindString": "Type alias",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24419,7 +25073,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "LitUnstable.DebugLog.Entry"
@@ -24433,6 +25086,7 @@
                 "moduleSpecifier": "lit-html/lit-html.js"
               }
             ],
+            "kindString": "Namespace",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24440,7 +25094,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Namespace",
             "location": {
               "page": "misc",
               "anchor": "LitUnstable.DebugLog"
@@ -24454,6 +25107,7 @@
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
+        "kindString": "Namespace",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -24461,7 +25115,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Namespace",
         "location": {
           "page": "misc",
           "anchor": "LitUnstable"
@@ -24494,22 +25147,26 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "old",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "boolean"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Function",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -24517,7 +25174,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Function",
         "location": {
           "page": "misc",
           "anchor": "notEqual"
@@ -24553,6 +25209,7 @@
                       "type": "literal",
                       "value": "update"
                     },
+                    "kindString": "Property",
                     "entrypointSources": [
                       {
                         "fileName": "packages/lit/src/index.ts",
@@ -24560,7 +25217,6 @@
                         "moduleSpecifier": "lit"
                       }
                     ],
-                    "kindString": "Property",
                     "location": {
                       "page": "misc",
                       "anchor": "ReactiveUnstable.DebugLog.Update.kind"
@@ -24574,6 +25230,7 @@
                     "moduleSpecifier": "reactive-element/reactive-element.js"
                   }
                 ],
+                "kindString": "Interface",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24581,7 +25238,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Interface",
                 "location": {
                   "page": "misc",
                   "anchor": "ReactiveUnstable.DebugLog.Update"
@@ -24602,6 +25258,7 @@
                   "package": "@lit/reactive-element",
                   "qualifiedName": "ReactiveUnstable.DebugLog.Update"
                 },
+                "kindString": "Type alias",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24609,7 +25266,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "ReactiveUnstable.DebugLog.Entry"
@@ -24623,6 +25279,7 @@
                 "moduleSpecifier": "reactive-element/reactive-element.js"
               }
             ],
+            "kindString": "Namespace",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24630,7 +25287,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Namespace",
             "location": {
               "page": "misc",
               "anchor": "ReactiveUnstable.DebugLog"
@@ -24644,6 +25300,7 @@
             "moduleSpecifier": "reactive-element/reactive-element.js"
           }
         ],
+        "kindString": "Namespace",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -24651,7 +25308,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Namespace",
         "location": {
           "page": "misc",
           "anchor": "ReactiveUnstable"
@@ -24687,7 +25343,8 @@
                       "type": "reference",
                       "name": "Template",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "parent",
@@ -24695,16 +25352,19 @@
                       "type": "reference",
                       "name": "ChildPart",
                       "package": "lit-html"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "reference",
                   "name": "TemplateInstance",
                   "package": "lit-html"
-                }
+                },
+                "kindString": "Constructor signature"
               }
             ],
+            "kindString": "Constructor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24712,7 +25372,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Constructor",
             "location": {
               "page": "misc",
               "anchor": "TemplateInstance.constructor"
@@ -24744,8 +25403,10 @@
                 "type": "reference",
                 "name": "Node",
                 "package": "typescript"
-              }
+              },
+              "kindString": "Get signature"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24753,7 +25414,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "TemplateInstance.parentNode"
@@ -24774,6 +25434,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Class",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -24781,7 +25442,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Class",
         "location": {
           "page": "misc",
           "anchor": "TemplateInstance"
@@ -24825,6 +25485,7 @@
                     }
                   ]
                 },
+                "kindString": "Type alias",
                 "entrypointSources": [
                   {
                     "fileName": "packages/lit/src/index.ts",
@@ -24832,7 +25493,6 @@
                     "moduleSpecifier": "lit"
                   }
                 ],
-                "kindString": "Type alias",
                 "location": {
                   "page": "misc",
                   "anchor": "Unstable.DebugLog.Entry"
@@ -24846,6 +25506,7 @@
                 "moduleSpecifier": "lit-element/lit-element.js"
               }
             ],
+            "kindString": "Namespace",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24853,7 +25514,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Namespace",
             "location": {
               "page": "misc",
               "anchor": "Unstable.DebugLog"
@@ -24867,6 +25527,7 @@
             "moduleSpecifier": "lit-element/lit-element.js"
           }
         ],
+        "kindString": "Namespace",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -24874,7 +25535,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Namespace",
         "location": {
           "page": "misc",
           "anchor": "Unstable"
@@ -24900,6 +25560,7 @@
               "name": "HTMLTemplateElement",
               "package": "typescript"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24907,7 +25568,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplate.el"
@@ -24927,6 +25587,7 @@
               "name": "TrustedHTML",
               "package": "@types/trusted-types"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24934,7 +25595,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplate.h"
@@ -24961,6 +25621,7 @@
               "type": "reference",
               "name": "Omit.parts"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -24968,7 +25629,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplate.parts"
@@ -25000,6 +25660,7 @@
             "package": "typescript"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25007,7 +25668,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "CompiledTemplate"
@@ -25050,6 +25710,7 @@
                 "name": "unknown"
               }
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25057,7 +25718,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "CompiledTemplateResult.values"
@@ -25071,6 +25731,7 @@
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25078,7 +25739,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "CompiledTemplateResult"
@@ -25093,6 +25753,7 @@
             "moduleSpecifier": "lit-html/lit-html.js"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25100,7 +25761,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "DirectiveParent"
@@ -25137,6 +25797,7 @@
             "name": "TemplateInstance"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25144,7 +25805,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "Disconnectable"
@@ -25174,22 +25834,26 @@
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               },
               {
                 "name": "old",
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Parameter"
               }
             ],
             "type": {
               "type": "intrinsic",
               "name": "boolean"
-            }
+            },
+            "kindString": "Call signature"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25197,7 +25861,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "HasChanged"
@@ -25227,6 +25890,7 @@
           "name": "TemplateResult",
           "package": "lit-html"
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25234,7 +25898,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "HTMLTemplateResult"
@@ -25269,17 +25932,21 @@
                       "type": "reference",
                       "name": "ReactiveElement",
                       "package": "@lit/reactive-element"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25287,7 +25954,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "Initializer"
@@ -25336,7 +26002,8 @@
                           "name": "symbol"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -25345,7 +26012,8 @@
                     "type": {
                       "type": "reference",
                       "name": "K"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -25355,13 +26023,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Map.delete"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Map.delete"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25369,7 +26039,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.delete"
@@ -25412,7 +26081,8 @@
                           "name": "symbol"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -25421,7 +26091,8 @@
                     "type": {
                       "type": "reference",
                       "name": "K"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -25438,13 +26109,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Map.get"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Map.get"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25452,7 +26125,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.get"
@@ -25495,7 +26167,8 @@
                           "name": "symbol"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -25504,7 +26177,8 @@
                     "type": {
                       "type": "reference",
                       "name": "K"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -25514,13 +26188,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Map.has"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Map.has"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25528,7 +26204,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.has"
@@ -25571,7 +26246,8 @@
                           "name": "symbol"
                         }
                       ]
-                    }
+                    },
+                    "kindString": "Type parameter"
                   }
                 ],
                 "parameters": [
@@ -25580,7 +26256,8 @@
                     "type": {
                       "type": "reference",
                       "name": "K"
-                    }
+                    },
+                    "kindString": "Parameter"
                   },
                   {
                     "name": "value",
@@ -25594,7 +26271,8 @@
                         "type": "reference",
                         "name": "T"
                       }
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
@@ -25611,13 +26289,15 @@
                 "overwrites": {
                   "type": "reference",
                   "name": "Map.set"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
             "overwrites": {
               "type": "reference",
               "name": "Map.set"
             },
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25625,7 +26305,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "PropertyValueMap.set"
@@ -25641,7 +26320,8 @@
         ],
         "typeParameters": [
           {
-            "name": "T"
+            "name": "T",
+            "kindString": "Type parameter"
           }
         ],
         "extendedTypes": [
@@ -25662,6 +26342,7 @@
             "package": "typescript"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -25669,7 +26350,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "PropertyValueMap"
@@ -25729,6 +26409,7 @@
               "type": "reference",
               "name": "ChildPart.options"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25736,7 +26417,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "RootPart.options"
@@ -25763,6 +26443,7 @@
               "type": "reference",
               "name": "ChildPart.type"
             },
+            "kindString": "Property",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25770,7 +26451,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Property",
             "location": {
               "page": "misc",
               "anchor": "RootPart.type"
@@ -25830,12 +26510,14 @@
               "inheritedFrom": {
                 "type": "reference",
                 "name": "ChildPart.endNode"
-              }
+              },
+              "kindString": "Get signature"
             },
             "inheritedFrom": {
               "type": "reference",
               "name": "ChildPart.endNode"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25843,7 +26525,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "RootPart.endNode"
@@ -25887,12 +26568,14 @@
               "inheritedFrom": {
                 "type": "reference",
                 "name": "ChildPart.parentNode"
-              }
+              },
+              "kindString": "Get signature"
             },
             "inheritedFrom": {
               "type": "reference",
               "name": "ChildPart.parentNode"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25900,7 +26583,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "RootPart.parentNode"
@@ -25960,12 +26642,14 @@
               "inheritedFrom": {
                 "type": "reference",
                 "name": "ChildPart.startNode"
-              }
+              },
+              "kindString": "Get signature"
             },
             "inheritedFrom": {
               "type": "reference",
               "name": "ChildPart.startNode"
             },
+            "kindString": "Accessor",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -25973,7 +26657,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Accessor",
             "location": {
               "page": "misc",
               "anchor": "RootPart.startNode"
@@ -26010,15 +26693,18 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "boolean"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "void"
-                }
+                },
+                "kindString": "Call signature"
               }
             ],
+            "kindString": "Method",
             "entrypointSources": [
               {
                 "fileName": "packages/lit/src/index.ts",
@@ -26026,7 +26712,6 @@
                 "moduleSpecifier": "lit"
               }
             ],
-            "kindString": "Method",
             "location": {
               "page": "misc",
               "anchor": "RootPart.setConnected"
@@ -26047,6 +26732,7 @@
             "package": "lit-html"
           }
         ],
+        "kindString": "Interface",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -26054,7 +26740,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Interface",
         "location": {
           "page": "misc",
           "anchor": "RootPart"
@@ -26126,17 +26811,21 @@
                     "type": {
                       "type": "intrinsic",
                       "name": "unknown"
-                    }
+                    },
+                    "kindString": "Parameter"
                   }
                 ],
                 "type": {
                   "type": "intrinsic",
                   "name": "unknown"
-                }
+                },
+                "kindString": "Call signature"
               }
-            ]
+            ],
+            "kindString": "Type literal"
           }
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -26144,7 +26833,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "ValueSanitizer"
@@ -26175,6 +26863,7 @@
             }
           ]
         },
+        "kindString": "Type alias",
         "entrypointSources": [
           {
             "fileName": "packages/lit/src/index.ts",
@@ -26182,7 +26871,6 @@
             "moduleSpecifier": "lit"
           }
         ],
-        "kindString": "Type alias",
         "location": {
           "page": "misc",
           "anchor": "WarningKind"

--- a/packages/lit-dev-content/site/_includes/api.html
+++ b/packages/lit-dev-content/site/_includes/api.html
@@ -125,8 +125,8 @@ layout: docs
     {%- elif t.location -%}
       {{- locationLink(t.location, t.name) -}}
 
-    {%- elif t.externalLocation -%}
-      {{- externalLink(t.externalLocation.url, t.name) -}}
+    {%- elif t.externalUrl -%}
+      {{- externalLink(t.externalUrl, t.name) -}}
 
     {%- elif t.type == "literal" -%}
       {%- if t.value == null -%}

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -51,7 +51,7 @@
     "source-map": "^0.8.0-beta.0",
     "strip-comments": "^2.0.1",
     "striptags": "^3.2.0",
-    "typedoc": "^0.23.28",
+    "typedoc": "^0.24.6",
     "uvu": "^0.5.1"
   }
 }

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-2.ts
@@ -5,6 +5,7 @@
  */
 
 import * as pathlib from 'path';
+import {ReflectionKind} from 'typedoc';
 
 import type {ApiDocsConfig} from '../types.js';
 
@@ -93,7 +94,7 @@ export const lit2Config: ApiDocsConfig = {
     {
       slug: 'directives',
       title: 'Directives',
-      tocFilter: (node) => node.kindString === 'Function',
+      tocFilter: (node) => node.kind === ReflectionKind.Function,
       versionLinks: {
         v1: 'api/lit-html/directives/',
       },

--- a/packages/lit-dev-tools-cjs/src/api-docs/generate.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/generate.ts
@@ -101,7 +101,10 @@ const analyze = async (config: ApiDocsConfig) => {
     throw new Error('TypeDoc.Application.convert() returned undefined');
   }
 
-  const json = await app.serializer.projectToObject(root);
+  const json = await app.serializer.projectToObject(
+    root,
+    pathlib.resolve(config.tsConfigPath, '..')
+  );
   const transformer = new ApiDocsTransformer(json, config);
   const {pages, symbolMap} = await transformer.transform();
 

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -106,9 +106,7 @@ export class ApiDocsTransformer {
     symbolMap: SymbolMap;
     pages: Pages;
   }> {
-    this.addKindStringsBackToAllNodes(
-      this.project as unknown as Record<string, unknown>
-    );
+    this.addKindStringsBackToAllNodes(this.project);
     // In the first pass, determine the page/anchor where each node should
     // appear in our layout, and index all nodes by TypeDoc numeric ID.
     for (const entrypoint of this.project.children ?? []) {
@@ -694,7 +692,7 @@ export class ApiDocsTransformer {
    * api.html. This method recursively walks the TypeDoc node and adds
    * `kindString` back to all nodes with a valid `kind` field.
    */
-  private addKindStringsBackToAllNodes(node: Record<string, unknown>) {
+  private addKindStringsBackToAllNodes(node: unknown) {
     if (typeof node !== 'object' || node == null) {
       return;
     }
@@ -707,11 +705,10 @@ export class ApiDocsTransformer {
     for (const [key, val] of Object.entries(node)) {
       if (key === 'kind' && typeof val === 'number') {
         // Add a `kindString` field to the node.
-        node['kindString'] = typedoc.ReflectionKind.singularString(
-          val as ReflectionKind
-        );
+        (node as {kindString: string})['kindString'] =
+          typedoc.ReflectionKind.singularString(val as ReflectionKind);
       }
-      this.addKindStringsBackToAllNodes(val as Record<string, unknown>);
+      this.addKindStringsBackToAllNodes(val);
     }
   }
 

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -15,7 +15,6 @@ import {
   SourceReference,
   ExtendedSourceReference,
   Location,
-  ExternalLocation,
   MigrationComment,
 } from './types.js';
 import {ReflectionKind} from 'typedoc';
@@ -434,9 +433,8 @@ export class ApiDocsTransformer {
         typeof val === 'string' &&
         symbolToExternalLink.has(val)
       ) {
-        (node as {externalLocation?: ExternalLocation}).externalLocation = {
-          url: symbolToExternalLink.get(val)!,
-        };
+        (node as {externalUrl?: string}).externalUrl =
+          symbolToExternalLink.get(val);
       } else if (!(isTopLevel && key === 'children')) {
         // We already recurse into children of top-level reflections in our main
         // traversal, no need to also do it here.

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -413,7 +413,7 @@ export class ApiDocsTransformer {
    * TypeDoc has a reflection with that id, then we should give it a location.
    */
   private addLocationsForAllIds(node: unknown, isTopLevel = true) {
-    if (typeof node !== 'object' || node === null) {
+    if (typeof node !== 'object' || node == null) {
       return;
     }
     if (node instanceof Array) {
@@ -423,7 +423,11 @@ export class ApiDocsTransformer {
       return;
     }
     for (const [key, val] of Object.entries(node)) {
-      if (key === 'id' && typeof val === 'number' && !('location' in node)) {
+      if (
+        key === 'target' &&
+        typeof val === 'number' &&
+        !('location' in node)
+      ) {
         const reflection = this.reflectionById.get(val);
         if (reflection && reflection.location) {
           (node as {location?: Location}).location = reflection.location;

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -28,7 +28,10 @@ const findIndexOrInfinity = <T>(
 };
 
 const isType = (node: DeclarationReflection) => {
-  return node.kindString === 'Type alias' || node.kindString === 'Interface';
+  return (
+    node.kind === typedoc.ReflectionKind.TypeAlias ||
+    node.kind === typedoc.ReflectionKind.Interface
+  );
 };
 
 /**
@@ -116,6 +119,7 @@ export class ApiDocsTransformer {
         // to copy our original entrypoint source info to each node.
         (node as ExtendedDeclarationReflection).entrypointSources =
           entrypoint.sources;
+        this.addKindStringToNodes(node);
         for (const source of node.sources ?? []) {
           this.makeSourceRelativeToMonorepoRoot(source);
           await this.updateSourceFromDtsToTs(source);
@@ -180,8 +184,10 @@ export class ApiDocsTransformer {
           return aImportLength - bImportLength;
         }
         // Prefer a value to a type.
-        const aTypeAlias = aReflection?.kindString === 'Type alias';
-        const bTypeAlias = bReflection?.kindString === 'Type alias';
+        const aTypeAlias =
+          aReflection?.kind === typedoc.ReflectionKind.TypeAlias;
+        const bTypeAlias =
+          bReflection?.kind === typedoc.ReflectionKind.TypeAlias;
         if (!aTypeAlias && bTypeAlias) {
           return -1;
         }
@@ -217,7 +223,13 @@ export class ApiDocsTransformer {
         secondPassVisit(child);
       }
     };
-    secondPassVisit(this.project);
+
+    if (!this.project.children) {
+      throw new Error(`Unexpected empty project`);
+    }
+    for (const child of this.project.children) {
+      secondPassVisit(child);
+    }
 
     const pages = this.reorganizeExportsIntoPages();
     this.prunePageData(pages);
@@ -237,7 +249,7 @@ export class ApiDocsTransformer {
       node.flags?.isExternal ||
       node.name.startsWith('_') ||
       // Reference types don't seem useful; just aliases for other nodes.
-      node.kindString === 'Reference'
+      node.kind === typedoc.ReflectionKind.Reference
     );
   }
 
@@ -248,7 +260,7 @@ export class ApiDocsTransformer {
     node: DeclarationReflection,
     ancestry: Array<DeclarationReflection>
   ) {
-    if (!node.kindString || node.kindString === 'Module') {
+    if (!node.kind || node.kind === typedoc.ReflectionKind.Module) {
       return;
     }
 
@@ -305,7 +317,7 @@ export class ApiDocsTransformer {
    * functions uniformly regardless of how they are defined.
    */
   private promoteVariableFunctions(node: DeclarationReflection) {
-    if (node.kindString !== 'Variable') {
+    if (node.kind !== typedoc.ReflectionKind.Variable) {
       return;
     }
     const signatures = (node.type as {declaration?: DeclarationReflection})
@@ -313,7 +325,7 @@ export class ApiDocsTransformer {
     if (!signatures) {
       return;
     }
-    node.kindString = 'Function';
+    node.kind = typedoc.ReflectionKind.Function;
     node.signatures = signatures;
     for (const sig of node.signatures ?? []) {
       sig.name = node.name;
@@ -325,7 +337,7 @@ export class ApiDocsTransformer {
    * they can be treated more uniformly with properties.
    */
   private promoteAccessorTypes(node: DeclarationReflection) {
-    if (node.kindString !== 'Accessor') {
+    if (node.kind !== typedoc.ReflectionKind.Accessor) {
       return;
     }
     if (node.getSignature?.type) {
@@ -348,7 +360,10 @@ export class ApiDocsTransformer {
       node.comment = node.type.declaration?.signatures?.[0]?.comment;
     }
     // Handle accessors
-    if (node.kindString === 'Accessor' && node.getSignature?.comment) {
+    if (
+      node.kind === typedoc.ReflectionKind.Accessor &&
+      node.getSignature?.comment
+    ) {
       node.comment = node.getSignature.comment;
     }
   }
@@ -480,7 +495,14 @@ export class ApiDocsTransformer {
           key === 'tags' ||
           // The "target" key is unstable causing our "Check API data is in
           // sync" approach to fail. We also do not use this key.
-          key === 'target'
+          key === 'target' ||
+          // We do not use the 'variant' or 'refersToTypeParameter' field.
+          key === 'variant' ||
+          key === 'refersToTypeParameter' ||
+          // We already compute and generate our own url to the source code,
+          // which tends to be more accurate. Remove the one automatically added
+          // by TypeDoc.
+          key === 'url'
         ) {
           delete node[key as keyof typeof node];
         }
@@ -659,6 +681,13 @@ export class ApiDocsTransformer {
       commentNode.text = text + '\n';
     }
     commentNode.summary = undefined;
+  }
+
+  private addKindStringToNodes(node: DeclarationReflection) {
+    if (node.kind) {
+      (node as ExtendedDeclarationReflection).kindString =
+        typedoc.ReflectionKind.singularString(node.kind);
+    }
   }
 
   /**

--- a/packages/lit-dev-tools-cjs/src/api-docs/types.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/types.ts
@@ -28,7 +28,6 @@ export interface MigrationComment
 
 export interface ExtendedDeclarationReflection extends DeclarationReflection {
   location?: Location;
-  externalLocation?: ExternalLocation;
   entrypointSources?: Array<ExtendedSourceReference>;
   heritage?: Array<{name: string; location?: Location}>;
   expandedCategories?: Array<{
@@ -56,11 +55,6 @@ export interface Location {
    * See https://github.com/JordanShurmer/eleventy-plugin-nesting-toc
    */
   excludeFromTOC?: boolean;
-}
-
-/** A link to e.g. MDN. */
-export interface ExternalLocation {
-  url: string;
 }
 
 export interface ApiDocsConfig {

--- a/packages/lit-dev-tools-cjs/src/api-docs/types.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/types.ts
@@ -36,6 +36,7 @@ export interface ExtendedDeclarationReflection extends DeclarationReflection {
     anchor: string;
     children: Array<DeclarationReflection>;
   }>;
+  kindString?: string;
 }
 
 export type SourceReference = typedoc.JSONOutput.SourceReference;


### PR DESCRIPTION
This bumps TypeDoc to the latest version. Only one minor patch from the last PR: https://github.com/lit/lit.dev/pull/1090

My hope is that this gives us some more tools for the labs documentation. For example a new `project root path` option is now required & may fix the strange file paths seen in https://github.com/lit/lit.dev/pull/1092.

Regardless - while I have some context in this area - I'm trying to get us as updated as possible.

### Changes

 - TypeDoc removed `kindString`. We use this extensively in our `api.html` template so I needed to add it back using a full tree traversal.
 - TypeDoc now uses `target` to reference the id of the declaration for reflected nodes. This initially broke all linking between symbols. Fixed once I figured out the id was on `target`.
 - Small API compatibility changes.

### Testing

Very manual process again.

This was tested by once again going page by page in the docs and diff checking the content.
I also checked the View Source links continued to work & generated pages look the same between prod and this PR.



### Issues found and fixed list

These issues occurred because initially I did not fully traverse the TypeDoc tree to add `kindString` fields back. Issue resolved by a full traversal.

 - [x] `enableWarning` lost its type: https://pr1093-b007374---lit-dev-5ftespv5na-uc.a.run.app/docs/api/LitElement/#LitElement.enableWarning
 - [x] `creationScope` became a TODO type: https://pr1093-b007374---lit-dev-5ftespv5na-uc.a.run.app/docs/api/LitElement/#RenderOptions.creationScope
 - [x] Lost links to MDN. E.g. https://pr1093-a1f740f---lit-dev-5ftespv5na-uc.a.run.app/docs/api/styles/#CSSResult.styleSheet
 - [x] Lost generated docs cross links. TypeDoc is linking to the exported module & not the symbol declaration!!!!