### PR TITLE
Fix TODO in lit-html 1 API docs

### DIFF
--- a/packages/lit-dev-api/api-data/lit-html-1/pages.json
+++ b/packages/lit-dev-api/api-data/lit-html-1/pages.json
@@ -91,10 +91,11 @@
           }
         ],
         "type": {
-          "type": "reflection",
-          "declaration": {
-            "name": "__type",
-            "kindString": "Type literal"
+          "type": "typeOperator",
+          "operator": "unique",
+          "target": {
+            "type": "intrinsic",
+            "name": "symbol"
           }
         },
         "defaultValue": "{}",
@@ -4467,10 +4468,11 @@
           }
         ],
         "type": {
-          "type": "reflection",
-          "declaration": {
-            "name": "__type",
-            "kindString": "Type literal"
+          "type": "typeOperator",
+          "operator": "unique",
+          "target": {
+            "type": "intrinsic",
+            "name": "symbol"
           }
         },
         "defaultValue": "{}",


### PR DESCRIPTION
The v1 docs no longer get automatically generated. I fixed the issue by manually updating the content such that it renders the correct `symbol` type.

Fixes https://github.com/lit/lit.dev/issues/1097


### Testing

`nothing` type is fixed: https://pr1139-93a3865---lit-dev-5ftespv5na-uc.a.run.app/docs/v1/api/lit-html/templates/#nothing

`noChange` type is fixed: https://pr1139-93a3865---lit-dev-5ftespv5na-uc.a.run.app/docs/v1/api/lit-html/custom-directives/#noChange