### PR TITLE
[infra] Use macos for search index GHA

### DIFF
--- a/.github/workflows/build-and-publish-search-index.yml
+++ b/.github/workflows/build-and-publish-search-index.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-publish-search-index:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 10
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1


### PR DESCRIPTION
Missed this from https://github.com/lit/lit.dev/pull/1206 as it only runs after merging.