### PR TITLE
Fix edit link to unversioned URLs linking to a 404 GitHub page

### DIFF
--- a/packages/lit-dev-content/site/_includes/docs.html
+++ b/packages/lit-dev-content/site/_includes/docs.html
@@ -9,6 +9,7 @@
 {% endif %}
 {% set isLatestVersionedUrl = selectedVersion == latestVersion and page.url.includes("/" + latestVersion + "/") %}
 {% set isUnversionedPage = page.inputPath.includes("/unversioned/") %}
+{% set editableFilePath = page.inputPath.replace("/unversioned/", "/" + selectedVersion + "/") %}
 
 {% block head %}
   {% include "social-tags.html" %}
@@ -49,7 +50,6 @@
         </div>
       </nav>
     {% endif %}
-    <litdev-edit-this-page filepath="{{ page.inputPath }}"></litdev-edit-this-page>
   </div>
 
   <div id="articleWrapper">
@@ -71,7 +71,7 @@
       {% if not nonEditableDocumentRegex.test(page.inputPath) %}
       <p id="edit-page-link">
         <a
-            href="https://github.com/lit/lit.dev/edit/main/packages/lit-dev-content/{{ page.inputPath }}">
+            href="https://github.com/lit/lit.dev/edit/main/packages/lit-dev-content/{{ editableFilePath }}">
           Edit this page
           <lazy-svg
               loading="visible"


### PR DESCRIPTION
### Issue

Recently we added #1107 which generates unversioned files from the latest versioned directory. This broke the edit links for unversioned files.

Repro:

On an unversioned URL, try and edit the page. E.g., https://lit.dev/docs/#:~:text=reusable%2C%20maintainable%20code.-,Edit%20this%20page,-Next

Issue is that we end up navigating to https://github.com/lit/lit.dev/edit/main/packages/lit-dev-content/site/docs/unversioned/index.md, which does not exist because the `/unversioned/` subdirectory is generated.


### Fix

Swap out `/unversioned/` with the `selectedVersion` for that page - which points to where the file was copied from. `/unversioned/index.html` will become `/v2/index.html`, which exists and can be edited.

Change is a build time fix.

### Cleanup

I removed `litdev-edit-this-page` which is not defined and therefore never renders anything. It was added in this commit https://github.com/lit/lit.dev/pull/919/files#diff-37acd914daae6f611ba2456cb543eb346fbdf40de724300d259ff940ef20ef79R43 and I think it may have been an accident. As the element doesn't render anything I think this is a no-op removal. I tried to search the repo for any references and couldn't find any.


Thank you!