### PR TITLE
fix typo in custom-directives.md

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/custom-directives.md
@@ -406,7 +406,7 @@ export const resolvePromise = directive(ResolvePromise);
 
 Here, the rendered template shows "Waiting for promise to resolve", followed by the resolved value of the promise, whenever it resolves.
 
-Async directives often need to subscribe to external resources. To prevent memory leaks async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
+Async directives often need to subscribe to external resources. To prevent memory leaks, async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
 
 * `disconnected()`: Called when a directive is no longer in use.  Directive instances are disconnected in three cases:
   - When the DOM tree the directive is contained in is removed from the DOM

--- a/packages/lit-dev-content/site/docs/v3/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/custom-directives.md
@@ -406,7 +406,7 @@ export const resolvePromise = directive(ResolvePromise);
 
 Here, the rendered template shows "Waiting for promise to resolve", followed by the resolved value of the promise, whenever it resolves.
 
-Async directives often need to subscribe to external resources. To prevent memory leaks async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
+Async directives often need to subscribe to external resources. To prevent memory leaks, async directives should unsubscribe or dispose of resources when the directive instance is no longer in use.  For this purpose, `AsyncDirective` provides the following extra lifecycle callbacks and API:
 
 * `disconnected()`: Called when a directive is no longer in use.  Directive instances are disconnected in three cases:
   - When the DOM tree the directive is contained in is removed from the DOM


### PR DESCRIPTION
Since async directives do not  unsubscribe memory leaks, I think it is necessary to add `,`.