### PR TITLE
update playground to install the Lit 3.0 second prerelease

### DIFF
--- a/packages/lit-dev-content/samples/v3-base.json
+++ b/packages/lit-dev-content/samples/v3-base.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0-pre.0\",\n    \"@lit/reactive-element\": \"^2.0.0-pre.0\",\n    \"lit-element\": \"^4.0.0-pre.0\",\n    \"lit-html\": \"^3.0.0-pre.0\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0-pre.1\",\n    \"@lit/reactive-element\": \"^2.0.0-pre.1\",\n    \"lit-element\": \"^4.0.0-pre.1\",\n    \"lit-html\": \"^3.0.0-pre.1\"\n  }\n}",
       "hidden": true
     }
   }


### PR DESCRIPTION
### Context

We've landed the second Lit v3.0 pre-releases. This change updates the v3 docs to use those packages.

Link to pre-release blog post: https://lit.dev/blog/2023-09-27-lit-3.0-prerelease-2/


### Test plan

Tested manually by flicking through the v3 docs and checking the live samples work.