### PR TITLE
[infra] attempt to fix timeout on blocking render

### DIFF
--- a/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
@@ -45,7 +45,7 @@ export class BlockingRenderer {
   private exited = false;
   private renderTimeout: number;
 
-  constructor({renderTimeout = 120_000, maxHtmlBytes = 1024 * 1024} = {}) {
+  constructor({renderTimeout = 15_000, maxHtmlBytes = 1024 * 1024} = {}) {
     this.renderTimeout = renderTimeout;
     this.sharedHtml = new Uint8Array(new SharedArrayBuffer(maxHtmlBytes));
     this.worker = new workerthreads.Worker(

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
@@ -45,7 +45,7 @@ export class BlockingRenderer {
   private exited = false;
   private renderTimeout: number;
 
-  constructor({renderTimeout = 60_000, maxHtmlBytes = 1024 * 1024} = {}) {
+  constructor({renderTimeout = 120_000, maxHtmlBytes = 1024 * 1024} = {}) {
     this.renderTimeout = renderTimeout;
     this.sharedHtml = new Uint8Array(new SharedArrayBuffer(maxHtmlBytes));
     this.worker = new workerthreads.Worker(

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -156,6 +156,7 @@ export const playgroundPlugin = (
 
   eleventyConfig.addPairedShortcode(
     'highlight',
+    // TODO(ajakubowicz): this can be made async as of 11ty 2.0
     (code: string, lang: 'js' | 'ts' | 'html' | 'css') => render(code, lang)
   );
 

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -156,8 +156,14 @@ export const playgroundPlugin = (
 
   eleventyConfig.addPairedShortcode(
     'highlight',
-    // TODO(ajakubowicz): this can be made async as of 11ty 2.0
-    (code: string, lang: 'js' | 'ts' | 'html' | 'css') => render(code, lang)
+    async (code: string, lang: 'js' | 'ts' | 'html' | 'css'): Promise<string> => {
+      // Add a 2 -> 10 second jitter, so that we don't overload the blocking
+      // renderer. This is a hack to work around blocking code that can be made
+      // async now that 11ty supports async shortcodes.
+      // TODO: Add a non blocking render alternative.
+      await new Promise(resolve => setTimeout(resolve, Math.random() * 10_000 + 2_000))
+      return render(code, lang)
+    }
   );
 
   eleventyConfig.addMarkdownHighlighter(


### PR DESCRIPTION
Currently GitHub actions timeout and thus never run integration tests.

This is an attempt at a quick fix, to unblock us cheaply so working on Lit 3.0 release can go smoothly.