### PR TITLE
Tutorial / Intro to Lit / 01: Add missing export declaration

### DIFF
--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/01.md
@@ -12,7 +12,7 @@ In Lit, most things start with defining a _component_. Here we've given you a st
     ```
 
     ```js
-    class MyElement extends LitElement {
+    export class MyElement extends LitElement {
     }
     customElements.define('my-element', MyElement);
     ```

--- a/packages/lit-dev-content/site/tutorials/content/intro-to-lit/01.md
+++ b/packages/lit-dev-content/site/tutorials/content/intro-to-lit/01.md
@@ -7,7 +7,7 @@ In Lit, most things start with defining a _component_. Here we've given you a st
 
     ```ts
     @customElement('my-element')
-    class MyElement extends LitElement {
+    export class MyElement extends LitElement {
     }
     ```
 


### PR DESCRIPTION
The class definition in the description didn't contain the export declaration.
I added it to match the output of the "solve" functionality.