### PR TITLE
Update playground-elements to v0.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "playground-elements": "^0.18.0",
+        "playground-elements": "^0.18.1",
         "prettier": "^2.1.2",
         "typescript": "~4.7.4",
         "wireit": "^0.9.4"
@@ -7074,9 +7074,9 @@
       }
     },
     "node_modules/playground-elements": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.18.0.tgz",
-      "integrity": "sha512-Pdoq1gs2pEadMhrvHF84vk6WghHEOFe+PmtvSJn4bpatGmi720OJuS1+UBDVS05XxHZ8C4VpD6IdlaNGMksDnA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.18.1.tgz",
+      "integrity": "sha512-QCAK9oPZwI/+ZK9mWaS+JlyqTLD7npGZnTqYO0MnHPAkcgUUj6lcYtESy6WICxj0Jl6mBx4wLJFOfXAb6QxLNA==",
       "dev": true,
       "dependencies": {
         "@material/mwc-button": "^0.27.0",
@@ -15206,9 +15206,9 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "playground-elements": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.18.0.tgz",
-      "integrity": "sha512-Pdoq1gs2pEadMhrvHF84vk6WghHEOFe+PmtvSJn4bpatGmi720OJuS1+UBDVS05XxHZ8C4VpD6IdlaNGMksDnA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/playground-elements/-/playground-elements-0.18.1.tgz",
+      "integrity": "sha512-QCAK9oPZwI/+ZK9mWaS+JlyqTLD7npGZnTqYO0MnHPAkcgUUj6lcYtESy6WICxj0Jl6mBx4wLJFOfXAb6QxLNA==",
       "dev": true,
       "requires": {
         "@material/mwc-button": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "playground-elements": "^0.18.0",
+    "playground-elements": "^0.18.1",
     "prettier": "^2.1.2",
     "typescript": "~4.7.4",
     "wireit": "^0.9.4"


### PR DESCRIPTION
Tab should now be two spaces instead of one.

Upgrade to playground-elements 0.18.1: https://github.com/google/playground-elements/releases/tag/v0.18.1


### Test plan

Tested by spot checking the playground & demos. Pressed tab and checked that 2 spaces were created.