### PR TITLE
Remove editable link from generated API docs.

### DIFF
--- a/packages/lit-dev-content/site/_includes/docs.html
+++ b/packages/lit-dev-content/site/_includes/docs.html
@@ -58,7 +58,8 @@
 
       {{ content | safe }}
 
-
+      {% set nonEditableDocumentRegex = r/.+\/api\/.+/ %}
+      {% if not nonEditableDocumentRegex.test(page.inputPath) %}
       <p id="edit-page-link">
         <a
             href="https://github.com/lit/lit.dev/edit/main/packages/lit-dev-content/{{ page.inputPath }}">
@@ -70,6 +71,7 @@
           </lazy-svg>
         </a>
       </p>
+      {% endif %}
 
       {% set navItems = collections[collection] | eleventyNavigation | flattenNavigationAndAddNextPrev %}
       {% for item in navItems %}


### PR DESCRIPTION
This link currently does not provide a good user experience (on generated API pages) - linking to a computed page.

For example, clicking: https://lit.dev/docs/api/LitElement/#:~:text=in%20the%20container.-,Edit%20this%20page,-Previous
takes the user to: https://github.com/lit/lit.dev/edit/main/packages/lit-dev-content/site/docs/api/api.html


### Fix

Remove this link from generated API pages.


Fixes: https://github.com/lit/lit.dev/issues/1094


### Testing

Tested by checking that docs pages still have the "Editable" link & generated API docs no longer have that link.