### PR TITLE
Update playground-elements to v0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@types/codemirror": "^5.60.7",
-        "playground-elements": "^0.17.0",
+        "playground-elements": "^0.18.0",
         "prettier": "^2.1.2",
         "typescript": "~4.7.4",
         "wireit": "^0.9.4"
@@ -7081,9 +7081,9 @@
       }
     },
     "node_modules/playground-elements": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.17.1.tgz",
-      "integrity": "sha512-cizOM5yuq+Mh3H2fiJuLfQYV6W1IdQ2lY4kKGKwzh47XXVeZvFImcCzm9FAzxIiW/5qTfhYT5H71OJOaffnoOQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.18.0.tgz",
+      "integrity": "sha512-Pdoq1gs2pEadMhrvHF84vk6WghHEOFe+PmtvSJn4bpatGmi720OJuS1+UBDVS05XxHZ8C4VpD6IdlaNGMksDnA==",
       "dev": true,
       "dependencies": {
         "@material/mwc-button": "^0.27.0",
@@ -15219,9 +15219,9 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "playground-elements": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.17.1.tgz",
-      "integrity": "sha512-cizOM5yuq+Mh3H2fiJuLfQYV6W1IdQ2lY4kKGKwzh47XXVeZvFImcCzm9FAzxIiW/5qTfhYT5H71OJOaffnoOQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.18.0.tgz",
+      "integrity": "sha512-Pdoq1gs2pEadMhrvHF84vk6WghHEOFe+PmtvSJn4bpatGmi720OJuS1+UBDVS05XxHZ8C4VpD6IdlaNGMksDnA==",
       "dev": true,
       "requires": {
         "@material/mwc-button": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "playground-elements": "^0.17.0",
+    "playground-elements": "^0.18.0",
     "prettier": "^2.1.2",
     "typescript": "~4.7.4",
     "wireit": "^0.9.4"


### PR DESCRIPTION
Fixes https://github.com/lit/lit.dev/issues/1128


### Testing

Apart from our unit test coverage, I also manually checked the tutorials & code samples on the site.

Because the bundled version has been updated to TS 5, there is a chance that certain gists and prior code now has TS errors. However that does not seem to be avoidable unless we add a feature to bundle TypeScript versions.