### PR TITLE
Localization docs overview: minor typo in default JS config file

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/localization/overview.md
+++ b/packages/lit-dev-content/site/docs/v2/localization/overview.md
@@ -377,8 +377,8 @@ blank.
   "sourceLocale": "en",
   "targetLocales": ["es-419", "zh-Hans"],
   "inputFiles": [
-    "src/**/*.js",
-  ]
+    "src/**/*.js"
+  ],
   "output": {
     "mode": "runtime",
     "outputDir": "./src/generated/locales"

--- a/packages/lit-dev-content/site/docs/v3/localization/overview.md
+++ b/packages/lit-dev-content/site/docs/v3/localization/overview.md
@@ -377,8 +377,8 @@ blank.
   "sourceLocale": "en",
   "targetLocales": ["es-419", "zh-Hans"],
   "inputFiles": [
-    "src/**/*.js",
-  ]
+    "src/**/*.js"
+  ],
   "output": {
     "mode": "runtime",
     "outputDir": "./src/generated/locales"


### PR DESCRIPTION
This PR corrects a minor typo in the Localization › Overview section of the docs v2 & v3.

## Changes

- [Docs v2 › Localization › Overview › Config file](https://lit.dev/docs/v2/localization/overview/#config-file) (JS sample):
`inputFiles: ["src/**/*.js"],` instead of `inputFiles: ["src/**/*.js",]`
- [Docs v3 › Localization › Overview › Config file](https://lit.dev/docs/v3/localization/overview/#config-file) (JS sample):
`inputFiles: ["src/**/*.js"],` instead of `inputFiles: ["src/**/*.js",]`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
