### PR TITLE
update v3 pre-release banner to point at the second pre-release announcement

### DIFF
--- a/packages/lit-dev-content/site/_includes/default.html
+++ b/packages/lit-dev-content/site/_includes/default.html
@@ -76,7 +76,7 @@
     {% elif selectedVersion === "v3" %}
       <litdev-banner>
         You're viewing docs for a pre-release version of Lit. Read the Lit 3.0 pre-releases
-        announcement <a href="/blog/2023-05-15-lit-3.0-prerelease/">here</a>.
+        announcement <a href="/blog/2023-09-27-lit-3.0-prerelease-2/">here</a>.
       </litdev-banner>
     {% endif %}
 


### PR DESCRIPTION
We've done a second pre-release which contains the hybrid decorators. This PR keeps our banner up to date.

This PR updates the v3 pre-release banner to point at the latest pre-release blog post. That blog post then references the first announcement if someone is interested.

![Screenshot 2023-10-02 at 11 57 33 AM](https://github.com/lit/lit.dev/assets/15080861/5fcd0cdf-d5f7-4187-987f-ad33abb6f6a7)



