### PR TITLE
Fix regression in unique symbol type generation

### DIFF
--- a/packages/lit-dev-content/site/_includes/api-v1.html
+++ b/packages/lit-dev-content/site/_includes/api-v1.html
@@ -61,7 +61,7 @@ layout: docs
     {%- elif t.operator == 'keyof' -%}
       keyof {{ type(t.target) }}
 
-    {%- elif t.type == "typeOperator" and t.operator == "unique" -%}
+    {%- elif t.operator == 'unique' and t.target.name == 'symbol' -%}
       symbol
 
     {%- elif t.type == 'conditional' -%}

--- a/packages/lit-dev-content/site/_includes/api-v1.html
+++ b/packages/lit-dev-content/site/_includes/api-v1.html
@@ -61,7 +61,7 @@ layout: docs
     {%- elif t.operator == 'keyof' -%}
       keyof {{ type(t.target) }}
 
-    {%- elif t.operator == 'unique' and t.target.name == 'symbol' -%}
+    {%- elif t.type == "typeOperator" and t.operator == "unique" -%}
       symbol
 
     {%- elif t.type == 'conditional' -%}

--- a/packages/lit-dev-content/site/_includes/api.html
+++ b/packages/lit-dev-content/site/_includes/api.html
@@ -61,7 +61,7 @@ layout: docs
     {%- elif t.operator == 'keyof' -%}
       keyof {{ type(t.target) }}
 
-    {%- elif t.operator == 'unique' and t.target.name == 'symbol' -%}
+    {%- elif t.type == "typeOperator" and t.operator == "unique" -%}
       symbol
 
     {%- elif t.type == 'conditional' -%}


### PR DESCRIPTION
Originally we'd have the text `symbol` for the type of `noChange` or `nothing`. However a change in TypeDoc broke this rendering - and it currently renders TODO.

I fixed the check.

See `Type` in https://lit.dev/docs/api/custom-directives/#noChange or https://lit.dev/docs/api/templates/#nothing

Then compare with preview URL. There are only two instances impacted by this issue (verified by searching `pages.json` data.