### PR TITLE
fix typo in templates/custom-directives.md

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/custom-directives.md
@@ -457,7 +457,7 @@ class ObserveDirective extends AsyncDirective {
   disconnected() {
     this.unsubscribe!();
   }
-  // If the subtree the directive is in was disconnected and subsequently
+  // If the directive is in was disconnected and subsequently
   // re-connected, re-subscribe to make the directive operable again
   reconnected() {
     this.subscribe(this.observable!);

--- a/packages/lit-dev-content/site/docs/v3/templates/custom-directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/custom-directives.md
@@ -457,7 +457,7 @@ class ObserveDirective extends AsyncDirective {
   disconnected() {
     this.unsubscribe!();
   }
-  // If the subtree the directive is in was disconnected and subsequently
+  // If the directive is in was disconnected and subsequently
   // re-connected, re-subscribe to make the directive operable again
   reconnected() {
     this.subscribe(this.observable!);


### PR DESCRIPTION
I think `the subtree` is unnecessary, since it does not fit context.