### PR TITLE
[infra] Update rollup config and remove unneeded types packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2199,15 +2199,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==",
-      "deprecated": "This is a stub types definition for source-map (https://github.com/mozilla/source-map). source-map provides its own type definitions, so you don't need @types/source-map installed!",
-      "dependencies": {
-        "source-map": "*"
-      }
-    },
     "node_modules/@types/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -9333,7 +9324,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/jsdom": "^16.2.13",
-        "@types/source-map": "^0.5.7",
         "@types/strip-comments": "^2.0.1",
         "@web/dev-server": "^0.1.6",
         "@web/dev-server-core": "^0.3.5",
@@ -11333,14 +11323,6 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
-      }
-    },
-    "@types/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==",
-      "requires": {
-        "source-map": "*"
       }
     },
     "@types/strip-comments": {
@@ -14520,7 +14502,6 @@
       "version": "file:packages/lit-dev-tools-cjs",
       "requires": {
         "@types/jsdom": "^16.2.13",
-        "@types/source-map": "^0.5.7",
         "@types/strip-comments": "^2.0.1",
         "@web/dev-server": "^0.1.6",
         "@web/dev-server-core": "^0.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2124,16 +2124,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
       "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ=="
     },
-    "node_modules/@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "*"
-      }
-    },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
@@ -9293,8 +9283,7 @@
         "@types/koa-conditional-get": "^2.0.0",
         "@types/koa-etag": "^3.0.0",
         "@types/koa-send": "^4.1.3",
-        "@types/koa-static": "^4.0.1",
-        "@types/node-fetch": "^3.0.3"
+        "@types/koa-static": "^4.0.1"
       }
     },
     "packages/lit-dev-tests": {
@@ -11270,15 +11259,6 @@
       "version": "16.11.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
       "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ=="
-    },
-    "@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "*"
-      }
     },
     "@types/parse5": {
       "version": "6.0.3",
@@ -14498,7 +14478,6 @@
         "@types/koa-etag": "^3.0.0",
         "@types/koa-send": "^4.1.3",
         "@types/koa-static": "^4.0.1",
-        "@types/node-fetch": "^3.0.3",
         "koa": "^2.13.0",
         "koa-conditional-get": "^3.0.0",
         "koa-etag": "^4.0.0",

--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -99,7 +99,7 @@ export default [
         showMinifiedSize: false,
       }),
     ],
-    preserveEntrySignatures: 'strict',
+    preserveEntrySignatures: false,
   },
 
   // A separate bundle is made for the server so that we do not modify the

--- a/packages/lit-dev-content/rollup.config.js
+++ b/packages/lit-dev-content/rollup.config.js
@@ -30,7 +30,6 @@ const terserOptions = {
 
 export default [
   {
-    name: 'client',
     input: [
       // lit-hydrate-support MUST be loaded first to make sure lit hydration
       // helpers are bundled before LitElement attempts to use hydration support
@@ -100,14 +99,13 @@ export default [
         showMinifiedSize: false,
       }),
     ],
+    preserveEntrySignatures: 'strict',
   },
+
+  // A separate bundle is made for the server so that we do not modify the
+  // client module graph just to SSR a component.
   {
-    name: 'SSR',
-    input: [
-      // A separate bundle is made for the server so that we do not modify the
-      // client module graph just to SSR a component.
-      'lib/components/ssr.js',
-    ],
+    input: ['lib/components/ssr.js'],
     output: {
       dir: 'rollupout/server',
       format: 'esm',

--- a/packages/lit-dev-server/package.json
+++ b/packages/lit-dev-server/package.json
@@ -74,7 +74,6 @@
     "@types/koa-conditional-get": "^2.0.0",
     "@types/koa-etag": "^3.0.0",
     "@types/koa-send": "^4.1.3",
-    "@types/koa-static": "^4.0.1",
-    "@types/node-fetch": "^3.0.3"
+    "@types/koa-static": "^4.0.1"
   }
 }

--- a/packages/lit-dev-tools-cjs/package.json
+++ b/packages/lit-dev-tools-cjs/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@types/jsdom": "^16.2.13",
-    "@types/source-map": "^0.5.7",
     "@types/strip-comments": "^2.0.1",
     "@web/dev-server": "^0.1.6",
     "@web/dev-server-core": "^0.3.5",


### PR DESCRIPTION
Removed `@types/source-map` and `@types/node-fetch` as these packages already ships with type. The following warnings were showing up on npm installs:
```
npm WARN deprecated @types/source-map@0.5.7: This is a stub types definition for source-map (https://github.com/mozilla/source-map). source-map provides its own type definitions, so you don't need @types/source-map installed!
npm WARN deprecated @types/node-fetch@3.0.3: This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.
```

Removed the `name` fields from rollup output config that was causing the following warning:
```
(!) You have passed an unrecognized option
Unknown input options: name. Allowed options: acorn, acornInjectPlugins, cache, context, experimentalCacheExpiry, external, inlineDynamicImports, input, makeAbsoluteExternalsRelative, manualChunks, maxParallelFileOps, maxParallelFileReads, moduleContext, onwarn, perf, plugins, preserveEntrySignatures, preserveModules, preserveSymlinks, shimMissingExports, strictDeprecations, treeshake, watch
```

Added `preserveEntrySignatures: false` to rollup config as per this warning:
```
(!) To preserve the export signature of the entry module "lib/global/hydrate-common-components.js", an empty facade chunk was created. This often happens when creating a bundle for a web app where chunks are placed in script tags and exports are ignored. In this case it is recommended to set "preserveEntrySignatures: false" to avoid this and reduce the number of chunks. Otherwise if this is intentional, set "preserveEntrySignatures: 'strict'" explicitly to silence this warning.
https://rollupjs.org/guide/en/#preserveentrysignatures
```