### PR TITLE
remove search index generation from dev build

### DIFF
--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -580,7 +580,11 @@ ${content}
     );
     await Promise.all(emptyDocsIndexFiles.map((path) => fs.unlink(path)));
 
-    await createSearchIndex(ENV.eleventyOutDir);
+    if (!DEV) {
+      // Only create the search index in production when we'll be uploading it
+      // to algolia.
+      await createSearchIndex(ENV.eleventyOutDir);
+    }
 
     if (DEV) {
       // Symlink css, images, and playground projects. We do this in dev mode


### PR DESCRIPTION
Part of https://github.com/lit/lit.dev/issues/1201

### Context

While profiling lit.dev, I found this as an easy performance win to make dev mode builds faster.

In the old days, the Lit.dev search was done locally, so the search index could be used and debugged locally. However now the search index is instead deployed to Algolia. Thus the several seconds it takes to create the search index can be skipped when building the site in dev mode.

### Results

Before this change, tested with `dev:build`:

`[11ty] Wrote 373 files in 15.58 seconds (41.8ms each, v2.0.1)`

After this change:

`[11ty] Wrote 373 files in 12.15 seconds (32.6ms each, v2.0.1)`

