### PR TITLE
Remove versioned v2 pages from search results

### DIFF
--- a/packages/lit-dev-tools-cjs/src/search/indexers/index-docs.ts
+++ b/packages/lit-dev-tools-cjs/src/search/indexers/index-docs.ts
@@ -22,6 +22,8 @@ export const indexDocs = async (outputDir: string, idOffset = 0) => {
       ['docs', 'internal'],
       // Would pollute results and would require more ui hints for v1 stuff
       ['docs', 'v1'],
+      // Removed versioned v2 documentation - which currently duplicates all results
+      ['docs', 'v2'],
       // handled by the api indexer
       ['docs', 'api'],
     ];


### PR DESCRIPTION
Fixes duplicate results appearing in search results.
Currently the versioned v2 and unversioned content is indexed leading to duplicate results.


To reproduce, search on lit.dev for `lifecycle`. Notice when scrolling down you get both options.


Fix is to filter out the `v2` directory.
