### PR TITLE
Add a file patch to circumvent broken module resolution in v3 generated repo d.ts file

### DIFF
--- a/packages/lit-dev-api/api-data/lit-3/pages.json
+++ b/packages/lit-dev-api/api-data/lit-3/pages.json
@@ -6,7 +6,7 @@
       "v1": "api/lit-element/LitElement/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "LitElement",
@@ -3116,7 +3116,7 @@
       "v1": "api/lit-element/UpdatingElement/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "ReactiveElement",
@@ -6265,7 +6265,7 @@
       "v1": "api/lit-html/templates/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "html",
@@ -6851,7 +6851,7 @@
       "v1": "api/lit-element/styles/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "adoptStyles",
@@ -7463,7 +7463,7 @@
       "v1": "api/lit-element/decorators/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "customElement",
@@ -8768,7 +8768,7 @@
       "v1": "api/lit-html/directives/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "asyncAppend",
@@ -17744,7 +17744,7 @@
       "v1": "api/lit-html/custom-directives/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "AsyncDirective",
@@ -21810,7 +21810,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 226,
+            "line": 215,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21820,7 +21820,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 106
+                "line": 105
               }
             ],
             "parameters": [
@@ -21867,7 +21867,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 208,
+            "line": 207,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21877,7 +21877,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 99
+                "line": 98
               }
             ],
             "parameters": [
@@ -21923,7 +21923,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 67,
+            "line": 66,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21933,7 +21933,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 33
+                "line": 32
               }
             ],
             "parameters": [
@@ -21989,7 +21989,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 96,
+            "line": 95,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21999,7 +21999,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 55
+                "line": 54
               }
             ],
             "parameters": [
@@ -22091,7 +22091,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 60,
+            "line": 59,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22101,7 +22101,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 29
+                "line": 28
               }
             ],
             "parameters": [
@@ -22164,7 +22164,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 34,
+            "line": 33,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22174,7 +22174,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 16
+                "line": 15
               }
             ],
             "parameters": [
@@ -22222,7 +22222,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 79,
+            "line": 78,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22232,7 +22232,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 42
+                "line": 41
               }
             ],
             "parameters": [
@@ -22278,7 +22278,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 48,
+            "line": 47,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22288,7 +22288,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 25
+                "line": 24
               }
             ],
             "parameters": [
@@ -22362,7 +22362,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 215,
+            "line": 214,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22372,7 +22372,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 105
+                "line": 104
               }
             ],
             "parameters": [
@@ -22422,7 +22422,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 167,
+            "line": 166,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22432,7 +22432,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 72
+                "line": 71
               }
             ],
             "typeParameter": [
@@ -22528,7 +22528,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 191,
+            "line": 190,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22538,7 +22538,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 84
+                "line": 83
               }
             ],
             "parameters": [
@@ -22595,12 +22595,12 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 37,
+            "line": 34,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           },
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 42,
+            "line": 40,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22617,7 +22617,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                    "line": 18
+                    "line": 17
                   }
                 ],
                 "type": {
@@ -22634,7 +22634,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                    "line": 19
+                    "line": 18
                   }
                 ],
                 "type": {
@@ -22647,7 +22647,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 17
+                "line": 16
               }
             ],
             "kindString": "Type literal"
@@ -22711,7 +22711,7 @@
       "v1": "api/lit-html/templates/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "html",
@@ -23396,7 +23396,7 @@
       "v1": "api/lit-element/LitElement/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "ReactiveController",
@@ -23851,7 +23851,7 @@
       "v1": "api/lit-element/LitElement/"
     },
     "repo": "lit/lit",
-    "commit": "d04a3e30eb3ae3520fb0ac163fb5ddbbf6030620",
+    "commit": "12109c25997ef03180d7eefe05c64e0fb20dd2b0",
     "items": [
       {
         "name": "defaultConverter",

--- a/packages/lit-dev-api/api-data/lit-3/pages.json
+++ b/packages/lit-dev-api/api-data/lit-3/pages.json
@@ -21810,7 +21810,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 215,
+            "line": 226,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21820,7 +21820,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 105
+                "line": 106
               }
             ],
             "parameters": [
@@ -21867,7 +21867,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 207,
+            "line": 208,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21877,7 +21877,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 98
+                "line": 99
               }
             ],
             "parameters": [
@@ -21923,7 +21923,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 66,
+            "line": 67,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21933,7 +21933,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 32
+                "line": 33
               }
             ],
             "parameters": [
@@ -21989,7 +21989,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 95,
+            "line": 96,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -21999,7 +21999,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 54
+                "line": 55
               }
             ],
             "parameters": [
@@ -22091,7 +22091,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 59,
+            "line": 60,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22101,7 +22101,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 28
+                "line": 29
               }
             ],
             "parameters": [
@@ -22164,7 +22164,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 33,
+            "line": 34,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22174,7 +22174,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 15
+                "line": 16
               }
             ],
             "parameters": [
@@ -22222,7 +22222,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 78,
+            "line": 79,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22232,7 +22232,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 41
+                "line": 42
               }
             ],
             "parameters": [
@@ -22278,7 +22278,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 47,
+            "line": 48,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22288,7 +22288,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 24
+                "line": 25
               }
             ],
             "parameters": [
@@ -22362,7 +22362,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 214,
+            "line": 215,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22372,7 +22372,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 104
+                "line": 105
               }
             ],
             "parameters": [
@@ -22422,7 +22422,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 166,
+            "line": 167,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22432,7 +22432,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 71
+                "line": 72
               }
             ],
             "typeParameter": [
@@ -22528,7 +22528,7 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 190,
+            "line": 191,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22538,7 +22538,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 83
+                "line": 84
               }
             ],
             "parameters": [
@@ -22595,12 +22595,12 @@
         "sources": [
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 34,
+            "line": 37,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           },
           {
             "fileName": "packages/lit-html/src/directive-helpers.ts",
-            "line": 40,
+            "line": 42,
             "moduleSpecifier": "lit-html/directive-helpers.js"
           }
         ],
