### PR TITLE
add v3 page redirects to each of the v1 pages

### DIFF
--- a/packages/lit-dev-content/site/docs/v1/components/decorators.md
+++ b/packages/lit-dev-content/site/docs/v1/components/decorators.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 6
 versionLinks:
   v2: components/decorators/
+  v3: components/decorators/
 ---
 
 Decorators are special expressions that can alter the behavior of class, class method, and class field declarations. LitElement supplies a set of decorators that reduce the amount of boilerplate code you need to write when defining a component.

--- a/packages/lit-dev-content/site/docs/v1/components/events.md
+++ b/packages/lit-dev-content/site/docs/v1/components/events.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 4
 versionLinks:
   v2: components/events/
+  v3: components/events/
 ---
 
 ## Where to add your event listeners

--- a/packages/lit-dev-content/site/docs/v1/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/v1/components/lifecycle.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 5
 versionLinks:
   v2: components/lifecycle/
+  v3: components/lifecycle/
 ---
 
 ## Overview

--- a/packages/lit-dev-content/site/docs/v1/components/properties.md
+++ b/packages/lit-dev-content/site/docs/v1/components/properties.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 3
 versionLinks:
   v2: components/properties/
+  v3: components/properties/
 ---
 
 ## Overview {#overview}

--- a/packages/lit-dev-content/site/docs/v1/components/styles.md
+++ b/packages/lit-dev-content/site/docs/v1/components/styles.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 2
 versionLinks:
   v2: components/styles/
+  v3: components/styles/
 ---
 
 This page describes how to add styles to your component.

--- a/packages/lit-dev-content/site/docs/v1/components/templates.md
+++ b/packages/lit-dev-content/site/docs/v1/components/templates.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 1
 versionLinks:
   v2: components/rendering/
+  v3: components/rendering/
 ---
 
 Add a template to your component to define internal DOM to implement your component.

--- a/packages/lit-dev-content/site/docs/v1/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v1/getting-started.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 2
 versionLinks:
   v2: getting-started/
+  v3: getting-started/
 ---
 
 There are two main ways to use LitElement:

--- a/packages/lit-dev-content/site/docs/v1/index.md
+++ b/packages/lit-dev-content/site/docs/v1/index.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 1
 versionLinks:
   v2:
+  v3:
 ---
 
 LitElement is a simple base class for creating fast, lightweight web components that work in any web page with any framework.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/concepts.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/concepts.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 8
 versionLinks:
   v2: templates/overview/
+  v3: templates/overview/
 ---
 
 lit-html utilizes some unique properties of JavaScript template literals and HTML `<template>` elements to function and achieve fast performance. So it's helpful to understand them first.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/creating-directives.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/creating-directives.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 6
 versionLinks:
   v2: templates/custom-directives/
+  v3: templates/custom-directives/
 ---
 
 Directives are functions that can customize how lit-html renders values. Template authors can use directives in their templates like other functions:

--- a/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 2
 versionLinks:
   v2: getting-started/
+  v3: getting-started/
 ---
 
 ## Installation

--- a/packages/lit-dev-content/site/docs/v1/lit-html/introduction.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/introduction.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 1
 versionLinks:
   v2: libraries/standalone-templates/
+  v3: libraries/standalone-templates/
 ---
 
 ## What is lit-html?

--- a/packages/lit-dev-content/site/docs/v1/lit-html/release-notes.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/release-notes.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 10
 versionLinks:
   v2: releases/upgrade/
+  v3: releases/upgrade/
 ---
 
 ## lit-html 1.3.0

--- a/packages/lit-dev-content/site/docs/v1/lit-html/rendering-templates.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/rendering-templates.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 5
 versionLinks:
   v2: components/rendering/
+  v3: components/rendering/
 ---
 
 A lit-html template expression does not cause any DOM to be created or updated. It's only a description of DOM, called a `TemplateResult`. To actually create or update DOM, you need to pass the `TemplateResult` to the `render()` function, along with a container to render to:

--- a/packages/lit-dev-content/site/docs/v1/lit-html/styling-templates.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/styling-templates.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 4
 versionLinks:
   v2: components/styles/
+  v3: components/styles/
 ---
 
 lit-html focuses on one thing: rendering HTML. How you apply styles to the HTML lit-html creates depends on how you're using it—for example, if you're using lit-html inside a component system like LitElement, you can follow the patterns used by that component system.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/template-reference.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/template-reference.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 7
 versionLinks:
   v2: templates/overview/
+  v3: templates/overview/
 ---
 
 lit-html templates are written using JavaScript template literals tagged with the `html` tag. The contents of the literal are mostly plain, declarative, HTML:

--- a/packages/lit-dev-content/site/docs/v1/lit-html/tools.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/tools.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 9
 versionLinks:
   v2: tools/overview/
+  v3: tools/overview/
 ---
 
 lit-html is available from the npm registry. If you're already using npm to manage dependencies, you can use lit-html much like any other JavaScript library you install from npm. This section describes some additional tools or plugins you might want to add to your workflow to make it easier to work with lit-html.

--- a/packages/lit-dev-content/site/docs/v1/lit-html/writing-templates.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/writing-templates.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 3
 versionLinks:
   v2: templates/overview/
+  v3: templates/overview/
 ---
 
 lit-html is a templating library that provides fast, efficient rendering and updating of HTML. It lets you express web UI as a function of data.

--- a/packages/lit-dev-content/site/docs/v1/resources/community.md
+++ b/packages/lit-dev-content/site/docs/v1/resources/community.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 1
 versionLinks:
   v2: resources/community/
+  v3: resources/community/
 ---
 
 There are many great resources and locations to learn about LitElement and web components,

--- a/packages/lit-dev-content/site/docs/v1/tools/build.md
+++ b/packages/lit-dev-content/site/docs/v1/tools/build.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 3
 versionLinks:
   v2: tools/production/
+  v3: tools/production/
 ---
 
 When building an app that includes LitElement components, you can use common JavaScript build tools like <a href="https://rollupjs.org/" target="_blank" rel="noopener">Rollup</a> or <a href="https://webpack.js.org/" target="_blank" rel="noopener">webpack</a>.

--- a/packages/lit-dev-content/site/docs/v1/tools/publish.md
+++ b/packages/lit-dev-content/site/docs/v1/tools/publish.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 1
 versionLinks:
   v2: tools/publishing/
+  v3: tools/publishing/
 ---
 
 This page describes how to publish a LitElement component to npm.

--- a/packages/lit-dev-content/site/docs/v1/tools/use.md
+++ b/packages/lit-dev-content/site/docs/v1/tools/use.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   order: 2
 versionLinks:
   v2: tools/overview/
+  v3: tools/overview/
 ---
 
 This page describes how to [use a LitElement component in your application](#use). It also describes how to make sure your deployed code is browser-ready by [building it for production](#build) and [loading the Web Components polyfills](#polyfills).


### PR DESCRIPTION
Currently these are not auto generated, so must be manually provided.

### Why

On google search, frustratingly some links still navigate to `v1` documentation.

For example, if you search: "firstUpdated", the very first link is to: `https://lit.dev/docs/v1/components/lifecycle/`.

Then when you press `v3` it doesn't take you to the right page.

### Fix

Map the v1 pages to their respective v3 pages.

### Test plan

Tested manually.


### Future work

We should consider a system which can figure out automatically how to skip versions.
We only need to provide `v1 -> v2`, and `v2 -> v3`, to compute the path from `v1 -> v3`.