### PR TITLE
prevent version selector being autocompleted by the browser

### DIFF
--- a/packages/lit-dev-content/site/_includes/site-nav.html
+++ b/packages/lit-dev-content/site/_includes/site-nav.html
@@ -2,7 +2,7 @@
    <a href="{{ site.baseurl }}/docs/">Documentation</a>
 
    <litdev-version-selector>
-      <select name="version">
+      <select name="version" autocomplete="off">
         {% for version, versionData in versions %}
           <option value="{{ version }}"
             {% if version == selectedVersion %}


### PR DESCRIPTION
This fixes an issue where when you navigate back in history, the browser pre-fills the select with the value from just after you navigated.

Repro:

1. Navigate to lit.dev.
2. Select `v1`, and be navigated to the v1 docs.
3. Press back in history, and note the select is set to v1.


### Why is the fix worth it

This prevents confusion on navigating backwards, and having the version dropdown not reflect the page that you're on.

### Tradeoff

Safari `autocomplete="off"` doesn't work. And the workaround for Safari is a lot more involved.
This PR is an incremental improvement for Firefox and Chrome.

Tested manually across Chrome/Firefox/Safari.