### PR TITLE
[infra] Deflake integration test

### DIFF
--- a/packages/lit-dev-tests/src/playwright/playground.spec.ts
+++ b/packages/lit-dev-tests/src/playwright/playground.spec.ts
@@ -78,6 +78,8 @@ test.describe('Playground', () => {
   test('updating the example code updates the preview', async ({page}) => {
     await page.goto(`/playground`);
 
+    await waitForPlaygroundPreviewToLoad(page);
+
     // Double click text=blue
     await page.dblclick('text=blue');
 


### PR DESCRIPTION
This should fix test failures like the one here: https://github.com/lit/lit.dev/actions/runs/5190347793/jobs/9356646136

This was due to the changing of code before the playground preview was loaded, which somehow broke the style such that the text just became black.