### PR TITLE
Add standard decorator documentation

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -25,25 +25,13 @@ export class MyElement extends LitElement {
 }
 ```
 
-{#custom-element}
+{% aside "info" "no-header"%}
 
-The `@customElement` decorator defines a custom element, equivalent to calling:
-
-```js
-customElements.define('my-element', MyElement);
-```
-
-The `@property` decorator declares a [reactive property](/docs/v3/components/properties/).
-
-{% aside "info" %}
-
-Decorator versions and syntax.
-
-Lit decorators support multiple versions of the decorator specification – TypeScript experimental decorators and standard decorators – but to be used as standard decorators require a newer syntax of using the `accessor` keyword on decorated properties.
-
-We recommend that TypeScript users stick with experimental decorators for the moment, and as such, all of our TS code samples contain syntax that work in that mode, _without_ the `accessor` keyword.
-
-If you are using Babel to compile decorators, or are required to use `"experimentalDecorators": false` in your TypeScript config, you will need to add those. See [Standard decorators](#standard-decorators) for more information.
+Lit supports two different versions of the JavaScript decorators proposal – an early version supported by TypeScript that we refer to as _experimental decorators_ and a new and final version we refer to as _standard decorators_.
+ 
+There are some small differences in usage between the two proposals (standard decorators sometimes require the `accessor` keyword). Our code samples are written for experimental decorators because we recommend them for production at the moment.
+ 
+See [Decorator versions](#decorator-versions) for more details.
 
 {% endaside %}
 
@@ -51,7 +39,7 @@ If you are using Babel to compile decorators, or are required to use `"experimen
 
 | Decorator | Summary | More Info |
 |-----------|---------|--------------|
