### PR TITLE
[infra] Update wireit to 0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "playground-elements": "^0.18.1",
         "prettier": "^2.1.2",
         "typescript": "~4.7.4",
-        "wireit": "^0.9.4"
+        "wireit": "^0.14.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -8974,9 +8974,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.4.tgz",
-      "integrity": "sha512-QGDxePp956+tBXFAKt/1+cBwfUdCQ23+AcGnjmdTN/9GfkNqiHwfq6n7HyoYEx08tmN6K/faEozkLcMIllhVVg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.0.tgz",
+      "integrity": "sha512-CwHhyWduARI7zOoyyQvxH6U/5GTy8p6RxTe2LpwIhE4Y8PbaTk0iH8dLkeGMvxETVBkxCgQnF2GfzYKXMSmYSw==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -16715,9 +16715,9 @@
       }
     },
     "wireit": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.4.tgz",
-      "integrity": "sha512-QGDxePp956+tBXFAKt/1+cBwfUdCQ23+AcGnjmdTN/9GfkNqiHwfq6n7HyoYEx08tmN6K/faEozkLcMIllhVVg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.0.tgz",
+      "integrity": "sha512-CwHhyWduARI7zOoyyQvxH6U/5GTy8p6RxTe2LpwIhE4Y8PbaTk0iH8dLkeGMvxETVBkxCgQnF2GfzYKXMSmYSw==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "playground-elements": "^0.18.1",
     "prettier": "^2.1.2",
     "typescript": "~4.7.4",
-    "wireit": "^0.9.4"
+    "wireit": "^0.14.0"
   }
 }


### PR DESCRIPTION
This is a small infrastructure bump to keep lit.dev on the most recent wireit version.

Risk should be small.