### PR TITLE
v3: upgrade guide decorator section

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/components/properties.md
+++ b/packages/lit-dev-content/site/docs/v3/components/properties.md
@@ -573,13 +573,11 @@ To specify how getting and setting works for a property, you can define your own
 ```ts
 private _prop = 0;
 
+@property()
 set prop(val: number) {
-  let oldVal = this._prop;
   this._prop = Math.floor(val);
-  this.requestUpdate('prop', oldVal);
 }
 
-@property()
 get prop() { return this._prop; }
 ```
 
@@ -591,9 +589,7 @@ static properties = {
 _prop = 0;
 
 set prop(val) {
-  let oldVal = this._prop;
   this._prop = Math.floor(val);
-  this.requestUpdate('prop', oldVal);
 }
 
 get prop() { return this._prop; }
@@ -601,9 +597,7 @@ get prop() { return this._prop; }
 
 {% endswitchable-sample %}
 
-To use custom property accessors with the `@property` or `@state` decorators, put the decorator on the getter, as shown above.
-
-The setters that Lit generates automatically call `requestUpdate()`. If you write your own setter you must call `requestUpdate()` manually, supplying the property name and its old value.
+To use custom property accessors with the `@property` or `@state` decorators, put the decorator on the setter, as shown above. `@property` or `@state` decorated setters call `requestUpdate()`.
 
 In most cases, **you do not need to create custom property accessors.** To compute values from existing properties, we recommend using the [`willUpdate`](/docs/v3/components/lifecycle/#willupdate) callback, which allows you to set values during the update cycle without triggering an additional update. To perform a custom action after the element updates, we recommend using the [`updated`](/docs/v3/components/lifecycle/#updated) callback. A custom setter can be used in rare cases when it's important to synchronously validate any value the user sets.
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -147,9 +147,38 @@ set myProperty (val) { ... }
 
 ### Optional: upgrade to standard decorators {#standard-decorator-migration}
 
-To use standard decorators, your decorators should add the `accessor` keyword.
-Lit 3 decorators are flexible and work as both experimental decorators, and as
-standard decorators.
+
+While Lit 3 adds support for standard decorators, we still recommend that TypeScript users stay with experimental decorators. This is because the emitted code for standard decorators from the TypeScript and Babel compilers is quite large at the moment.
+
+We will recommend standard decorators for production when browsers support them, or when we release decorator transform support in our new Lit compiler.
+
+But you can try standard decorators now, and they work in TypeScript 5.2 and above and Babel 7.23 with the `@babel/plugin-proposal-decorators` plugin.
+
+### Configuration
+
+#### TypeScript
+
+Install TypeScript 5.2 or later, and _remove_ the `"experimentalDecorators"` setting from your tsconfig if it's present.
+
+#### Babel
+
+Install Babel 7.23 or later, and [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators). Be sure to pass the `"version": "2023-05"` option to the plugin.
+
+### Source updates
+
+#### Add the `accessor` keyword to decorated fields.
+
+Standard decorators are not allowed to change the _kind_ of class member they decorate. Decorators that need to create getters and setters must be applied to existing getters and setters. To make this more ergonomic the decorators standard adds the `accessor` keyword which creates "auto accessors" when applied to a class field. Auto accessors look and act much like class fields, but create accessors on the prototype backed by private storage.
+
+```ts
+class A {
+  accessor foo = 42;
+}
+```ts
+
+The `@property()`, `@state()`, `@query()`, `@queryAll()`, `@queryAssignedElements()` and `@queryAssignedNode()` decorators require the `accessor` keyword.
+
+Example:
 
 ```ts
 class MyElement extends LitElement {

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -125,26 +125,6 @@ import '@lit-labs/ssr-client/lit-element-hydrate-support.js';
 import {hydrate} from '@lit-labs/ssr-client';
 ```
 
-### Optional: To aid migration to standard decorators, decorate hand written setters {#decorated-getter}
-
-When using standard decorators, `@property()` and `@state()` must be used on the
-setter for hand-written accessors, and will throw a type error when applied on a
-hand written getter. Thus we recommend incrementally migrating.
-
-```ts
-// This will throw a type error if using standard decorators.
-@property()
-get myProperty () { ... }
-
-set myProperty (val) { ... }
-
-// Becomes:
-get myProperty () { ... }
-
-@property()
-set myProperty (val) { ... }
-```
-
 ### Optional: upgrade to standard decorators {#standard-decorator-migration}
 
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -47,7 +47,7 @@ Changes to Lit decorator behavior in Lit 3.0:
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
 - Lit 3 decorators no longer support the `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should [migrate to standard decorators](#standard-decorator-migration).
-- [optional]: [We recommend migrating `@property()` and `@state()` to the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
+- [Optional]: [We recommend migrating `@property()` and `@state()` to the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
 
 ## List of removed APIs
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -42,7 +42,7 @@ While Lit 2 supported TypeScript experimental decorators and Babel's "2018-09" d
 
 The Lit 3 decorators are mostly backwards compatible with the Lit 2 TypeScript decorators - **most likely no changes are needed**.
 
-To make the Lit 2.x decorators consistent between both decorator modes there have been some minor breaking
+Some minor breaking changes were necessary to make the Lit decorators behave consistently between both experimental and standard decorator modes:
 changes to Lit decorator behavior in Lit 3.0:
 
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -40,7 +40,7 @@ changes to Lit decorator behavior in Lit 3.0:
 
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
-- Lit 3 decorators do not support Babel (`@babel/plugin-proposal-decorators`) with `version: "2018-09"`.
+- Lit 3 decorators no longer support `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should instead [migrate](#standard-decorator-migration) to use `version: "2023-05"` with plugin version greater than `7.23.0` which follows the TC39 standard decorator spec.
 - [optional]: [We recommend migrating `@property()` and `@state()` the the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
 
 ## List of removed APIs
@@ -138,4 +138,26 @@ get myProperty () { ... }
 
 @property()
 set myProperty (val) { ... }
+```
+
+### Optional: upgrade to standard decorators {#standard-decorator-migration}
+
+To use standard decorators, your decorators should add the `accessor` keyword.
+Lit 3 decorators are flexible and work as both experimental decorators, and as
+standard decorators.
+
+```ts
+class MyElement extends LitElement {
+  // Lit 3.0 experimental decorators, which are backwards compatible with Lit 2.0
+  @property()
+  myProperty = "initial value"
+
+  // Lit 3.0 adds support for standard decorators.
+  // When using TypeScript:
+  //  - `accessor` keyword is optional when `experimentalDecorators: true`.
+  //  - `accessor` keyword is required when `experimentalDecorators: false`.
+  @property()
+  accessor myProperty = "initial value"
+...
+}
 ```

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -38,10 +38,10 @@ The Lit 3 decorators are largely backwards compatible. If you've been using them
 To make the Lit 2.x decorators consistent between both decorator modes there have been some minor breaking
 changes to Lit decorator behavior in Lit 3.0:
 
-- `@property()` and `@state()` must be used on the setter for hand-written accessors. [Decorating the getter no longer works](#decorated-getter).
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
 - Lit 3 decorators do not support Babel (`@babel/plugin-proposal-decorators`) with `version: "2018-09"`.
+- [optional]: [We recommend migrating `@property()` and `@state()` the the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
 
 ## List of removed APIs
 
@@ -120,19 +120,20 @@ import '@lit-labs/ssr-client/lit-element-hydrate-support.js';
 import {hydrate} from '@lit-labs/ssr-client';
 ```
 
-### Hand written getters can no longer be reactive properties {#decorated-getter}
+### Optional: To aid migration to standard decorators, decorate hand written setters {#decorated-getter}
 
-`@property()` and `@state()` must be used on the setter for hand-written accessors,
-and will throw a type error when applied on a hand written getter.
+When using standard decorators, `@property()` and `@state()` must be used on the
+setter for hand-written accessors, and will throw a type error when applied on a
+hand written getter. Thus we recommend incrementally migrating.
 
 ```ts
-// This will throw a type error.
+// This will throw a type error if using standard decorators.
 @property()
 get myProperty () { ... }
 
 set myProperty (val) { ... }
 
-// Instead decorate the setter.
+// Becomes:
 get myProperty () { ... }
 
 @property()

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -186,4 +186,41 @@ class MyElement extends LitElement {
   accessor myProperty = "initial value"
 ...
 }
-```
+\```
+#### Move decorators from getters to setters
+
+Standard decorators can only replace the class member they're directly applied to. Lit decorators need to intercept property setting, so the decorators must be applied to setters. This is different from the Lit 2 recommendation of applying decorators to getters.
+
+For `@property()` and `@state()` you should also remove any `this.requestUpdate()` calls in the setter since this is done automatically now. If you need to _not_ have `requestUpdate()` called, you'll have to use the `hasChanged` property option.
+
+Note that for `@property()` and `@state()` the _getter_ will be called by the decorator when setting the property to retrieve the old value. This means that you _must_ define both a getter and a setter.
+
+Before:
+```ts
+class MyElement extends LitElement {
+  private _foo = 42;
+  set(v) {
+    const oldValue = this._foo;
+    this._foo = v;
+    this.requestUpdate('foo', oldValue);
+  }
+  @property()
+  get() {
+    return this._foo;
+  }
+}
+\```
+
+After:
+```ts
+class MyElement extends LitElement {
+  private _foo = 42;
+  @property()
+  set(v) {
+    this._foo = v;
+  }
+  get() {
+    return this._foo;
+  }
+}
+\```

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -182,14 +182,6 @@ Example:
 
 ```ts
 class MyElement extends LitElement {
-  // Lit 3.0 experimental decorators, which are backwards compatible with Lit 2.0
-  @property()
-  myProperty = "initial value"
-
-  // Lit 3.0 adds support for standard decorators.
-  // When using TypeScript:
-  //  - `accessor` keyword is optional when `experimentalDecorators: true`.
-  //  - `accessor` keyword is required when `experimentalDecorators: false`.
   @property()
   accessor myProperty = "initial value"
 ...

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -40,8 +40,9 @@ While Lit 2 supported TypeScript experimental decorators and Babel's "2018-09" d
 
 The Lit 3 decorators are mostly backwards compatible with the Lit 2 TypeScript decorators - **most likely no changes are needed**.
 
-Some minor breaking changes were necessary to make the Lit decorators behave consistently between both experimental and standard decorator modes:
-changes to Lit decorator behavior in Lit 3.0:
+Some minor breaking changes were necessary to make the Lit decorators behave consistently between both experimental and standard decorator modes.
+
+Changes to Lit decorator behavior in Lit 3.0:
 
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
@@ -58,7 +59,7 @@ impacted by this list.
 - [Removed deprecated call signature for the `queryAssignedNodes` decorator.](#removed-queryassignednodes-non-object)
 - [Moved experimental server side rendering hydration modules from `lit`, `lit-element`, and `lit-html` to `@lit-labs/ssr-client`.](#moved-experimental-hydration)
 
-## Steps to Upgrade
+## Steps to upgrade
 
 ### Removed `UpdatingElement` alias for `ReactiveElement` {#removed-updating-element}
 
@@ -88,7 +89,7 @@ import {customElement, property, state} from 'lit-element';
 import {customElement, property, state} from 'lit/decorators.js';
 ```
 
-### Deprecated `queryAssignedNodes(slot: string, flatten: bool, selector: string)` decorator removed {#removed-queryassignednodes-non-object}
+### Deprecated `queryAssignedNodes(slot: string, flatten: bool, selector: string)` decorator signature removed {#removed-queryassignednodes-non-object}
 
 Migrate any usage of `queryAssignedNodes` taking a selector to use `queryAssignedElements`.
 
@@ -125,7 +126,7 @@ import '@lit-labs/ssr-client/lit-element-hydrate-support.js';
 import {hydrate} from '@lit-labs/ssr-client';
 ```
 
-## Optional: upgrade to standard decorators {#standard-decorator-migration}
+## Optional: Upgrade to standard decorators {#standard-decorator-migration}
 
 While Lit 3 adds support for standard decorators, we still recommend that TypeScript users stay with experimental decorators. This is because the emitted code for standard decorators from the TypeScript and Babel compilers is quite large at the moment.
 
@@ -143,17 +144,11 @@ Install TypeScript 5.2 or later, and _remove_ the `"experimentalDecorators"` set
 
 Install Babel 7.23 or later, and [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators). Be sure to pass the `"version": "2023-05"` option to the plugin.
 
-### Source updates
+### Code changes
 
-#### Add the `accessor` keyword to decorated fields. {#add-accessor-to-decorated-fields}
+#### Add the `accessor` keyword to decorated fields {#add-accessor-to-decorated-fields}
 
-Standard decorators are not allowed to change the _kind_ of class member they decorate. Decorators that need to create getters and setters must be applied to existing getters and setters. To make this more ergonomic the decorators standard adds the `accessor` keyword which creates "auto accessors" when applied to a class field. Auto accessors look and act much like class fields, but create accessors on the prototype backed by private storage.
-
-```ts
-class A {
-  accessor foo = 42;
-}
-```
+Standard decorators are not allowed to change the _kind_ of class member they decorate. Decorators that need to create getters and setters must be applied to existing getters and setters. To make this more ergonomic, the decorators standard adds the `accessor` keyword which creates "auto accessors" when applied to a class field. Auto accessors look and act much like class fields, but create accessors on the prototype backed by private storage.
 
 The `@property()`, `@state()`, `@query()`, `@queryAll()`, `@queryAssignedElements()` and `@queryAssignedNode()` decorators require the `accessor` keyword.
 
@@ -171,7 +166,7 @@ class MyElement extends LitElement {
 
 Standard decorators can only replace the class member they're directly applied to. Lit decorators need to intercept property setting, so the decorators must be applied to setters. This is different from the Lit 2 recommendation of applying decorators to getters.
 
-For `@property()` and `@state()` you should also remove any `this.requestUpdate()` calls in the setter since this is done automatically now. If you need to _not_ have `requestUpdate()` called, you'll have to use the `hasChanged` property option.
+For `@property()` and `@state()` you can also remove any `this.requestUpdate()` calls in the setter since this is done automatically now. If you need to _not_ have `requestUpdate()` called, you'll have to use the `noAccessor` property option.
 
 Note that for `@property()` and `@state()` the _getter_ will be called by the decorator when setting the property to retrieve the old value. This means that you _must_ define both a getter and a setter.
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -33,17 +33,16 @@ Lit 2.x and 3.0 are _interoperable_: templates, base classes, and directives fro
 
 ## Decorator behavior has been unified
 
-To make the upgrade path from experimental decorators to standard decorators as
-smooth as possible, existing experimental decorators now support the standard
-spec, and work with the new `accessor` keyword. This is to make incremental
-migration to standard decorators possible.
+In Lit 3.0 our decorators support running in three configurations:
 
-Once all decorator call sites in your project use the `accessor` keyword, you can
-build with `experimentalDecorators` set to `true` or `false` without a change in
-behavior.
+1. With the TypeScript `experimentalDecorators` flag and properties without the `accessor` keyword. This is backwards compatible with Lit 2 users. As standard decorators are still immature, this is the most performant option that we recommend for production for the time being.
+2. With the TypeScript `experimentalDecorators` flag and with the `accessor` keyword. This aids migration to standard decorators. Code can add the `accessor` keyword one decorator at a time to migrate gradually.
+3. As standard decorators, which need the `accessor` keyword, and TypeScript 5.2 (without the `experimentalDecorators` flag), or Babel 7.23.0.
+
+Each of these configurations is self contained. An application can mix and match libraries written in each of these configurations, and it is not generally a breaking change for a library to switch from one decorator configuration to another.
 
 To make Lit decorators consistent between both decorator modes there have been some minor breaking
-changes to the experimental decorators:
+changes to experimental decorators:
 
 - `@property` and `@state` must be used on the setter for hand-written accessors. The getter no longer works.
 - `requestUpdate()` is called automatically for `@property` and `@state` decorated

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -1,7 +1,7 @@
 ---
-title: Upgrade to Lit 3.x guide
+title: Lit 3 upgrade guide
 eleventyNavigation:
-  key: Upgrade to Lit 3.x guide
+  key: Lit 3 upgrade guide
   parent: Releases
   order: 3
 versionLinks:
@@ -10,22 +10,22 @@ versionLinks:
 
 <div class="alert alert-info">
 
-If you are looking to migrate from Lit 1.x to Lit 2.x, see the [Lit 2.0 upgrade guide](/docs/v2/releases/upgrade/).
+If you are looking to migrate from Lit 1.x to Lit 2.x, see the [Lit 2 upgrade guide](/docs/v2/releases/upgrade/).
 
 </div>
 
 ## Overview
 
-Lit 3.0 has very few breaking changes from Lit 2.0:
+Lit 3.0 has very few breaking changes from Lit 2.x:
 
 - IE11 is no longer supported.
 - Lit's npm modules are now published as ES2021.
-- APIs deprecated with the Lit 2.0 release have been removed.
+- APIs marked deprecated in Lit 2.x releases have been removed.
 - SSR hydration support modules have moved to the `@lit-labs/ssr-client` package.
 - Decorator behavior has been unified between TypeScript experimental decorators and standard decorators.
 - Support was removed for Babel decorators version "2018-09"
 
-Lit 3.0 should require no changes to upgrade from Lit 2.0 for the vast majority
+Lit 3.0 should require no changes to upgrade from Lit 2.x for the vast majority
 of users. Most apps and libraries should be able to extend their npm version
 ranges to include both 2.x and 3.x, like `"^2.7.0 || ^3.0.0"`.
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -47,7 +47,7 @@ changes to Lit decorator behavior in Lit 3.0:
 
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
-- Lit 3 decorators no longer support `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should instead [migrate](#standard-decorator-migration) to use `version: "2023-05"` with plugin version greater than `7.23.0` which follows the TC39 standard decorator spec.
+- Lit 3 decorators no longer support the `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should [migrate to standard decorators](#standard-decorator-migration).
 - [optional]: [We recommend migrating `@property()` and `@state()` the the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
 
 ## List of removed APIs

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -35,25 +35,13 @@ Lit 2.x and 3.0 are _interoperable_: templates, base classes, and directives fro
 
 The Lit 3 decorators are largely backwards compatible. If you've been using them with TypeScript, **most likely no changes are needed**. We've added forward compatibility with standard decorators, but the legacy `experimentalDecorators: true` without the `accessor` keyword is currently the more performant option.
 
-In Lit 3.0 there are three supported ways to use our decorators:
-
-1. With the TypeScript `experimentalDecorators` flag, and no `accessor` keyword. This is backwards compatible with Lit 2.
-2. With the TypeScript `experimentalDecorators` flag and using the `accessor` keyword. This aids migration to standard decorators. [Code can add the `accessor` keyword one decorator at a time to migrate gradually](#standard-decorator-migration).
-3. As standard decorators, which need the `accessor` keyword, and TypeScript 5.2 (without the `experimentalDecorators` flag), or Babel 7.23.0.
-
-Each supported way of using decorators is self contained. An application can mix and match libraries written in each of these configurations, and it is not generally a breaking change for a library to switch from one decorator configuration to another.
-
-To make Lit decorators consistent between both decorator modes there have been some minor breaking
-changes to Lit decorator behavior:
+To make the Lit 2.x decorators consistent between both decorator modes there have been some minor breaking
+changes to Lit decorator behavior in Lit 3.0:
 
 - `@property()` and `@state()` must be used on the setter for hand-written accessors. [Decorating the getter no longer works](#decorated-getter).
-- `requestUpdate()` is called automatically for `@property()` and `@state()` decorated
-  accessors where previously that was the setters responsibility.
+- `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
 - Lit 3 decorators do not support Babel (`@babel/plugin-proposal-decorators`) with `version: "2018-09"`.
-
-To use the standard decorator configuration, your decorated class fields **must** include the `accessor` keyword.
-To aid in migration from experimental decorators to standard decorators, decorated class fields with the `accessor` keyword will also work with the `experimentalDecorators` flag set to `true`. So users can start migrating code without changing the TS configuration.
 
 ## List of removed APIs
 
@@ -130,29 +118,6 @@ import {hydrate} from 'lit/experimental-hydrate.js';
 // Updated
 import '@lit-labs/ssr-client/lit-element-hydrate-support.js';
 import {hydrate} from '@lit-labs/ssr-client';
-```
-
-### Optional upgrade to standard decorators  {#standard-decorator-migration}
-
-To use standard decorators, your decorators should add the `accessor` keyword.
-Lit 3 decorators are flexible and work as both experimental decorators, and as
-standard decorators.
-
-```ts
-class MyElement extends LitElement {
-  // Lit 3.0 experimental decorators, which are backwards compatible with Lit 2.0
-  @property()
-  myProperty = "initial value"
-
-  // Lit 3.0 adds support for standard decorators.
-  // When using TypeScript:
-  //  - `accessor` keyword is optional when `experimentalDecorators: true`.
-  //  - `accessor` keyword is required when `experimentalDecorators: false`.
-  @property()
-  accessor myProperty = "initial value"
-
-...
-}
 ```
 
 ### Hand written getters can no longer be reactive properties {#decorated-getter}

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -33,7 +33,14 @@ Lit 2.x and 3.0 are _interoperable_: templates, base classes, and directives fro
 
 ## Updates to Lit decorators
 
-The Lit 3 decorators are largely backwards compatible. If you've been using them with TypeScript, **most likely no changes are needed**. We've added forward compatibility with standard decorators, but the legacy `experimentalDecorators: true` without the `accessor` keyword is currently the more performant option.
+
+JavaScript decorators have recently been standardized by TC39 and are at Stage 3 of the four-stage standardization process. Stage 3 is when JavaScript implementations such as VMs and compilers start implementing the stable specification. TypeScript 5.2 and Babel 7.23 have implemented the standard recently.
+
+This means that there is more than one version of the decorator API in existence: standard decorators, TypeScript's experimental decorators, and previous proposals that Babel has implemented, such as version "2018-09".
+
+While Lit 2 supported TypeScript experimental decorators and Babel's "2018-09" decorators, Lit 3 now supports standard decorators and TypeScript experimental decorators.
+
+The Lit 3 decorators are mostly backwards compatible with the Lit 2 TypeScript decorators - **most likely no changes are needed**.
 
 To make the Lit 2.x decorators consistent between both decorator modes there have been some minor breaking
 changes to Lit decorator behavior in Lit 3.0:

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -25,9 +25,7 @@ Lit 3.0 has very few breaking changes from Lit 2.x:
 - Decorator behavior has been unified between TypeScript experimental decorators and standard decorators.
 - Support was removed for Babel decorators version "2018-09"
 
-Lit 3.0 should require no changes to upgrade from Lit 2.x for the vast majority
-of users. Most apps and libraries should be able to extend their npm version
-ranges to include both 2.x and 3.x, like `"^2.7.0 || ^3.0.0"`.
+For the vast majority of users there should be no required code changes to upgrade from Lit 2 to Lit 3. Most apps and libraries should be able to extend their npm version ranges to include both 2.x and 3.x, like `"^2.7.0 || ^3.0.0"`.
 
 Lit 2.x and 3.0 are _interoperable_: templates, base classes, and directives from one version of Lit will work with those from another.
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -45,8 +45,8 @@ changes to Lit decorator behavior in Lit 3.0:
 
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
-- Lit 3 decorators no longer support the `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should [migrate to standard decorators](#add-accessor-to-decorated-fields).
-- [optional]: [We recommend migrating `@property()` and `@state()` the the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
+- Lit 3 decorators no longer support the `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should [migrate to standard decorators](#standard-decorator-migration).
+- [optional]: [We recommend migrating `@property()` and `@state()` to the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
 
 ## List of removed APIs
 
@@ -125,8 +125,7 @@ import '@lit-labs/ssr-client/lit-element-hydrate-support.js';
 import {hydrate} from '@lit-labs/ssr-client';
 ```
 
-### Optional: upgrade to standard decorators {#standard-decorator-migration}
-
+## Optional: upgrade to standard decorators {#standard-decorator-migration}
 
 While Lit 3 adds support for standard decorators, we still recommend that TypeScript users stay with experimental decorators. This is because the emitted code for standard decorators from the TypeScript and Babel compilers is quite large at the moment.
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -27,7 +27,7 @@ Lit 3.0 has very few breaking changes from Lit 2.x:
 
 For the vast majority of users there should be no required code changes to upgrade from Lit 2 to Lit 3. Most apps and libraries should be able to extend their npm version ranges to include both 2.x and 3.x, like `"^2.7.0 || ^3.0.0"`.
 
-Lit 2.x and 3.0 are _interoperable_: templates, base classes, and directives from one version of Lit will work with those from another.
+Lit 2.x and 3.0 are _interoperable_ – templates, base classes, and directives from one version of Lit will work with those from another.
 
 ## Updates to Lit decorators
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -37,7 +37,7 @@ The Lit 3 decorators are largely backwards compatible. If you've been using them
 
 In Lit 3.0 there are three supported ways to use our decorators:
 
-1. With the TypeScript `experimentalDecorators` flag and properties without the `accessor` keyword. This is backwards compatible with Lit 2.
+1. With the TypeScript `experimentalDecorators` flag, and no `accessor` keyword. This is backwards compatible with Lit 2.
 2. With the TypeScript `experimentalDecorators` flag and using the `accessor` keyword. This aids migration to standard decorators. [Code can add the `accessor` keyword one decorator at a time to migrate gradually](#standard-decorator-migration).
 3. As standard decorators, which need the `accessor` keyword, and TypeScript 5.2 (without the `experimentalDecorators` flag), or Babel 7.23.0.
 
@@ -50,6 +50,7 @@ changes to Lit decorator behavior:
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated
   accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
+- Lit 3 decorators do not support Babel (`@babel/plugin-proposal-decorators`) with `version: "2018-09"`.
 
 To use the standard decorator configuration, your decorated class fields **must** include the `accessor` keyword.
 To aid in migration from experimental decorators to standard decorators, decorated class fields with the `accessor` keyword will also work with the `experimentalDecorators` flag set to `true`. So users can start migrating code without changing the TS configuration.

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -1,40 +1,64 @@
 ---
-title: Upgrade guide
+title: Upgrade to Lit 3.x guide
 eleventyNavigation:
-  key: Upgrade guide
+  key: Upgrade to Lit 3.x guide
   parent: Releases
   order: 3
 versionLinks:
   v2: releases/upgrade/
 ---
 
+<div class="alert alert-info">
+
+If you are looking to migrate from Lit 1.x to Lit 2.x, see the [Lit 2.0 upgrade guide](/docs/v2/releases/upgrade/).
+
+</div>
+
 ## Overview
 
-Lit 3.0 has very few breaking changes from Lit 2.0. Any projects using Lit 2
-without deprecation warnings should not require any changes to upgrade to Lit 3.
+Lit 3.0 has very few breaking changes from Lit 2.0:
 
-Lit 3.0:
-
-- Drops support for IE11
-- Is published as ES2021
-- Removes a few deprecated APIs
+- IE11 is no longer supported.
+- Lit's npm modules are now published as ES2021.
+- APIs deprecated with the Lit 2.0 release have been removed.
+- SSR hydration support modules have moved to the `@lit-labs/ssr-client` package.
+- Decorator behavior has been unified between TypeScript experimental decorators and standard decorators.
+- Support was removed for Babel decorators version "2018-09"
 
 Lit 3.0 should require no changes to upgrade from Lit 2.0 for the vast majority
 of users. Most apps and libraries should be able to extend their npm version
 ranges to include both 2.x and 3.x, like `"^2.7.0 || ^3.0.0"`.
 
-Lit 2.x and 3.0 are _interoperable_: templates, base classes, directives,
-decorators, etc., from one version of Lit will work with those from another.
+Lit 2.x and 3.0 are _interoperable_: templates, base classes, and directives from one version of Lit will work with those from another.
+
+## Decorator behavior has been unified
+
+To make the upgrade path from experimental decorators to standard decorators as
+smooth as possible, existing experimental decorators now support the standard
+spec, and work with the new `accessor` keyword. This is to make incremental
+migration to standard decorators possible.
+
+Once all decorator call sites in your project use the `accessor` keyword, you can
+build with `experimentalDecorators` set to `true` or `false` without a change in
+behavior.
+
+To make Lit decorators consistent between both decorator modes there have been some minor breaking
+changes to the experimental decorators:
+
+- `@property` and `@state` must be used on the setter for hand-written accessors. The getter no longer works.
+- `requestUpdate()` is called automatically for `@property` and `@state` decorated
+  accessors where previously that was the setters responsibility.
+- The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
 
 ## List of removed APIs
 
 If your Lit 2.x project does not have deprecation warnings you should not be
 impacted by this list.
 
- - [Removed `UpdatingElement` alias for `ReactiveElement`.](#removed-updating-element)
- - [Removed re-export of decorators from main `lit-element` module.](#removed-re-export-decorators)
- - [Removed deprecated call signature for the `queryAssignedNodes` decorator.](#removed-queryassignednodes-non-object)
- - [Moved experimental server side rendering hydration modules from `lit`, `lit-element`, and `lit-html` to `@lit-labs/ssr-client`.](#moved-experimental-hydration)
+- [Removed `UpdatingElement` alias for `ReactiveElement`.](#removed-updating-element)
+- [Removed re-export of decorators from main `lit-element` module.](#removed-re-export-decorators)
+- [Removed deprecated call signature for the `queryAssignedNodes` decorator.](#removed-queryassignednodes-non-object)
+- [Moved experimental server side rendering hydration modules from `lit`, `lit-element`, and `lit-html` to `@lit-labs/ssr-client`.](#moved-experimental-hydration)
 
 ## Steps to Upgrade
 
@@ -45,10 +69,10 @@ functional change as `UpdatingElement` was aliasing `ReactiveElement`.
 
 ```ts
 // Removed
-import { UpdatingElement } from "lit";
+import {UpdatingElement} from 'lit';
 
 // Updated
-import { ReactiveElement } from "lit";
+import {ReactiveElement} from 'lit';
 ```
 
 ### Removed re-export of decorators from `lit-element` {#removed-re-export-decorators}
@@ -60,10 +84,10 @@ exported by `lit-element`, and should instead be imported from
 
 ```ts
 // Removed decorator exports from lit-element
-import { customElement, property, state } from "lit-element";
+import {customElement, property, state} from 'lit-element';
 
 // Updated
-import { customElement, property, state } from "lit/decorators.js";
+import {customElement, property, state} from 'lit/decorators.js';
 ```
 
 ### Deprecated `queryAssignedNodes(slot: string, flatten: bool, selector: string)` decorator removed {#removed-queryassignednodes-non-object}
@@ -95,7 +119,7 @@ Experimental hydration support has been moved out of core libraries and into
 
 ```ts
 // Removed
-import 'lit/experimental-hydrate-support.js'
+import 'lit/experimental-hydrate-support.js';
 import {hydrate} from 'lit/experimental-hydrate.js';
 
 // Updated

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -23,7 +23,7 @@ Lit 3.0 has very few breaking changes from Lit 2.x:
 - APIs marked deprecated in Lit 2.x releases have been removed.
 - SSR hydration support modules have moved to the `@lit-labs/ssr-client` package.
 - Decorator behavior has been unified between TypeScript experimental decorators and standard decorators.
-- Support was removed for Babel decorators version "2018-09"
+- Support was removed for Babel decorators version "2018-09".
 
 For the vast majority of users there should be no required code changes to upgrade from Lit 2 to Lit 3. Most apps and libraries should be able to extend their npm version ranges to include both 2.x and 3.x, like `"^2.7.0 || ^3.0.0"`.
 

--- a/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
+++ b/packages/lit-dev-content/site/docs/v3/releases/upgrade.md
@@ -45,7 +45,7 @@ changes to Lit decorator behavior in Lit 3.0:
 
 - `requestUpdate()` is called automatically for `@property()` and `@state()` decorated accessors where previously that was the setters responsibility.
 - The value of an accessor is read on first render and used as the initial value for `changedProperties` and attribute reflection.
-- Lit 3 decorators no longer support the `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should [migrate to standard decorators](#standard-decorator-migration).
+- Lit 3 decorators no longer support the `version: "2018-09"` option of `@babel/plugin-proposal-decorators`. Babel users should [migrate to standard decorators](#add-accessor-to-decorated-fields).
 - [optional]: [We recommend migrating `@property()` and `@state()` the the setter for hand-written accessors to aid in migrating to standard decorators.](#decorated-getter)
 
 ## List of removed APIs
@@ -166,7 +166,7 @@ Install Babel 7.23 or later, and [`@babel/plugin-proposal-decorators`](https://b
 
 ### Source updates
 
-#### Add the `accessor` keyword to decorated fields.
+#### Add the `accessor` keyword to decorated fields. {#add-accessor-to-decorated-fields}
 
 Standard decorators are not allowed to change the _kind_ of class member they decorate. Decorators that need to create getters and setters must be applied to existing getters and setters. To make this more ergonomic the decorators standard adds the `accessor` keyword which creates "auto accessors" when applied to a class field. Auto accessors look and act much like class fields, but create accessors on the prototype backed by private storage.
 
@@ -174,7 +174,7 @@ Standard decorators are not allowed to change the _kind_ of class member they de
 class A {
   accessor foo = 42;
 }
-```ts
+```
 
 The `@property()`, `@state()`, `@query()`, `@queryAll()`, `@queryAssignedElements()` and `@queryAssignedNode()` decorators require the `accessor` keyword.
 
@@ -186,8 +186,9 @@ class MyElement extends LitElement {
   accessor myProperty = "initial value"
 ...
 }
-\```
-#### Move decorators from getters to setters
+```
+
+#### Move decorators from getters to setters {#decorated-getter}
 
 Standard decorators can only replace the class member they're directly applied to. Lit decorators need to intercept property setting, so the decorators must be applied to setters. This is different from the Lit 2 recommendation of applying decorators to getters.
 
@@ -196,6 +197,7 @@ For `@property()` and `@state()` you should also remove any `this.requestUpdate(
 Note that for `@property()` and `@state()` the _getter_ will be called by the decorator when setting the property to retrieve the old value. This means that you _must_ define both a getter and a setter.
 
 Before:
+
 ```ts
 class MyElement extends LitElement {
   private _foo = 42;
@@ -209,9 +211,10 @@ class MyElement extends LitElement {
     return this._foo;
   }
 }
-\```
+```
 
 After:
+
 ```ts
 class MyElement extends LitElement {
   private _foo = 42;
@@ -223,4 +226,4 @@ class MyElement extends LitElement {
     return this._foo;
   }
 }
-\```
+```


### PR DESCRIPTION
Issue: https://github.com/lit/lit.dev/issues/1189

This PR specifically addresses the decorator section.

### Context

Since this guide was last written, we now have hybrid decorators that are compatible with both experimental and standard decorator environments.

This change updates the guidance to include the breaking changes in experimental decorators.

Other changes:
 - Add a link to the v2 upgrade guide on the top.
 - Rename the upgrade guide to `Upgrade to Lit 3.x guide`.
 - Update the custom accessor guidance. You no longer need to call `requestUpdate`.

### Release plan

Note this can be merged directly to main, as it's scoped to the `v3` documentation.

### Tested

Manually via preview link.

Thank you!