### PR TITLE
Flip site to v3 as the latest Lit version

### DIFF
--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -67,16 +67,11 @@
 
     {% include 'header.html' %}
 
-    {% if selectedVersion !== latestVersion and selectedVersion !== "v3"  %}
+    {% if selectedVersion !== latestVersion %}
       <litdev-banner>
         You're viewing docs for an older version of Lit. Click
         <a href="{{ versions[latestVersion].path }}/{{ versionLinks[latestVersion] }}">
         here</a> for the latest version.
-      </litdev-banner>
-    {% elif selectedVersion === "v3" %}
-      <litdev-banner>
-        You're viewing docs for a pre-release version of Lit. Read the Lit 3.0 pre-releases
-        announcement <a href="/blog/2023-05-15-lit-3.0-prerelease/">here</a>.
       </litdev-banner>
     {% endif %}
 

--- a/packages/lit-dev-content/site/docs/v2/v2.json
+++ b/packages/lit-dev-content/site/docs/v2/v2.json
@@ -1,3 +1,4 @@
 {
-  "collection": "docs-v2"
+  "collection": "docs-v2",
+  "selectedVersion": "v2"
 }

--- a/packages/lit-dev-content/site/site.json
+++ b/packages/lit-dev-content/site/site.json
@@ -1,13 +1,13 @@
 {
-  "selectedVersion": "v2",
-  "latestVersion": "v2",
+  "selectedVersion": "v3",
+  "latestVersion": "v3",
   "versions": {
     "v3": {
-      "path": "/docs/v3",
+      "path": "/docs",
       "label": "v3"
     },
     "v2": {
-      "path": "/docs",
+      "path": "/docs/v2",
       "label": "v2"
     },
     "v1": {

--- a/packages/lit-dev-tools-esm/src/build-unversioned-docs.ts
+++ b/packages/lit-dev-tools-esm/src/build-unversioned-docs.ts
@@ -15,7 +15,7 @@ const CONTENT_PKG = pathlib.resolve(REPO_ROOT, 'packages', 'lit-dev-content');
 const SITE_JSON = pathlib.resolve(CONTENT_PKG, 'site', 'site.json');
 
 interface SiteJSON {
-  latestVersion: 'v1' | 'v2';
+  latestVersion: 'v1' | 'v2' | 'v3';
 }
 
 type EleventyFrontMatterData = string[];
@@ -44,7 +44,7 @@ const UNVERSIONED_VERSION_LOCATION = pathlib.resolve(
  *
  * The following transforms are then applied on the files:
  *   - Permalink frontmatter is added to strip the version from the URL. E.g.,
- *     /docs/v2/* becomes /docs/*.
+ *     /docs/v3/* becomes /docs/*.
  *  - `api.html` has frontmatter transformed so base api paths become
  *    unversioned.
  *  - The latest version `v[N].json` file is renamed `unversioned.json` so it


### PR DESCRIPTION
Issue: https://github.com/lit/lit.dev/issues/1190

### Context

This PR flips the unversioned part of the site to use `v3`. E.g., instead of `/docs` referring to `/docs/v2`, it will refer to `/docs/v3`.

### When to merge this PR

When we have released Lit 3.0. 