@@ -22617,7 +22617,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                    "line": 17
+                    "line": 18
                   }
                 ],
                 "type": {
@@ -22634,7 +22634,7 @@
                 "sources": [
                   {
                     "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                    "line": 18
+                    "line": 19
                   }
                 ],
                 "type": {
@@ -22647,7 +22647,7 @@
             "sources": [
               {
                 "fileName": "packages/lit-dev-api/api-data/lit-3/repo/packages/lit-html/development/directive-helpers.d.ts",
-                "line": 16
+                "line": 17
               }
             ],
             "kindString": "Type literal"

--- a/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-3.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/configs/lit-3.ts
@@ -42,6 +42,28 @@ export const lit3Config: ApiDocsConfig = {
     pathlib.join(srcDir, 'static-html.ts'),
   ],
 
+  extraSetupCommands: [
+    {
+      cmd: 'npm',
+      args: ['run', 'build:ts'],
+    },
+    // Apply file patch to fix typedoc errors during docs generation. Because
+    // `npm run build:ts` is run prior to this, the patch file can always be
+    // applied unless a change has occurred in the file being patched.
+    {
+      cmd: 'patch',
+      // directive-helpers contains an import of the private `ChildPart` class
+      // that typedoc cannot resolve. By stripping this import typedoc
+      // successfully generates API docs without changing the generated docs
+      // output.
+      args: [
+        'packages/lit-html/development/directive-helpers.d.ts',
+        '-i',
+        '../../../../../packages/lit-dev-tools-cjs/src/api-docs/lit-3-patches/fix-directive-helpers-declaration.patch',
+      ],
+    },
+  ],
+
   pages: [
     {
       slug: 'LitElement',

--- a/packages/lit-dev-tools-cjs/src/api-docs/generate.ts
+++ b/packages/lit-dev-tools-cjs/src/api-docs/generate.ts
@@ -11,17 +11,14 @@ import {execFile} from 'child_process';
 import {promisify} from 'util';
 import {ApiDocsTransformer} from './transformer.js';
 import {lit2Config} from './configs/lit-2.js';
-
-// TODO(https://github.com/lit/lit.dev/issues/1112) Fix automatic generation of
-// Lit 3.0 docs.
-// import {lit3Config} from './configs/lit-3.js';
+import {lit3Config} from './configs/lit-3.js';
 
 import type {ApiDocsConfig} from './types.js';
 
 const execFileAsync = promisify(execFile);
 
 // Only generate documentation for most recent Lit versions.
-const configs = [lit2Config /* , lit3Config */];
+const configs = [lit2Config, lit3Config];
 
 /**
  * Check whether the given file path exists.

--- a/packages/lit-dev-tools-cjs/src/api-docs/lit-3-patches/fix-directive-helpers-declaration.patch
+++ b/packages/lit-dev-tools-cjs/src/api-docs/lit-3-patches/fix-directive-helpers-declaration.patch
@@ -1,6 +1,6 @@
 --- packages/lit-html/development/directive-helpers.d.ts	2023-05-15 17:13:11
 +++ packages/lit-html/development/directive-helpers_new.d.ts	2023-05-16 13:31:18
-@@ -5,9 +5,8 @@
+@@ -5,9 +5,9 @@
   */
  import { Part, DirectiveParent, TemplateResult } from './lit-html.js';
  import { DirectiveResult, DirectiveClass, PartInfo } from './directive.js';
@@ -9,7 +9,7 @@
 -type ChildPart = InstanceType<typeof ChildPart>;
 +type Primitive = null | undefined | boolean | number | string | symbol | bigint; 
 +type ChildPart = import("./lit-html.js").ChildPart;
-+
++ 
  /**
   * Tests if a value is a primitive value.
   *

--- a/packages/lit-dev-tools-cjs/src/api-docs/lit-3-patches/fix-directive-helpers-declaration.patch
+++ b/packages/lit-dev-tools-cjs/src/api-docs/lit-3-patches/fix-directive-helpers-declaration.patch
@@ -1,0 +1,16 @@
+--- packages/lit-html/development/directive-helpers.d.ts	2023-05-15 17:13:11
++++ packages/lit-html/development/directive-helpers_new.d.ts	2023-05-16 13:31:18
+@@ -5,9 +5,8 @@
+  */
+ import { Part, DirectiveParent, TemplateResult } from './lit-html.js';
+ import { DirectiveResult, DirectiveClass, PartInfo } from './directive.js';
+-type Primitive = null | undefined | boolean | number | string | symbol | bigint;
+-declare const ChildPart: typeof import("./lit-html.js").ChildPart;
+-type ChildPart = InstanceType<typeof ChildPart>;
++type Primitive = null | undefined | boolean | number | string | symbol | bigint; 
++type ChildPart = import("./lit-html.js").ChildPart;
++
+ /**
+  * Tests if a value is a primitive value.
+  *
+\ No newline at end of file


### PR DESCRIPTION
Fixes https://github.com/lit/lit.dev/issues/1111 and https://github.com/lit/lit.dev/issues/1112

### Context

TypeScript 5.0 creates a declaration file that typedoc doesn't resolve. This can be worked around by patching the file after `build:ts` such that it can be understood.

I also bumped the Lit 3.0 pre-release commit hash.


### Test

Tested because `pages.json` hasn't changes and "check API data in sync" has passed.