### PR TITLE
fix: remove errant semi-colon after decorator

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/localization/overview.md
+++ b/packages/lit-dev-content/site/docs/v3/localization/overview.md
@@ -65,7 +65,7 @@ import {html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {msg} from '@lit/localize';
 
-@customElement('my-greeter');
+@customElement('my-greeter')
 class MyGreeter extends LitElement {
   @property()
   who = 'World';


### PR DESCRIPTION
Fixes the `Declaration expected.` TS error when running demo.