### PR TITLE
[infra] Use latest kaniko executor image for cloudbuild

### DIFF
--- a/cloudbuild-main.yaml
+++ b/cloudbuild-main.yaml
@@ -9,9 +9,7 @@ steps:
   # https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/docker
   # https://cloud.google.com/build/docs/kaniko-cache
   - id: build
-    # Kaniko pinned to earlier version due to
-    # https://github.com/GoogleContainerTools/kaniko/issues/1786
-    name: gcr.io/kaniko-project/executor:v1.6.0
+    name: gcr.io/kaniko-project/executor:latest
     args:
       - --dockerfile=./Dockerfile
       - --destination=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -13,9 +13,7 @@ steps:
   # https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/docker
   # https://cloud.google.com/build/docs/kaniko-cache
   - id: build
-    # Kaniko pinned to earlier version due to
-    # https://github.com/GoogleContainerTools/kaniko/issues/1786
-    name: gcr.io/kaniko-project/executor:v1.6.0
+    name: gcr.io/kaniko-project/executor:latest
     args:
       - --dockerfile=./Dockerfile
       - --destination=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/lit-dev:$COMMIT_SHA


### PR DESCRIPTION
The issue mentioned in the comment with the version pinning https://github.com/GoogleContainerTools/kaniko/issues/1786 has been fixed.

Our production build started failing though and seems kaniko related. The error shown in GCP is the same as https://github.com/GoogleContainerTools/kaniko/issues/1604

Not sure why we just started seeing this now, but trying to see if using the latest version fixes this.