### PR TITLE
Add a small note about type checking context

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/data/context.md
+++ b/packages/lit-dev-content/site/docs/v2/data/context.md
@@ -129,7 +129,9 @@ class MyElement extends LitElement {
 }
 ```
 
-TypeScript will warn that the type `string` is not assignable to the type `Logger`.
+TypeScript will warn that the type `string` is not assignable to the type `Logger`. Note that this check is currently only for public fields.
+
+<!-- More info on type checking at https://github.com/lit/lit/issues/3926 -->
 
 #### Context equality
 

--- a/packages/lit-dev-content/site/docs/v2/data/context.md
+++ b/packages/lit-dev-content/site/docs/v2/data/context.md
@@ -131,7 +131,9 @@ class MyElement extends LitElement {
 
 TypeScript will warn that the type `string` is not assignable to the type `Logger`. Note that this check is currently only for public fields.
 
-<!-- More info on type checking at https://github.com/lit/lit/issues/3926 -->
+<!-- 
+  TODO https://github.com/lit/lit/issues/3926 this will likely need to be updated once we move to standard decorators.
+ -->
 
 #### Context equality
 

--- a/packages/lit-dev-content/site/docs/v3/data/context.md
+++ b/packages/lit-dev-content/site/docs/v3/data/context.md
@@ -130,7 +130,9 @@ class MyElement extends LitElement {
 ```
 
 TypeScript will warn that the type `string` is not assignable to the type `Logger`. Note that this check is currently only for public fields.
-<!-- More info on type checking at https://github.com/lit/lit/issues/3926 -->
+<!-- 
+  TODO https://github.com/lit/lit/issues/3926 this will likely need to be updated once we move to standard decorators.
+ -->
 
 #### Context equality
 

--- a/packages/lit-dev-content/site/docs/v3/data/context.md
+++ b/packages/lit-dev-content/site/docs/v3/data/context.md
@@ -129,7 +129,8 @@ class MyElement extends LitElement {
 }
 ```
 
-TypeScript will warn that the type `string` is not assignable to the type `Logger`.
+TypeScript will warn that the type `string` is not assignable to the type `Logger`. Note that this check is currently only for public fields.
+<!-- More info on type checking at https://github.com/lit/lit/issues/3926 -->
 
 #### Context equality
 

--- a/packages/lit-dev-content/site/docs/v3/data/context.md
+++ b/packages/lit-dev-content/site/docs/v3/data/context.md
@@ -130,6 +130,7 @@ class MyElement extends LitElement {
 ```
 
 TypeScript will warn that the type `string` is not assignable to the type `Logger`. Note that this check is currently only for public fields.
+
 <!-- 
   TODO https://github.com/lit/lit/issues/3926 this will likely need to be updated once we move to standard decorators.
  -->


### PR DESCRIPTION
I didn't want to go into the full details because it felt like it would disrupt the flow of this page, and the main information that people need to know is that we're not type checking private or protected fields.