### PR TITLE
Fix font in examples/properties-basic sample

### DIFF
--- a/packages/lit-dev-content/samples/examples/properties-basic/index.html
+++ b/packages/lit-dev-content/samples/examples/properties-basic/index.html
@@ -4,7 +4,7 @@
     <script type="module" src="./name-tag.js"></script>
     <style>
       body {
-        font-family: sans-serif'
+        font-family: sans-serif;
       }
     </style>
   </head>


### PR DESCRIPTION
Fixes font not being applied in https://lit.dev/playground/#sample=examples/properties-basic, due to an errant single quote at the end of the `font-family` value.

Fix is to replace quote with semicolon. It's also technically possible to leave out the last semicolon so removing the single quote is also a possible solution.


Tested manually by checking the sample looks good now!

### Screenshots

#### Prior
<img width="875" alt="Screenshot 2023-05-31 at 5 41 53 PM" src="https://github.com/lit/lit.dev/assets/15080861/7eea8596-e565-44f7-b2f6-0a5b6efd2f1e">

In developer tools: `Rendered font: Times—Local file(33 glyphs)`

#### With this change

<img width="859" alt="Screenshot 2023-05-31 at 5 41 46 PM" src="https://github.com/lit/lit.dev/assets/15080861/8d4b8b29-c7e0-4346-aa22-1d7fc3b68c34">





