### PR TITLE
[examples] Pin `@types/react`

### DIFF
--- a/packages/lit-dev-content/samples/examples/react-basics/project.json
+++ b/packages/lit-dev-content/samples/examples/react-basics/project.json
@@ -15,7 +15,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"^18\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/examples/react-events/project.json
+++ b/packages/lit-dev-content/samples/examples/react-events/project.json
@@ -13,7 +13,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"^18\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/examples/react-refs/project.json
+++ b/packages/lit-dev-content/samples/examples/react-refs/project.json
@@ -13,7 +13,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@lit-labs/react\": \"^1.1.1\",\n    \"@types/react\": \"^18\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@lit-labs/react\": \"^1.1.1\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/examples/react-slots/project.json
+++ b/packages/lit-dev-content/samples/examples/react-slots/project.json
@@ -13,7 +13,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"^18\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }


### PR DESCRIPTION
It seems the latest update to `@types/react` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135 is causing a TS error in the playground.
<img width="777" alt="image" src="https://github.com/lit/lit.dev/assets/40413829/7e1e82cf-7cb5-4713-9b22-cf9bd6d400c4">

I can't reproduce the TS error in local VS Code and it only seems to happen within playground-elements. Will need to investigate this but for now pinning the version so the error isn't present in the playground seems good.