### PR TITLE
Update bundle URLs to `3`.

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v3/getting-started.md
@@ -76,7 +76,7 @@ are two types of bundles:
   <dt class="paramName">core</dt>
   <dd class="paramDetails">
     <a href="https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js">
-      https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js
+      https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js
     </a>
     <br>
     <code>core</code> exports the same items as
@@ -87,7 +87,7 @@ are two types of bundles:
   <dt class="paramName">all</dt>
   <dd class="paramDetails">
     <a href="https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js">
-      https://cdn.jsdelivr.net/gh/lit/dist@2/all/lit-all.min.js
+      https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js
     </a>
     <br>
     <code>all</code> exports everything in <code>core</code> plus

--- a/packages/lit-dev-content/site/docs/v3/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v3/getting-started.md
@@ -55,7 +55,7 @@ standard JavaScript modules with no dependencies - any modern browser should be
 able to import and run the bundles from within a `<script type="module">` like this:
 
 ```js
-import {LitElement, html} from 'https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js';
+import {LitElement, html} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 ```
 
 <div class="alert alert-warning">
@@ -75,8 +75,8 @@ are two types of bundles:
 <dl class="params">
   <dt class="paramName">core</dt>
   <dd class="paramDetails">
-    <a href="https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js">
-      https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js
+    <a href="https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js">
+      https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js
     </a>
     <br>
     <code>core</code> exports the same items as
@@ -86,8 +86,8 @@ are two types of bundles:
 
   <dt class="paramName">all</dt>
   <dd class="paramDetails">
-    <a href="https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js">
-      https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js
+    <a href="https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js">
+      https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js
     </a>
     <br>
     <code>all</code> exports everything in <code>core</code> plus

--- a/packages/lit-dev-content/site/docs/v3/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v3/getting-started.md
@@ -55,7 +55,7 @@ standard JavaScript modules with no dependencies - any modern browser should be
 able to import and run the bundles from within a `<script type="module">` like this:
 
 ```js
-import {LitElement, html} from 'https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js';
+import {LitElement, html} from 'https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js';
 ```
 
 <div class="alert alert-warning">
@@ -75,7 +75,7 @@ are two types of bundles:
 <dl class="params">
   <dt class="paramName">core</dt>
   <dd class="paramDetails">
-    <a href="https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js">
+    <a href="https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js">
       https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js
     </a>
     <br>
@@ -86,7 +86,7 @@ are two types of bundles:
 
   <dt class="paramName">all</dt>
   <dd class="paramDetails">
-    <a href="https://cdn.jsdelivr.net/gh/lit/dist@2/all/lit-all.min.js">
+    <a href="https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js">
       https://cdn.jsdelivr.net/gh/lit/dist@2/all/lit-all.min.js
     </a>
     <br>

--- a/packages/lit-dev-tests/known-good-urls.txt
+++ b/packages/lit-dev-tests/known-good-urls.txt
@@ -514,3 +514,5 @@ https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#decorator-m
 https://preactjs.com/guide/v10/signals/
 https://www.youtube.com/watch?v=l6Gn5uV83sw
 https://github.com/e111077
+https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js
+https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js

--- a/packages/lit-dev-tests/known-good-urls.txt
+++ b/packages/lit-dev-tests/known-good-urls.txt
@@ -514,5 +514,5 @@ https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#decorator-m
 https://preactjs.com/guide/v10/signals/
 https://www.youtube.com/watch?v=l6Gn5uV83sw
 https://github.com/e111077
-https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/core/lit-core.min.js
-https://cdn.jsdelivr.net/gh/lit/dist@3.0.0/all/lit-all.min.js
+https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js
+https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js


### PR DESCRIPTION
These are out of date as of today! 🎉 I specifically changed them to `3.0.0` rather than just `3` so that users that copy these URLs don't get surprised by the content changing out from under them when new minor and patch versions are released. If there's a way to dynamically reference the latest full version string, let me know and I'll update to that instead.