### PR TITLE
Fix strange TypeDoc regression in Custom Directives API.

### DIFF
--- a/packages/lit-dev-content/site/_includes/api.html
+++ b/packages/lit-dev-content/site/_includes/api.html
@@ -143,6 +143,9 @@ layout: docs
     {%- elif t.name and t.name !== '__type' -%}
       {{- t.name -}}
 
+    {%- elif page.url.includes("api/custom-directives") -%}
+      ReadonlyArray&lt;string>
+
     {%- else -%}
       TODO
       {# {{ t | dump }} #}

--- a/packages/lit-dev-content/site/_includes/api.html
+++ b/packages/lit-dev-content/site/_includes/api.html
@@ -144,6 +144,7 @@ layout: docs
       {{- t.name -}}
 
     {%- elif page.url.includes("api/custom-directives") -%}
+      <!-- TODO(https://github.com/lit/lit.dev/issues/1099) -->
       ReadonlyArray&lt;string>
 
     {%- else -%}


### PR DESCRIPTION
Somehow TypeDoc no longer recognizes the type for `ReadonlyArray`. This is a hack just for this page.

See fix on https://pr1098-7a4bf41---lit-dev-5ftespv5na-uc.a.run.app/docs/api/custom-directives/

There are no longer TODO's.
Tracking robust fix in https://github.com/lit/lit.dev/issues/1099


Note: This "fix" is a hack - but it resolves the user facing issue.
