### PR TITLE
typo: remove semicolon from v2 localization docs

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/localization/overview.md
+++ b/packages/lit-dev-content/site/docs/v2/localization/overview.md
@@ -65,7 +65,7 @@ import {html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {msg} from '@lit/localize';
 
-@customElement('my-greeter');
+@customElement('my-greeter')
 class MyGreeter extends LitElement {
   @property()
   who = 'World';


### PR DESCRIPTION
Propagates https://github.com/lit/lit.dev/pull/1223 to the v2 docs