### PR TITLE
Add lit-labs/compiler to the v3 labs page

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/libraries/labs.md
+++ b/packages/lit-dev-content/site/docs/v3/libraries/labs.md
@@ -217,6 +217,20 @@ A plugin for [Eleventy](https://www.11ty.dev) that pre-renders Lit components at
 <tr>
 <td>
 
+[compiler](https://www.npmjs.com/package/@lit-labs/compiler)
+
+</td>
+<td>A compiler for optimizing Lit templates.</td>
+<td class="labs-table-links">
+
+[📄&nbsp;Docs](https://github.com/lit/lit/tree/main/packages/labs/compiler#readme "Docs")<br>[💬&nbsp;Feedback](https://github.com/lit/lit/discussions/4117 "Feedback")<br>[🐞&nbsp;Issues](https://github.com/lit/lit/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+%5Blabs%2Fcompiler%5D "Issues")
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 [router](https://www.npmjs.com/package/@lit-labs/router)
 
 </td>


### PR DESCRIPTION
Umbrella Issue: https://github.com/lit/lit/issues/189
RFC: https://github.com/lit/rfcs/pull/21
Specific Issue: https://github.com/lit/lit/issues/4101

### Context

This is required as part of the initial pre-release with Lit 3.0

### Test plan

Tested manually by viewing the labs v3 page.

https://pr1175-d24c562---lit-dev-5ftespv5na-uc.a.run.app/docs/v3/libraries/labs/

Screenshot:


![Screenshot 2023-08-18 at 12 08 40 PM](https://github.com/lit/lit.dev/assets/15080861/a3e83366-6674-48ce-a88b-13532964d2f7)
