### PR TITLE
Remove hacks introduced yesterday to remove generated TODOs

### DIFF
--- a/packages/lit-dev-api/api-data/lit-2/pages.json
+++ b/packages/lit-dev-api/api-data/lit-2/pages.json
@@ -6400,7 +6400,11 @@
         ],
         "type": {
           "type": "typeOperator",
-          "operator": "unique"
+          "operator": "unique",
+          "target": {
+            "type": "intrinsic",
+            "name": "symbol"
+          }
         },
         "kindString": "Variable",
         "entrypointSources": [
@@ -6424,7 +6428,8 @@
               "content": [
                 {
                   "tag": "@link",
-                  "text": "Rendering Lit HTML Templates"
+                  "text": "Rendering Lit HTML Templates",
+                  "target": "https://lit.dev/docs/libraries/standalone-templates/#rendering-lit-html-templates|"
                 }
               ]
             }
@@ -15099,7 +15104,8 @@
               "content": [
                 {
                   "tag": "@link",
-                  "text": "styleMap code samples on Lit.dev"
+                  "text": "styleMap code samples on Lit.dev",
+                  "target": "https://lit.dev/docs/templates/directives/#stylemap"
                 }
               ]
             }
@@ -18415,7 +18421,14 @@
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
-                      "operator": "readonly"
+                      "operator": "readonly",
+                      "target": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "intrinsic",
+                          "name": "string"
+                        }
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -18601,7 +18614,14 @@
             ],
             "type": {
               "type": "typeOperator",
-              "operator": "readonly"
+              "operator": "readonly",
+              "target": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -18803,7 +18823,14 @@
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
-                      "operator": "readonly"
+                      "operator": "readonly",
+                      "target": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "intrinsic",
+                          "name": "string"
+                        }
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -19025,7 +19052,14 @@
             ],
             "type": {
               "type": "typeOperator",
-              "operator": "readonly"
+              "operator": "readonly",
+              "target": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
+              }
             },
             "inheritedFrom": {
               "type": "reference",
@@ -20316,7 +20350,14 @@
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
-                      "operator": "readonly"
+                      "operator": "readonly",
+                      "target": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "intrinsic",
+                          "name": "string"
+                        }
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -20538,7 +20579,14 @@
             ],
             "type": {
               "type": "typeOperator",
-              "operator": "readonly"
+              "operator": "readonly",
+              "target": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
+              }
             },
             "inheritedFrom": {
               "type": "reference",
@@ -20933,7 +20981,14 @@
                     "name": "strings",
                     "type": {
                       "type": "typeOperator",
-                      "operator": "readonly"
+                      "operator": "readonly",
+                      "target": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "intrinsic",
+                          "name": "string"
+                        }
+                      }
                     },
                     "kindString": "Parameter"
                   },
@@ -21155,7 +21210,14 @@
             ],
             "type": {
               "type": "typeOperator",
-              "operator": "readonly"
+              "operator": "readonly",
+              "target": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
+              }
             },
             "inheritedFrom": {
               "type": "reference",
@@ -21358,7 +21420,14 @@
             ],
             "type": {
               "type": "typeOperator",
-              "operator": "readonly"
+              "operator": "readonly",
+              "target": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
+              }
             },
             "kindString": "Property",
             "entrypointSources": [
@@ -22789,7 +22858,11 @@
         ],
         "type": {
           "type": "typeOperator",
-          "operator": "unique"
+          "operator": "unique",
+          "target": {
+            "type": "intrinsic",
+            "name": "symbol"
+          }
         },
         "kindString": "Variable",
         "entrypointSources": [

--- a/packages/lit-dev-content/site/_includes/api.html
+++ b/packages/lit-dev-content/site/_includes/api.html
@@ -61,7 +61,7 @@ layout: docs
     {%- elif t.operator == 'keyof' -%}
       keyof {{ type(t.target) }}
 
-    {%- elif t.type == "typeOperator" and t.operator == "unique" -%}
+      {%- elif t.operator == 'unique' and t.target.name == 'symbol' -%}
       symbol
 
     {%- elif t.type == 'conditional' -%}
@@ -142,10 +142,6 @@ layout: docs
 
     {%- elif t.name and t.name !== '__type' -%}
       {{- t.name -}}
-
-    {%- elif page.url.includes("api/custom-directives") -%}
-      <!-- TODO(https://github.com/lit/lit.dev/issues/1099) -->
-      ReadonlyArray&lt;string>
 
     {%- else -%}
       <span class="error-fallback-todo">TODO</span>

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -496,9 +496,12 @@ export class ApiDocsTransformer {
           // We don't render JSDoc tags directly, the ones we care about are
           // already extracted into e.g. "parameters".
           key === 'tags' ||
-          // The "target" key is unstable causing our "Check API data is in
-          // sync" approach to fail. We also do not use this key.
-          key === 'target' ||
+          // The "target" key is unstable when referring to a number `id`,
+          // causing our "Check API data is in sync" approach to fail. If not a
+          // number, this key can also represent a concrete type. Keep `type` val
+          // if it contains a `type` key.
+          (key === 'target' && typeof val === 'number') ||
+          (key === 'target' && typeof val === 'object' && !('type' in val)) ||
           // We do not use the 'variant' or 'refersToTypeParameter' field.
           key === 'variant' ||
           key === 'refersToTypeParameter' ||

--- a/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/transformer.ts
@@ -498,7 +498,7 @@ export class ApiDocsTransformer {
           key === 'tags' ||
           // The "target" key is unstable when referring to a number `id`,
           // causing our "Check API data is in sync" approach to fail. If not a
-          // number, this key can also represent a concrete type. Keep `type` val
+          // number, this key can also represent a concrete type. Keep `target`
           // if it contains a `type` key.
           (key === 'target' && typeof val === 'number') ||
           (key === 'target' && typeof val === 'object' && !('type' in val)) ||


### PR DESCRIPTION
Fixes: https://github.com/lit/lit.dev/issues/1099

### Context

During TypeDoc upgrades I lost some types. 

Specifically:
 - Lost `ReadonlyArray<string>` type. Was fixed with a hack in https://github.com/lit/lit.dev/pull/1098
 - Lost `nothing` and `noChange` unique symbol type. Also hack fixed in: https://github.com/lit/lit.dev/pull/1096

This change undoes the hacks introduced with the correct and nice fix.

### Fix

The types were on the `target` key - which we were removing after an upgrade to TypeDoc added unstable ids to `target`. Target is overloaded and removing it entirely caused the bug.

Fix is to remove all `target` keys, unless it contains a `type` key.

### Testing

Manually tested - but also automatically tested via the new test introduced in https://github.com/lit/lit.dev/pull/1101


Thank you so much!