### PR TITLE
Adjust Discord Banner Styling

### DIFF
--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -4,12 +4,14 @@
   justify-content: center;
   background: #5865F2;
   color: white;
-  height: 48px;
+  height: 50px;
 }
 
 #new-banner > p {
   text-align: center;
+  padding: 0px 5px 0px 5px;
   font-size: 18px;
+  line-height: 23px;
 }
 
 #new-banner a {

--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -2,16 +2,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 50px;
   background: #5865F2;
   color: white;
-  height: 50px;
 }
 
 #new-banner > p {
   text-align: center;
-  padding: 0px 5px 0px 5px;
+  padding: 2px 5px 2px 5px;
+  margin: 0px;
   font-size: 18px;
-  line-height: 23px;
 }
 
 #new-banner a {
@@ -110,6 +110,10 @@
 }
 
 @media (max-width: 900px) {
+  #new-banner > p {
+    font-size: 17px;
+  }
+
   #intro {
     flex-direction: column;
     align-items: center;

--- a/packages/lit-dev-content/site/css/home/1-splash.css
+++ b/packages/lit-dev-content/site/css/home/1-splash.css
@@ -111,7 +111,7 @@
 
 @media (max-width: 900px) {
   #new-banner > p {
-    font-size: 17px;
+    font-size: 16px;
   }
 
   #intro {


### PR DESCRIPTION
At the top of the hompage, a blue banner promotes the Lit discord channel.

Looks great on Desktop dimensions.

However, on mobile dimensions where the width of the page is smaller, text spills over to the next line. The container is a forced height, so content is too close to the edges and too far apart between text lines. Also, the lack of padding makes the text bump against the side of the screen at certain dimensions.

I made small changes to all of this. Since this is front and center at the home page of the website, I think it's important there's no underpadded, overflowing content.