### PR TITLE
Optimize dev edit-refresh loop by caching the highlighted files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ test-results
 *.tsbuildinfo
 
 .wireit
+.highlights_cache

--- a/packages/lit-dev-content/.eleventy.js
+++ b/packages/lit-dev-content/.eleventy.js
@@ -56,6 +56,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(eleventyNavigationPlugin);
   eleventyConfig.addPlugin(playgroundPlugin, {
     sandboxUrl: ENV.playgroundSandboxUrl,
+    isDevMode: DEV,
   });
   if (!DEV) {
     // In dev mode, we symlink these directly to source.

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
@@ -138,21 +138,22 @@ export class BlockingRenderer {
     });
   }
 
-  private getCachedRender(lang: string, code: string): string | null {
-    if (!this.isDevMode) {
-      return null;
-    }
-    const fileName = createUniqueFileNameKey(lang, code);
-    const absoluteFilePath = pathlib.resolve(cachedHighlightsDir, fileName);
+  private getCachedRender(cachedFileName: string): string | null {
+    const absoluteFilePath = pathlib.resolve(
+      cachedHighlightsDir,
+      cachedFileName
+    );
     if (fs.existsSync(absoluteFilePath)) {
       return fs.readFileSync(absoluteFilePath, {encoding: 'utf8'});
     }
     return null;
   }
 
-  private writeCachedRender(lang: string, code: string, html: string) {
-    const fileName = createUniqueFileNameKey(lang, code);
-    const absoluteFilePath = pathlib.resolve(cachedHighlightsDir, fileName);
+  private writeCachedRender(cachedFileName: string, html: string) {
+    const absoluteFilePath = pathlib.resolve(
+      cachedHighlightsDir,
+      cachedFileName
+    );
     fs.writeFileSync(absoluteFilePath, html);
   }
 
@@ -163,12 +164,13 @@ export class BlockingRenderer {
     }
     // In dev mode, speed up the edit-refresh loop by caching the syntax
     // highlighted code.
-    const cachedResult = this.getCachedRender(lang, code);
+    const cachedFileName = createUniqueFileNameKey(lang, code);
+    const cachedResult = this.getCachedRender(cachedFileName);
     if (cachedResult !== null) {
       return {html: cachedResult};
     }
     const {html} = this.renderWithWorker(lang, code);
-    this.writeCachedRender(lang, code, html);
+    this.writeCachedRender(cachedFileName, html);
     return {html};
   }
 

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/blocking-renderer.ts
@@ -123,8 +123,12 @@ export class BlockingRenderer {
     });
     try {
       fs.mkdirSync(cachedHighlightsDir);
-    } catch {
-      // Directory already exists.
+    } catch (error) {
+      if ((error as {code: string}).code === 'EEXIST') {
+        // Directory already exists.
+      } else {
+        throw error;
+      }
     }
   }
 

--- a/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
+++ b/packages/lit-dev-tools-cjs/src/playground-plugin/plugin.ts
@@ -89,12 +89,12 @@ const countVisibleLines = (filename: string, code: string): number => {
  */
 export const playgroundPlugin = (
   eleventyConfig: EleventyConfig,
-  {sandboxUrl}: {sandboxUrl: string}
+  {sandboxUrl, isDevMode}: {sandboxUrl: string; isDevMode: boolean}
 ) => {
   let renderer: BlockingRenderer | undefined;
 
   eleventyConfig.on('eleventy.before', () => {
-    renderer = new BlockingRenderer();
+    renderer = new BlockingRenderer({isDevMode});
   });
 
   eleventyConfig.on('eleventy.after', async () => {


### PR DESCRIPTION
Issue: https://github.com/lit/lit.dev/issues/1201

### Context

This PR focusses exclusively on faster edit-refresh dev mode times.

Result is 11.3s edit-refresh time (from 16.7s edit-refresh time) on my M2 silicon mac.
Or, 34.4s edit-refresh time (from 57.3s ) on intel mac.

### How

Instead of using the playwright browser process to always retrieve the syntax highlighted code, instead use a temporary dev cache so syntax highlighted code blocks can be retrieved from the file system.

This ends up being more optimal than running the code through the browser (even using synchronous file system calls).

Note: synchronous file system calls must be used as the whole API must be sync for 11ty.

### Test plan

Manually tried it with edit refresh.
Note, there is a risk of a collision. In this case the code may appear wrong **only in dev mode** where caching is enabled.
