### PR TITLE
Fix Motion examples package.json formatting and trailing comma

### DIFF
--- a/packages/lit-dev-content/samples/examples/motion-carousel/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-carousel/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-grid/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-grid/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-hero/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-hero/project.json
@@ -9,7 +9,7 @@
     "support.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-in-out/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-in-out/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-list/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-list/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-simple/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-simple/project.json
@@ -7,7 +7,7 @@
     "motion-slide.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-todos/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-todos/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",\n    \"@material/mwc-textfield\": \"^0.25.1\",\n    \"@material/mwc-checkbox\": \"^0.25.1\",\n    \"@material/mwc-button\": \"^0.25.1\",\n    \"@material/mwc-formfield\": \"^0.25.1\"  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",\n    \"@material/mwc-textfield\": \"^0.25.1\",\n    \"@material/mwc-checkbox\": \"^0.25.1\",\n    \"@material/mwc-button\": \"^0.25.1\",\n    \"@material/mwc-formfield\": \"^0.25.1\"\n  }\n}",
       "hidden": true
     }
   },


### PR DESCRIPTION
### Issue

Motion package.json samples have:

```json
{
  "dependencies": {
    "lit": "^2.0.0",
    "@lit-labs/motion": "^1.0.1",  }
}
```

Which result in error: `Invalid package.json: SyntaxError: Expected double-quoted property name in JSON at position 78`.

Repro at: https://lit.dev/playground/#sample=examples/motion-list

### Fix

Remove trailing comma.

### Testing

This is a tidy up change as there was no user facing impact (unless they created a `package.json`). Tested manually by checking the motion samples still work locally.