### PR TITLE
fix typo in custom-directives.md

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/custom-directives.md
@@ -404,7 +404,7 @@ export const resolvePromise = directive(ResolvePromise);
 
 {% endswitchable-sample %}
 
-Here, the rendered template shows "Waiting for promise to resolve," followed by the resolved value of the promise, whenever it resolves.
+Here, the rendered template shows "Waiting for promise to resolve", followed by the resolved value of the promise, whenever it resolves.
 
 Async directives often need to subscribe to external resources. To prevent memory leaks async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
 

--- a/packages/lit-dev-content/site/docs/v3/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/custom-directives.md
@@ -404,7 +404,7 @@ export const resolvePromise = directive(ResolvePromise);
 
 {% endswitchable-sample %}
 
-Here, the rendered template shows "Waiting for promise to resolve," followed by the resolved value of the promise, whenever it resolves.
+Here, the rendered template shows "Waiting for promise to resolve", followed by the resolved value of the promise, whenever it resolves.
 
 Async directives often need to subscribe to external resources. To prevent memory leaks async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
 


### PR DESCRIPTION
"Waiting for promise to resolve" is displayed at following example, not "Waiting for promise to resolve,".

```js
class ResolvePromise extends AsyncDirective {
  render(promise) {
    Promise.resolve(promise).then((resolvedValue) => {
      // Rendered asynchronously:
      this.setValue(resolvedValue);
    });
    // Rendered synchronously:
    return `Waiting for promise to resolve`;
  }
}
export const resolvePromise = directive(ResolvePromise);
```