### PR TITLE
[docs] Show exactly how a property expression behaves imperatively

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/templates/expressions.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/expressions.md
@@ -287,7 +287,13 @@ You can set a JavaScript property on an element using the `.` prefix and the pro
 html`<input .value=${this.itemCount}>`;
 ```
 
-You can use this syntax to pass complex data down the tree to subcomponents. For example, if you have a `my-list` component with a `listItems` property, you could pass it an array of objects:
+The behavior of the code above is the same as directly setting the `value` property on the `input` element, e.g.:
+
+```js
+inputEl.value = this.itemCount;
+```
+
+You can use the property expression syntax to pass complex data down the tree to subcomponents. For example, if you have a `my-list` component with a `listItems` property, you could pass it an array of objects:
 
 ```js
 html`<my-list .listItems=${this.items}></my-list>`;

--- a/packages/lit-dev-content/site/docs/v3/templates/expressions.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/expressions.md
@@ -287,6 +287,12 @@ You can set a JavaScript property on an element using the `.` prefix and the pro
 html`<input .value=${this.itemCount}>`;
 ```
 
+The behavior of the code above is the same as directly setting the `value` property on the `input` element, e.g.:
+
+```js
+inputEl.value = this.itemCount;
+```
+
 You can use this syntax to pass complex data down the tree to subcomponents. For example, if you have a `my-list` component with a `listItems` property, you could pass it an array of objects:
 
 ```js

--- a/packages/lit-dev-content/site/docs/v3/templates/expressions.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/expressions.md
@@ -293,7 +293,7 @@ The behavior of the code above is the same as directly setting the `value` prope
 inputEl.value = this.itemCount;
 ```
 
-You can use this syntax to pass complex data down the tree to subcomponents. For example, if you have a `my-list` component with a `listItems` property, you could pass it an array of objects:
+You can use the property expression syntax to pass complex data down the tree to subcomponents. For example, if you have a `my-list` component with a `listItems` property, you could pass it an array of objects:
 
 ```js
 html`<my-list .listItems=${this.items}></my-list>`;


### PR DESCRIPTION
Part of: https://github.com/lit/lit.dev/issues/1181

It is unclear what the property expression syntax actually does. This change adds explicit documentation to show the imperative alternative to property expression binding which should help developers build a mental model of property bindings.

This documents some questions that have come up in the past.

Thank you!