-| {% api-v3 "@customElement" "customElement" %} | Defines a custom element | [Above](#custom-element) |
+| {% api-v3 "@customElement" "customElement" %} | Defines a custom element | [Defining](/docs/v3/components/defining/) |
 | {% api-v3 "@eventOptions" "eventOptions" %} | Adds event listener options. | [Events](/docs/v3/components/events/#event-options-decorator) |
 | {% api-v3 "@property" "property" %} | Defines a public property. | [Properties](/docs/v3/components/properties/#declare-with-decorators) |
 | {% api-v3 "@state" "state" %} | Defines a private state property | [Properties](/docs/v3/components/properties/#declare-with-decorators) |
@@ -80,11 +68,11 @@ import {eventOptions} from 'lit/decorators/event-options.js';
 
 To use decorators, you need to build your code with a compiler such as [TypeScript](#decorators-typescript) or [Babel](#decorators-babel).
 
-In the future when decorators become a native web platform feature, this may no longer be necessary.
+In the future when decorators are supported natively in browsers, this will no longer be necessary
 
 ### Using decorators with TypeScript { #decorators-typescript }
 
-TypeScript supports both experimental decorators and standard decorators. We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
+TypeScript supports both experimental decorators and standard decorators. We recommend that TypeScript developers use experimental decorators for now for [optimal compiler output](#compiler-output-considerations).
 
 To use experimental decorators you must enable the `experimentalDecorators` compiler option.
 
@@ -95,7 +83,7 @@ You should also ensure that the `useDefineForClassFields` setting is `false`. No
 {
   "compilerOptions": {
     "experimentalDecorators": true,
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
   }
 }
 ```
@@ -112,8 +100,8 @@ This allows incremental migration off of experimental decorators by adding the `
 // tsconfig.json
 {
   "compilerOptions": {
-    "experimentalDecorators": false,
-    "useDefineForClassFields": true
+    "experimentalDecorators": false, // default for TS 5.0 and up
+    "useDefineForClassFields": true, // default when "target" is "ES2022" or higher
   }
 }
 ```
@@ -156,21 +144,21 @@ It means that the specification text is complete, and ready for browsers to impl
 
 {% endaside %}
 
-### Earlier decorators
+### Earlier decorator proposals
 
 Before the TC39 proposal reached stage 3, compilers implemented earlier versions of the decorator specification.
 
-Most notable of these is [TypeScript's "experimental decorators"](https://www.typescriptlang.org/docs/handbook/decorators.html) which Lit has supported since its inception and is our current recommendation for use.
+Most notable of these is [TypeScript's _experimental decorators_](https://www.typescriptlang.org/docs/handbook/decorators.html) which Lit has supported since its inception and is our current recommendation for use.
 
-Babel has also supported different versions of the specification over time as can be seen from the [`"version"` option of the decorator plugin](https://babeljs.io/docs/babel-plugin-proposal-decorators#version). In the past, Lit 2 has supported the `"2018-09"` version for Babel users but that has now been dropped in favor of the "standard" `"2023-05"` version described below.
+Babel has also supported different versions of the specification over time as can be seen from the [`"version"` option of the decorator plugin](https://babeljs.io/docs/babel-plugin-proposal-decorators#version). In the past, Lit 2 has supported the `"2018-09"` version for Babel users but that has now been dropped in favor of the _standard_ `"2023-05"` version described below.
 
 ### Standard decorators { #standard-decorators }
 
-"Standard decorators" is the version of decorators that has reached Stage 3 consensus at TC39, the body that defines ECMAScript/JavaScript.
+_Standard decorators_ is the version of decorators that has reached Stage 3 consensus at TC39, the body that defines ECMAScript/JavaScript.
 
 Standard decorators are supported in TypeScript and Babel, with native browser coming in the near future.
 
-The biggest difference between standard decorators and earlier versions of the decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member – fields, accessors, and methods – being decorated and replaced, and will only produce the same kind of member.
+The biggest difference between standard decorators and experimental decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member – fields, accessors, and methods – being decorated and replaced, and will only produce the same kind of member.
 
 Since many Lit decorators generate accessors, this means that the decorators need to be applied to accessors, not class fields.
 
@@ -184,7 +172,7 @@ class MyClass {
 
 Auto-accessors create a getter and setter pair that read and write from a private field. Decorators can then wrap these getters and setters.
 
-Lit decorators that work on class fields with experimental decorators - such as `@property()`, `@state()`, `@query()`, etc. - must be applied to accessors or auto-accessors with standard decorators:
+Lit decorators that work on class fields with experimental decorators – such as `@property()`, `@state()`, `@query()`, etc. – must be applied to accessors or auto-accessors with standard decorators:
 
 ```ts
 @customElement('my-element')
@@ -196,7 +184,7 @@ export class MyElement extends LitElement {
 }
 ```
 
-#### Compiler output considerations
+### Compiler output considerations
 
 Compiler output for standard decorators is unfortunately large due to the need to generate the accessors, private storage and other objects that are part of the decorators API.
 

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -19,7 +19,8 @@ For example, the `@customElement` and `@property()` decorators let you register 
 @customElement('my-element')
 export class MyElement extends LitElement {
 
-  @property() greeting = 'Welcome';
+  @property()
+  greeting = 'Welcome';
 
 }
 ```
@@ -34,91 +35,17 @@ customElements.define('my-element', MyElement);
 
 The `@property` decorator declares a [reactive property](/docs/v3/components/properties/).
 
-Other decorators provided by the Lit package can be found in the list of [built-in decorators](#built-in-decorators).
-
-## Background
-
-Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) support decorators, though no browsers have implemented them yet. Lit decorators work with Babel and TypeScript, and will work in browsers when they implement them natively.
-
 {% aside "info" %}
 
-What does stage 3 mean?
+Decorator versions and syntax.
 
-It means that the specification text is complete, and ready for browsers to implement. Once the specification has been implemented in multiple browsers, it can move to the final stage, stage 4, and be added to the ECMAScript standard. A stage 3 proposal will only change if critical issues are discovered during implementation.
+Lit decorators support multiple versions of the decorator specification – TypeScript experimental decorators and standard decorators – but to be used as standard decorators require a newer syntax of using the `accessor` keyword on decorated properties.
+
+We recommend that TypeScript users stick with experimental decorators for the moment, and as such, all of our TS code samples contain syntax that work in that mode, _without_ the `accessor` keyword.
+
+If you are using Babel to compile decorators, or are required to use `"experimentalDecorators": false` in your TypeScript config, you will need to add those. See [Standard decorators](#standard-decorators) for more information.
 
 {% endaside %}
-
-Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since its inception.
-
-Lit decorators work as both TypeScript experimental decorators _and_ standard decorators meaning they work with either configuration set in tsconfig. However, we currently recommend that TypeScript users use experimental decorator mode, i.e. projects should set `"experimentalDecorators": true`, because the emitted JavaScript is much smaller than in standard decorator mode. As such, all of the TypeScript code samples in our documentation reflect the syntax that works with this mode – namely, we omit the `accessor` keyword on class fields that's required for [standard decorators](#standard-decorators).
-
-If you are working in a TypeScript project that requires `"experimentalDecorators": false` or `useDefineForClassFields: true`, consult the [Migrating TypeScript to standard decorators](#migrating-typescript-standard-decorators) section of this page.
-
-## Enabling decorators { #enabling-decorators }
-
-To use decorators, you need to build your code with a compiler such as [TypeScript](#decorators-typescript) or [Babel](#decorators-babel).
-
-In the future when decorators become a native web platform feature, this may no longer be necessary.
-
-### Using decorators with TypeScript { #decorators-typescript }
-
-TypeScript supports both experimental decorators and standard decorators. Standard decorators are enabled by default in TypeScript 5.0 and later, though Lit requires decorator metadata, which is available in TypeScript 5.2 and later.
-
-We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
-
-To use experimental decorators you must enable the `experimentalDecorators` compiler option.
-
-You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this should only be required when the `target` is set to `ES2022` or greater, but it's recommended to explicitly ensure this setting is `false`.
-
-```json
-"experimentalDecorators": true,
-"useDefineForClassFields": false,
-```
-
-Enabling `emitDecoratorMetadata` is not required and not recommended.
-
-#### Migrating TypeScript experimental decorators to standard decorators { #migrating-typescript-standard-decorators }
-
-Lit decorators have been designed to support standard decorator syntax (using
-`accessor` on class field decorators) with TypeScript's experimental decorator
-mode.
-
-This allows incremental migration off of experimental decorators by adding the `accessor` keyword to decorated properties without a change of behavior.
-Once all class field decorators use the `accessor` keyword, you can change your
-`tsconfig.json` completing the migration to standard decorators:
-
-```json
-"experimentalDecorators": false,
-"useDefineForClassFields": true,
-```
-
-Read more about the code changes required to migrate to standard decorators in [the upgrade guide](/docs/v3/releases/upgrade/#standard-decorator-migration).
-
-### Using decorators with Babel { #decorators-babel }
-
-[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin as of version 7.23. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in [standard decorator mode with the `accessor` keyword](#standard-decorators) on decorated class fields.
-
-You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
-
-```json
-"plugins": [
-  ["@babel/plugin-proposal-decorators", {
-    "version": "2023-05"
-  }]
-]
-```
-
-<div class="alert alert-info">
-
-Lit decorators only work with `"version": "2023-05"`. Other versions, including the formerly supported `"2018-09"`, are not supported.
-
-</div>
-
-### Avoiding issues with class fields and decorators {#avoiding-issues-with-class-fields}
-
-Standard [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
-
-When using decorators, transpiler settings for Babel and TypeScript must be configured correctly as shown in the sections above for [TypeScript](#decorators-typescript) and [Babel](#decorators-babel).
 
 ## Built-in decorators
 
@@ -149,13 +76,101 @@ import {customElement} from 'lit/decorators/custom-element.js';
 import {eventOptions} from 'lit/decorators/event-options.js';
 ```
 
-## Standard decorators { #standard-decorators }
+## Enabling decorators { #enabling-decorators }
+
+To use decorators, you need to build your code with a compiler such as [TypeScript](#decorators-typescript) or [Babel](#decorators-babel).
+
+In the future when decorators become a native web platform feature, this may no longer be necessary.
+
+### Using decorators with TypeScript { #decorators-typescript }
+
+TypeScript supports both experimental decorators and standard decorators. We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
+
+To use experimental decorators you must enable the `experimentalDecorators` compiler option.
+
+You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this is only be required when the `target` is set to `ES2022` or greater, but it is recommended to explicitly set this to `false`.
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false
+  }
+}
+```
+
+Enabling `emitDecoratorMetadata` is not required and not recommended.
+
+#### Migrating TypeScript experimental decorators to standard decorators { #migrating-typescript-standard-decorators }
+
+Lit decorators have been designed to support standard decorator syntax (using `accessor` on class field decorators) with TypeScript's experimental decorator mode.
+
+This allows incremental migration off of experimental decorators by adding the `accessor` keyword to decorated properties without a change of behavior. Once all class field decorators use the `accessor` keyword, you can change your `tsconfig.json` completing the migration to standard decorators:
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "experimentalDecorators": false,
+    "useDefineForClassFields": true
+  }
+}
+```
+
+Note: The `accessor` keyword was introduced in TypeScript 4.9 and full standard decorator with metadata support requires TypeScript 5.2 or greater.
+
+Read more about the code changes required to migrate to standard decorators in [the upgrade guide](/docs/v3/releases/upgrade/#standard-decorator-migration).
+
+### Using decorators with Babel { #decorators-babel }
+
+[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin as of version 7.23. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in [standard decorator mode with the `accessor` keyword](#standard-decorators) on decorated class fields.
+
+You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
+
+```json
+"plugins": [
+  ["@babel/plugin-proposal-decorators", {
+    "version": "2023-05"
+  }]
+]
+```
+
+Note: Lit decorators only work with `"version": "2023-05"`. Other versions, including the formerly supported `"2018-09"`, are not supported.
+
+### Avoiding issues with class fields and decorators {#avoiding-issues-with-class-fields}
+
+Standard [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
+
+When using decorators, transpiler settings for Babel and TypeScript must be configured correctly as shown in the sections above for [TypeScript](#decorators-typescript) and [Babel](#decorators-babel).
+
+## Decorator versions
+
+Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) support decorators, though no browsers have implemented them yet. Lit decorators work with Babel and TypeScript, and will work in browsers when they implement them natively.
+
+{% aside "info" %}
+
+What does stage 3 mean?
+
+It means that the specification text is complete, and ready for browsers to implement. Once the specification has been implemented in multiple browsers, it can move to the final stage, stage 4, and be added to the ECMAScript standard. A stage 3 proposal will only change if critical issues are discovered during implementation.
+
+{% endaside %}
+
+### Earlier decorators
+
+Before the TC39 proposal reached stage 3, compilers implemented earlier versions of the decorator specification.
+
+Most notable of these is [TypeScript's "experimental decorators"](https://www.typescriptlang.org/docs/handbook/decorators.html) which Lit has supported since its inception and is our current recommendation for use.
+
+Babel has also supported different versions of the specification over time as can be seen from the [`"version"` option of the decorator plugin](https://babeljs.io/docs/babel-plugin-proposal-decorators#version). In the past, Lit 2 has supported the `"2018-09"` version for Babel users but that has now been dropped in favor of the "standard" `"2023-05"` version described below.
+
+### Standard decorators { #standard-decorators }
 
 "Standard decorators" is the version of decorators that has reached Stage 3 consensus at TC39, the body that defines ECMAScript/JavaScript.
 
 Standard decorators are supported in TypeScript and Babel, with native browser coming in the near future.
 
-The biggest difference between using standard decorators and experimental decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member – fields, accessors, and methods – being decorated and replaced, and will only produce the same kind of member.
+The biggest difference between standard decorators and earlier versions of the decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member – fields, accessors, and methods – being decorated and replaced, and will only produce the same kind of member.
 
 Since many Lit decorators generate accessors, this means that the decorators need to be applied to accessors, not class fields.
 
@@ -175,15 +190,16 @@ Lit decorators that work on class fields with experimental decorators - such as 
 @customElement('my-element')
 export class MyElement extends LitElement {
 
-  @property() accessor greeting = 'Welcome';
+  @property()
+  accessor greeting = 'Welcome';
 
 }
 ```
 
-### Compiler output considerations
+#### Compiler output considerations
 
 Compiler output for standard decorators is unfortunately large due to the need to generate the accessors, private storage and other objects that are part of the decorators API.
 
-So we recommend that users who wish to use decorators continue to use TypeScript experimental decorators for now.
+So we recommend that users who wish to use decorators, if possible, use TypeScript experimental decorators for now.
 
 In the future the Lit team plans on adding decorator transforms to our optional Lit Compiler in order to compile standard decorators to a more compact compiler output. Native browser support will also eliminate the need for any compiler transforms at all.

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -29,7 +29,7 @@ export class MyElement extends LitElement {
 
 Lit supports two different versions of the JavaScript decorators proposal – an early version supported by TypeScript that we refer to as _experimental decorators_ and a new and final version we refer to as _standard decorators_.
  
-There are some small differences in usage between the two proposals (standard decorators sometimes require the `accessor` keyword). Our code samples are written for experimental decorators because we recommend them for production at the moment.
+There are some small differences in usage between the two proposals (standard decorators often require the `accessor` keyword). Our code samples are written for experimental decorators because we recommend them for production at the moment.
  
 See [Decorator versions](#decorator-versions) for more details.
 
@@ -106,7 +106,7 @@ This allows incremental migration off of experimental decorators starting with t
 }
 ```
 
-Note: The `accessor` keyword was introduced in TypeScript 4.9 and full standard decorator with metadata support requires TypeScript 5.2 or greater.
+Note: The `accessor` keyword was introduced in TypeScript 4.9 and standard decorators with metadata require TypeScript ≥5.2.
 
 ### Using decorators with Babel { #decorators-babel }
 

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -26,14 +26,6 @@ export class MyElement extends LitElement {
 
 Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) support decorators, though no browsers have implemented them yet. Lit decorators work with Babel and TypeScript, and will work in browsers when they implement them natively.
 
-Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since it's inception.
-
-Lit decorators work with both TypeScript experimental decorators and standard decorators. We currently recommend that TypeScript users use experimental decorators because the compiler output is much smaller than for experimental decorators.
-
-This means that TypeScript-based Lit projects should have `"experimentalDecorators": true` in their tsconfig.
-
-See the [Enabling decorators](#enabling-decorators) section for more information.
-
 {% aside "info" %}
 
 What does stage 3 mean?
@@ -41,6 +33,14 @@ What does stage 3 mean?
 Stage 3 means that the specification text is complete, and ready for browsers to implement. Once the specification has been implemented in multiple browsers, it can move to the final stage, stage 4, and be added to the ECMAScript standard. A stage 3 proposal can still change, but only if critical issues are discovered during implementation.
 
 {% endaside %}
+
+Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since its inception.
+
+Lit decorators work as both TypeScript experimental decorators and standard decorators. We currently recommend that TypeScript users use experimental decorator mode because the JavaScript output is much smaller than in standard decorator mode.
+
+This means that TypeScript-based Lit projects should have `"experimentalDecorators": true` in their tsconfig.
+
+See the [Enabling decorators](#enabling-decorators) section for more information.
 
 {#custom-element}
 
@@ -85,7 +85,7 @@ import {eventOptions} from 'lit/decorators/event-options.js';
 
 ## Standard decorators { #standard-decorators }
 
-"Standard decorators" is the version of decorators that has reached Stage 3 consensus at TC39, the body that defines ECMAScript/JavaScript. The decorators specification has been fine-tuned with active VM implementor feedback to be as optimizable as possible.
+"Standard decorators" is the version of decorators that has reached Stage 3 consensus at TC39, the body that defines ECMAScript/JavaScript.
 
 Standard decorators are supported in TypeScript and Babel, with native browser coming in the near future.
 
@@ -130,13 +130,13 @@ In the future when decorators become a native web platform feature, this may no 
 
 ### Using decorators with TypeScript { #decorators-typescript }
 
-TypeScript supports both experimental decorators and standard decorators. Standard decorators are enabled by default in TypeScript 5.0 and later, though Lit requires decorator metadata, which is available TypeScript 5.2 and later.
+TypeScript supports both experimental decorators and standard decorators. Standard decorators are enabled by default in TypeScript 5.0 and later, though Lit requires decorator metadata, which is available in TypeScript 5.2 and later.
 
 We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
 
 To use experimental decorators you must enable the `experimentalDecorators` compiler option.
 
-You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this should only be required when the `target` is set to `esnext` or greater, but it's recommended to explicitly ensure this setting is `false`.
+You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this should only be required when the `target` is set to `ES2022` or greater, but it's recommended to explicitly ensure this setting is `false`.
 
 ```json
 "experimentalDecorators": true,
@@ -145,9 +145,25 @@ You should also ensure that the `useDefineForClassFields` setting is `false`. No
 
 Enabling `emitDecoratorMetadata` is not required and not recommended.
 
+#### Migrating TypeScript experimental decorators to standard decorators
+
+Standard decorator syntax (using `accessor` on class field decorators) is designed to be compatible with TypeScript's experimental decorator mode.
+
+This allows incremental migration off experimental decorators by incrementally
+adding the `accessor` keyword without a change of behavior.
+Once all class field decorators use the `accessor` keyword, you can change your
+`tsconfig.json` completing the migration to standard decorators:
+
+```json
+"experimentalDecorators": false,
+"useDefineForClassFields": true,
+```
+
+Read more about the code changes required to migrate to standard decorators in [the upgrade guide](/docs/releases/upgrade/#standard-decorator-migration).
+
 ### Using decorators with Babel { #decorators-babel }
 
-[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in standard decorator mode with the `accessor` keyword on decorated class fields.
+[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in [standard decorator mode with the `accessor` keyword](#standard-decorators) on decorated class fields.
 
 You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
 
@@ -165,43 +181,8 @@ Lit decorators only work with `version: "2023-05"`. Other versions (`"2021-12"` 
 
 </div>
 
-### Using decorators with TypeScript and Babel
-
-When using Babel to compile TypeScript sources, it's important to order the TypeScript transform before the decorators transform in your Babel config as follows:
-
-```json
-{
-  "assumptions": {
-    "setPublicClassFields": true
-  },
-  "plugins": [
-    ["@babel/plugin-transform-typescript", {
-      "allowDeclareFields": true
-    }],
-    ["@babel/plugin-proposal-decorators", {
-      "version": "2018-09",
-      "decoratorsBeforeExport": true
-    }],
-    ["@babel/plugin-proposal-class-properties"]
-  ]
-}
-```
-
-The `allowDeclareFields` setting is generally not needed, but it can be useful if you want to define a reactive property without using a decorator. For example,
-
-```ts
-static properties = { foo: {} };
-
-declare foo: string;
-
-constructor() {
-  super();
-  this.foo = 'bar';
-}
-```
-
 ### Avoiding issues with class fields and decorators {#avoiding-issues-with-class-fields}
 
-Standard [Class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
+Standard [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
 
 When using decorators, transpiler settings for Babel and TypeScript must be configured correctly as shown in the sections above for [TypeScript](#decorators-typescript) and [Babel](#decorators-babel).

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -9,9 +9,28 @@ versionLinks:
   v2: components/decorators/
 ---
 
-Decorators are special functions that can modify the behavior of classes, class methods, and class fields. Lit uses decorators to provide declarative APIs for things like registering elements, reactive properties, and queries.
+Decorators are functions that can be used to declaratively annotate and modify the behavior of classes.
 
-Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Currently no browsers implement decorators, but compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) provide support for an earlier version of the decorators proposal. Lit decorators work with Babel and TypeScript, and will be updated to work with the final specification when it's implemented in browsers.
+Lit provides a set of decorators that enable declarative APIs for things like registering elements, defining reactive properties and query properties, or adding event options to event handler methods.
+
+For example, the `@customElement` and `@property()` decorators let you register a custom element and define a reactive property in a compact, declarative way:
+
+```ts
+@customElement('my-element')
+export class MyElement extends LitElement {
+
+  @property() greeting = 'Welcome';
+
+}
+```
+
+Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) support decorators, though no browsers have implemented them yet. Lit decorators work with Babel and TypeScript, and will work in browsers when they implement them natively.
+
+Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since it's inception.
+
+Lit decorators work with both TypeScript experimental decorators and standard decorators. We currently recommend that TypeScript users use experimental decorators because the compiler output is much smaller than for experimental decorators.
+
+This means that TypeScript-based Lit projects should have `"experimentalDecorators": true` in their tsconfig.
 
 See the [Enabling decorators](#enabling-decorators) section for more information.
 
@@ -23,19 +42,6 @@ Stage 3 means that the specification text is complete, and ready for browsers to
 
 {% endaside %}
 
-
-
-Lit supplies a set of decorators that reduce the amount of boilerplate code you need to write when defining a component. For example, the `@customElement` and `@property` decorators make a basic element definition more compact:
-
-```ts
-@customElement('my-element')
-export class MyElement extends LitElement {
-  @property() greeting = "Welcome";
-  @property() name = "Sally";
-  @property({type: Boolean}) emphatic = true;
-  //...
-}
-```
 {#custom-element}
 
 The `@customElement` decorator defines a custom element, equivalent to calling:
@@ -77,6 +83,45 @@ import {customElement} from 'lit/decorators/custom-element.js';
 import {eventOptions} from 'lit/decorators/event-options.js';
 ```
 
+## Standard decorators { #standard-decorators }
+
+"Standard decorators" is the version of decorators that has reached Stage 3 consensus at TC39, the body that defines ECMAScript/JavaScript. The decorators specification has been fine-tuned with active VM implementor feedback to be as optimizable as possible.
+
+Standard decorators are supported in TypeScript and Babel, with native browser coming in the near future.
+
+The biggest difference between using standard decorators and experimental decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member - fields, accessors, and methods can be decorated and replaced, but only with the same kind of member.
+
+Since many Lit decorators generate accessors, this means that the decorators need to be applied to accessors, not class fields.
+
+To make this convenient, the standard decorator specification adds the `accessor` keyword to declare "auto-accessors":
+
+```ts
+class MyClass {
+  accessor foo = 42;
+}
+```
+
+Auto-accessors create a getter and setter pair that read and write from a private field. Decorators can then wrap these getters and setters.
+
+Lit decorators that work on class fields with experimental decorators - such as `@property()`, `@state()`, `@query()`, etc. - must be applied to accessors or auto-accessors with standard decorators:
+
+```ts
+@customElement('my-element')
+export class MyElement extends LitElement {
+
+  @property() accessor greeting = 'Welcome';
+
+}
+```
+
+### Compiler output considerations
+
+Compiler output for standard decorators is unfortunately large due to the need to generate the accessors, private storage and other objects that are part of the decorators API.
+
+So we recommend that users who wish to use decorators continue to use TypeScript experimental decorators for now.
+
+In the future the Lit team plans on adding decorator transforms to our optional Lit Compiler in order to compile standard decorators to a more compact compiler output. Native browser support will also eliminate the need for any compiler transforms at all.
+
 ## Enabling decorators { #enabling-decorators }
 
 To use decorators, you need to build your code with a compiler such as [TypeScript](#decorators-typescript) or [Babel](#decorators-babel).
@@ -85,7 +130,11 @@ In the future when decorators become a native web platform feature, this may no 
 
 ### Using decorators with TypeScript { #decorators-typescript }
 
-To use decorators with [TypeScript](https://www.typescriptlang.org/docs/handbook/decorators.html), enable the `experimentalDecorators` compiler option.
+TypeScript supports both experimental decorators and standard decorators. Standard decorators are enabled by default in TypeScript 5.0 and later, though Lit requires decorator metadata, which is available TypeScript 5.2 and later.
+
+We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
+
+To use experimental decorators you must enable the `experimentalDecorators` compiler option.
 
 You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this should only be required when the `target` is set to `esnext` or greater, but it's recommended to explicitly ensure this setting is `false`.
 
@@ -96,39 +145,29 @@ You should also ensure that the `useDefineForClassFields` setting is `false`. No
 
 Enabling `emitDecoratorMetadata` is not required and not recommended.
 
-### Using decorators with Babel  { #decorators-babel }
+### Using decorators with Babel { #decorators-babel }
 
-If you're compiling JavaScript with [Babel](https://babeljs.io/docs/en/), you can enable decorators by adding the following plugins and settings:
+[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in standard decorator mode with the `accessor` keyword on decorated class fields.
 
-*   [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators)
-*   [`@babel/plugin-proposal-class-properties`](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties)
-
-Note, the `@babel/plugin-proposal-class-properties` may not be required with the latest versions of Babel.
-
-To set up the plugins, add code like this to your Babel configuration:
+You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
 
 ```json
-"assumptions": {
-  "setPublicClassFields": true
-},
 "plugins": [
   ["@babel/plugin-proposal-decorators", {
-    "version": "2018-09",
-    "decoratorsBeforeExport": true
-  }],
-  ["@babel/plugin-proposal-class-properties"]
+    "version": "2023-05"
+  }]
 ]
 ```
 
 <div class="alert alert-info">
 
-Babel decorator support has been tested with `version: '2018-09'`. This is currently the default, but we recommend setting the version explicitly in case the default changes. Other versions ('2021-12' or 'legacy') are not supported, but this may change as Babel evolves. See the [Babel documentation](https://babeljs.io/docs/en/babel-plugin-proposal-decorators#options) if you want to experiment.
+Lit decorators only work with `version: "2023-05"`. Other versions (`"2021-12"` or `"legacy"`) are not supported.
 
 </div>
 
 ### Using decorators with TypeScript and Babel
 
-When using TypeScript with Babel, it's important to order the TypeScript transform before the decorators transform in your Babel config as follows:
+When using Babel to compile TypeScript sources, it's important to order the TypeScript transform before the decorators transform in your Babel config as follows:
 
 ```json
 {
@@ -163,8 +202,6 @@ constructor() {
 
 ### Avoiding issues with class fields and decorators {#avoiding-issues-with-class-fields}
 
-[Class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
-
-The current decorators [stage 3 proposal](https://github.com/tc39/proposal-decorators) does not directly address this issue, but it should be solved as the proposal evolves and matures.
+Standard [Class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
 
 When using decorators, transpiler settings for Babel and TypeScript must be configured correctly as shown in the sections above for [TypeScript](#decorators-typescript) and [Babel](#decorators-babel).

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -24,24 +24,6 @@ export class MyElement extends LitElement {
 }
 ```
 
-Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) support decorators, though no browsers have implemented them yet. Lit decorators work with Babel and TypeScript, and will work in browsers when they implement them natively.
-
-{% aside "info" %}
-
-What does stage 3 mean?
-
-Stage 3 means that the specification text is complete, and ready for browsers to implement. Once the specification has been implemented in multiple browsers, it can move to the final stage, stage 4, and be added to the ECMAScript standard. A stage 3 proposal can still change, but only if critical issues are discovered during implementation.
-
-{% endaside %}
-
-Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since its inception.
-
-Lit decorators work as both TypeScript experimental decorators and standard decorators. We currently recommend that TypeScript users use experimental decorator mode because the JavaScript output is much smaller than in standard decorator mode.
-
-This means that TypeScript-based Lit projects should have `"experimentalDecorators": true` in their tsconfig.
-
-See the [Enabling decorators](#enabling-decorators) section for more information.
-
 {#custom-element}
 
 The `@customElement` decorator defines a custom element, equivalent to calling:
@@ -50,9 +32,93 @@ The `@customElement` decorator defines a custom element, equivalent to calling:
 customElements.define('my-element', MyElement);
 ```
 
-The `@property` decorator declares a reactive property.
+The `@property` decorator declares a [reactive property](/docs/v3/components/properties/).
 
-See [Reactive properties](/docs/v3/components/properties/) for more information about configuring properties.
+Other decorators provided by the Lit package can be found in the list of [built-in decorators](#built-in-decorators).
+
+## Background
+
+Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for addition to the ECMAScript standard. Compilers like [Babel](https://babeljs.io/) and [TypeScript](https://www.typescriptlang.org/) support decorators, though no browsers have implemented them yet. Lit decorators work with Babel and TypeScript, and will work in browsers when they implement them natively.
+
+{% aside "info" %}
+
+What does stage 3 mean?
+
+It means that the specification text is complete, and ready for browsers to implement. Once the specification has been implemented in multiple browsers, it can move to the final stage, stage 4, and be added to the ECMAScript standard. A stage 3 proposal will only change if critical issues are discovered during implementation.
+
+{% endaside %}
+
+Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since its inception.
+
+Lit decorators work as both TypeScript experimental decorators _and_ standard decorators meaning they work with either configuration set in tsconfig. However, we currently recommend that TypeScript users use experimental decorator mode, i.e. projects should set `"experimentalDecorators": true`, because the emitted JavaScript is much smaller than in standard decorator mode. As such, all of the TypeScript code samples in our documentation reflect the syntax that works with this mode, namely, we omit the `accessor` keyword on class fields that's required for standard decorators.
+
+If you are working in a TypeScript project that requires `"experimentalDecorators": false` or `useDefineForClassFields: true`, consult the [standard decorators](#standard-decorators) section of this page.
+
+## Enabling decorators { #enabling-decorators }
+
+To use decorators, you need to build your code with a compiler such as [TypeScript](#decorators-typescript) or [Babel](#decorators-babel).
+
+In the future when decorators become a native web platform feature, this may no longer be necessary.
+
+### Using decorators with TypeScript { #decorators-typescript }
+
+TypeScript supports both experimental decorators and standard decorators. Standard decorators are enabled by default in TypeScript 5.0 and later, though Lit requires decorator metadata, which is available in TypeScript 5.2 and later.
+
+We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
+
+To use experimental decorators you must enable the `experimentalDecorators` compiler option.
+
+You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this should only be required when the `target` is set to `ES2022` or greater, but it's recommended to explicitly ensure this setting is `false`.
+
+```json
+"experimentalDecorators": true,
+"useDefineForClassFields": false,
+```
+
+Enabling `emitDecoratorMetadata` is not required and not recommended.
+
+#### Migrating TypeScript experimental decorators to standard decorators { #migrating-typescript-standard-decorators }
+
+Lit decorators have been designed to support standard decorator syntax (using
+`accessor` on class field decorators) with TypeScript's experimental decorator
+mode.
+
+This allows incremental migration off of experimental decorators by adding the `accessor` keyword to decorated properties without a change of behavior.
+Once all class field decorators use the `accessor` keyword, you can change your
+`tsconfig.json` completing the migration to standard decorators:
+
+```json
+"experimentalDecorators": false,
+"useDefineForClassFields": true,
+```
+
+Read more about the code changes required to migrate to standard decorators in [the upgrade guide](/docs/v3/releases/upgrade/#standard-decorator-migration).
+
+### Using decorators with Babel { #decorators-babel }
+
+[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin as of version 7.23. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in [standard decorator mode with the `accessor` keyword](#standard-decorators) on decorated class fields.
+
+You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
+
+```json
+"plugins": [
+  ["@babel/plugin-proposal-decorators", {
+    "version": "2023-05"
+  }]
+]
+```
+
+<div class="alert alert-info">
+
+Lit decorators only work with `"version": "2023-05"`. Other versions, including the formerly supported `"2018-09"`, are not supported.
+
+</div>
+
+### Avoiding issues with class fields and decorators {#avoiding-issues-with-class-fields}
+
+Standard [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
+
+When using decorators, transpiler settings for Babel and TypeScript must be configured correctly as shown in the sections above for [TypeScript](#decorators-typescript) and [Babel](#decorators-babel).
 
 ## Built-in decorators
 
@@ -70,7 +136,7 @@ See [Reactive properties](/docs/v3/components/properties/) for more information 
 
 ## Importing decorators
 
-You can import all the lit decorators via the `lit/decorators.js` module:
+You can import all of the Lit decorators via the `lit/decorators.js` module:
 
 ```js
 import {customElement, property, eventOptions, query} from 'lit/decorators.js';
@@ -89,7 +155,7 @@ import {eventOptions} from 'lit/decorators/event-options.js';
 
 Standard decorators are supported in TypeScript and Babel, with native browser coming in the near future.
 
-The biggest difference between using standard decorators and experimental decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member - fields, accessors, and methods can be decorated and replaced, but only with the same kind of member.
+The biggest difference between using standard decorators and experimental decorators is that, for performance reasons, standard decorators cannot change the _kind_ of a class member – fields, accessors, and methods – being decorated and replaced, and will only produce the same kind of member.
 
 Since many Lit decorators generate accessors, this means that the decorators need to be applied to accessors, not class fields.
 
@@ -121,70 +187,3 @@ Compiler output for standard decorators is unfortunately large due to the need t
 So we recommend that users who wish to use decorators continue to use TypeScript experimental decorators for now.
 
 In the future the Lit team plans on adding decorator transforms to our optional Lit Compiler in order to compile standard decorators to a more compact compiler output. Native browser support will also eliminate the need for any compiler transforms at all.
-
-## Enabling decorators { #enabling-decorators }
-
-To use decorators, you need to build your code with a compiler such as [TypeScript](#decorators-typescript) or [Babel](#decorators-babel).
-
-In the future when decorators become a native web platform feature, this may no longer be necessary.
-
-### Using decorators with TypeScript { #decorators-typescript }
-
-TypeScript supports both experimental decorators and standard decorators. Standard decorators are enabled by default in TypeScript 5.0 and later, though Lit requires decorator metadata, which is available in TypeScript 5.2 and later.
-
-We recommend that TypeScript developers use experimental decorators for now for optimal compiler output.
-
-To use experimental decorators you must enable the `experimentalDecorators` compiler option.
-
-You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this should only be required when the `target` is set to `ES2022` or greater, but it's recommended to explicitly ensure this setting is `false`.
-
-```json
-"experimentalDecorators": true,
-"useDefineForClassFields": false,
-```
-
-Enabling `emitDecoratorMetadata` is not required and not recommended.
-
-#### Migrating TypeScript experimental decorators to standard decorators
-
-Lit decorators have been designed to support standard decorator syntax (using
-`accessor` on class field decorators) with TypeScript's experimental decorator
-mode.
-
-This allows incremental migration off experimental decorators by incrementally
-adding the `accessor` keyword without a change of behavior.
-Once all class field decorators use the `accessor` keyword, you can change your
-`tsconfig.json` completing the migration to standard decorators:
-
-```json
-"experimentalDecorators": false,
-"useDefineForClassFields": true,
-```
-
-Read more about the code changes required to migrate to standard decorators in [the upgrade guide](/docs/releases/upgrade/#standard-decorator-migration).
-
-### Using decorators with Babel { #decorators-babel }
-
-[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in [standard decorator mode with the `accessor` keyword](#standard-decorators) on decorated class fields.
-
-You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
-
-```json
-"plugins": [
-  ["@babel/plugin-proposal-decorators", {
-    "version": "2023-05"
-  }]
-]
-```
-
-<div class="alert alert-info">
-
-Lit decorators only work with `version: "2023-05"`. Other versions (`"2021-12"` or `"legacy"`) are not supported.
-
-</div>
-
-### Avoiding issues with class fields and decorators {#avoiding-issues-with-class-fields}
-
-Standard [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with declaring reactive properties. See [Avoiding issues with class fields when declaring properties](/docs/v3/components/properties/#avoiding-issues-with-class-fields) for more information.
-
-When using decorators, transpiler settings for Babel and TypeScript must be configured correctly as shown in the sections above for [TypeScript](#decorators-typescript) and [Babel](#decorators-babel).

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -39,7 +39,7 @@ See [Decorator versions](#decorator-versions) for more details.
 
 | Decorator | Summary | More Info |
 |-----------|---------|--------------|
-| {% api-v3 "@customElement" "customElement" %} | Defines a custom element | [Defining](/docs/v3/components/defining/) |
+| {% api-v3 "@customElement" "customElement" %} | Defines a custom element. | [Defining](/docs/v3/components/defining/) |
 | {% api-v3 "@eventOptions" "eventOptions" %} | Adds event listener options. | [Events](/docs/v3/components/events/#event-options-decorator) |
 | {% api-v3 "@property" "property" %} | Defines a public property. | [Properties](/docs/v3/components/properties/#declare-with-decorators) |
 | {% api-v3 "@state" "state" %} | Defines a private state property | [Properties](/docs/v3/components/properties/#declare-with-decorators) |
@@ -72,11 +72,11 @@ In the future when decorators are supported natively in browsers, this will no l
 
 ### Using decorators with TypeScript { #decorators-typescript }
 
-TypeScript supports both experimental decorators and standard decorators. We recommend that TypeScript developers use experimental decorators for now for [optimal compiler output](#compiler-output-considerations).
+TypeScript supports both experimental decorators and standard decorators. We recommend that TypeScript developers use experimental decorators for now for [optimal compiler output](#compiler-output-considerations). If your project requires using standard decorators or setting `"useDefineForClassFields": true`, skip down to [migrating to standard decorators](#migrating-typescript-standard-decorators).
 
 To use experimental decorators you must enable the `experimentalDecorators` compiler option.
 
-You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this is only be required when the `target` is set to `ES2022` or greater, but it is recommended to explicitly set this to `false`.
+You should also ensure that the `useDefineForClassFields` setting is `false`. Note, this is only required when the `target` is set to `ES2022` or greater, but it is recommended to explicitly set this to `false`.
 
 ```json
 // tsconfig.json
@@ -92,15 +92,15 @@ Enabling `emitDecoratorMetadata` is not required and not recommended.
 
 #### Migrating TypeScript experimental decorators to standard decorators { #migrating-typescript-standard-decorators }
 
-Lit decorators have been designed to support standard decorator syntax (using `accessor` on class field decorators) with TypeScript's experimental decorator mode.
+Lit decorators are designed to support [standard decorator syntax](#standard-decorators) (using `accessor` on class field decorators) with TypeScript's experimental decorator mode.
 
-This allows incremental migration off of experimental decorators by adding the `accessor` keyword to decorated properties without a change of behavior. Once all class field decorators use the `accessor` keyword, you can change your `tsconfig.json` completing the migration to standard decorators:
+This allows incremental migration off of experimental decorators starting with the addition of the `accessor` keyword to decorated properties without a change of behavior. Once all decorated class field use the `accessor` keyword, you can change your compiler options to complete the migration to standard decorators:
 
 ```json
 // tsconfig.json
 {
   "compilerOptions": {
-    "experimentalDecorators": false, // default for TS 5.0 and up
+    "experimentalDecorators": false, // default for TypeScript 5.0 and up
     "useDefineForClassFields": true, // default when "target" is "ES2022" or higher
   }
 }
@@ -108,20 +108,19 @@ This allows incremental migration off of experimental decorators by adding the `
 
 Note: The `accessor` keyword was introduced in TypeScript 4.9 and full standard decorator with metadata support requires TypeScript 5.2 or greater.
 
-Read more about the code changes required to migrate to standard decorators in [the upgrade guide](/docs/v3/releases/upgrade/#standard-decorator-migration).
-
 ### Using decorators with Babel { #decorators-babel }
 
-[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin as of version 7.23. Babel does not support TypeScript experimental decorators, so you must use Lit decorators in [standard decorator mode with the `accessor` keyword](#standard-decorators) on decorated class fields.
+[Babel](https://babeljs.io/docs/en/) supports standard decorators with the [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) plugin as of version 7.23. Babel does not support TypeScript experimental decorators, so you must use Lit decorators with [standard decorator syntax](#standard-decorators) using the `accessor` keyword on decorated class fields.
 
-You can enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
+Enable decorators by adding [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/en/babel-plugin-proposal-decorators) with these Babel configuration settings:
 
 ```json
-"plugins": [
-  ["@babel/plugin-proposal-decorators", {
-    "version": "2023-05"
-  }]
-]
+// babel.config.json
+{
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", {"version": "2023-05"}]
+  ]
+}
 ```
 
 Note: Lit decorators only work with `"version": "2023-05"`. Other versions, including the formerly supported `"2018-09"`, are not supported.
@@ -186,7 +185,7 @@ export class MyElement extends LitElement {
 
 ### Compiler output considerations
 
-Compiler output for standard decorators is unfortunately large due to the need to generate the accessors, private storage and other objects that are part of the decorators API.
+Compiler output for standard decorators is unfortunately large due to the need to generate the accessors, private storage, and other objects that are part of the decorators API.
 
 So we recommend that users who wish to use decorators, if possible, use TypeScript experimental decorators for now.
 

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -147,7 +147,9 @@ Enabling `emitDecoratorMetadata` is not required and not recommended.
 
 #### Migrating TypeScript experimental decorators to standard decorators
 
-Standard decorator syntax (using `accessor` on class field decorators) is designed to be compatible with TypeScript's experimental decorator mode.
+Lit decorators have been designed to support standard decorator syntax (using
+`accessor` on class field decorators) with TypeScript's experimental decorator
+mode.
 
 This allows incremental migration off experimental decorators by incrementally
 adding the `accessor` keyword without a change of behavior.

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -50,9 +50,9 @@ It means that the specification text is complete, and ready for browsers to impl
 
 Previous versions of the decorators proposal are also supported by some compilers, most notably TypeScript's "experimental decorators" which Lit has supported since its inception.
 
-Lit decorators work as both TypeScript experimental decorators _and_ standard decorators meaning they work with either configuration set in tsconfig. However, we currently recommend that TypeScript users use experimental decorator mode, i.e. projects should set `"experimentalDecorators": true`, because the emitted JavaScript is much smaller than in standard decorator mode. As such, all of the TypeScript code samples in our documentation reflect the syntax that works with this mode, namely, we omit the `accessor` keyword on class fields that's required for standard decorators.
+Lit decorators work as both TypeScript experimental decorators _and_ standard decorators meaning they work with either configuration set in tsconfig. However, we currently recommend that TypeScript users use experimental decorator mode, i.e. projects should set `"experimentalDecorators": true`, because the emitted JavaScript is much smaller than in standard decorator mode. As such, all of the TypeScript code samples in our documentation reflect the syntax that works with this mode – namely, we omit the `accessor` keyword on class fields that's required for [standard decorators](#standard-decorators).
 
-If you are working in a TypeScript project that requires `"experimentalDecorators": false` or `useDefineForClassFields: true`, consult the [standard decorators](#standard-decorators) section of this page.
+If you are working in a TypeScript project that requires `"experimentalDecorators": false` or `useDefineForClassFields: true`, consult the [Migrating TypeScript to standard decorators](#migrating-typescript-standard-decorators) section of this page.
 
 ## Enabling decorators { #enabling-decorators }
 

--- a/packages/lit-dev-content/site/docs/v3/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v3/components/decorators.md
@@ -11,7 +11,7 @@ versionLinks:
 
 Decorators are functions that can be used to declaratively annotate and modify the behavior of classes.
 
-Lit provides a set of decorators that enable declarative APIs for things like registering elements, defining reactive properties and query properties, or adding event options to event handler methods.
+Lit provides a set of optional decorators that enable declarative APIs for things like registering elements, defining reactive properties and query properties, or adding event options to event handler methods.
 
 For example, the `@customElement` and `@property()` decorators let you register a custom element and define a reactive property in a compact, declarative way:
 


### PR DESCRIPTION
Supersedes https://github.com/lit/lit.dev/pull/1176

### Adds

 - Documentation about standard decorators
 - Documentation about the design of hybrid decorators to allow incremental migration, and how one such migration can be done.
 - Updated Babel decorator information.