### PR TITLE
docs: fix lit/react link

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/frameworks/react.md
+++ b/packages/lit-dev-content/site/docs/v3/frameworks/react.md
@@ -8,7 +8,7 @@ versionLinks:
   v2: frameworks/react/
 ---
 
-The [@lit/react](https://github.com/lit/lit/tree/main/packages/labs/react) package provides utilities to create React wrapper components for web components, and custom hooks from [reactive controllers](../../composition/controllers/).
+The [@lit/react](https://github.com/lit/lit/tree/main/packages/react) package provides utilities to create React wrapper components for web components, and custom hooks from [reactive controllers](../../composition/controllers/).
 
 The React component wrapper enables setting properties on custom elements (instead of just attributes), mapping DOM events to React-style callbacks, and enables correct type-checking in JSX by TypeScript.
 


### PR DESCRIPTION
As far as I know lit React graduated and the link seems to point to the old lab package instead of the new stable React package