### PR TITLE
[examples] Update examples to use Lit 3

### DIFF
--- a/packages/lit-dev-content/samples/examples/motion-carousel/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-carousel/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-grid/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-grid/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-hero/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-hero/project.json
@@ -9,7 +9,7 @@
     "support.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-in-out/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-in-out/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-list/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-list/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-simple/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-simple/project.json
@@ -7,7 +7,7 @@
     "motion-slide.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.7.4\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.3\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/motion-todos/project.json
+++ b/packages/lit-dev-content/samples/examples/motion-todos/project.json
@@ -8,7 +8,7 @@
     "styles.ts": {},
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",\n    \"@material/mwc-textfield\": \"^0.25.1\",\n    \"@material/mwc-checkbox\": \"^0.25.1\",\n    \"@material/mwc-button\": \"^0.25.1\",\n    \"@material/mwc-formfield\": \"^0.25.1\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit-labs/motion\": \"^1.0.1\",\n    \"@material/mwc-textfield\": \"^0.25.1\",\n    \"@material/mwc-checkbox\": \"^0.25.1\",\n    \"@material/mwc-button\": \"^0.25.1\",\n    \"@material/mwc-formfield\": \"^0.25.1\"\n  }\n}",
       "hidden": true
     }
   },

--- a/packages/lit-dev-content/samples/examples/react-basics/app.tsx
+++ b/packages/lit-dev-content/samples/examples/react-basics/app.tsx
@@ -1,6 +1,6 @@
 import React from 'https://esm.sh/react@18';
 import {createRoot} from 'https://esm.sh/react-dom@18/client';
-import {createComponent} from '@lit-labs/react';
+import {createComponent} from '@lit/react';
 import {DemoGreeting as DemoGreetingWC} from './demo-greeting.js';
 
 // Creates a React component from a Lit component

--- a/packages/lit-dev-content/samples/examples/react-basics/project.json
+++ b/packages/lit-dev-content/samples/examples/react-basics/project.json
@@ -3,7 +3,7 @@
   "order": 0,
   "title": "Basics",
   "description": "Render web components in React apps.",
-  "section": "@lit-labs/react",
+  "section": "@lit/react",
   "files": {
     "app.tsx": {
       "contentType": "text/typescript-jsx"
@@ -15,7 +15,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/examples/react-events/app.tsx
+++ b/packages/lit-dev-content/samples/examples/react-events/app.tsx
@@ -1,6 +1,6 @@
 import React from 'https://esm.sh/react@18';
 import {createRoot} from 'https://esm.sh/react-dom@18/client';
-import {createComponent} from '@lit-labs/react';
+import {createComponent} from '@lit/react';
 import {ClickRoulette as ClickRouletteWC} from './click-roulette.js';
 
 const ClickRoulette = createComponent({

--- a/packages/lit-dev-content/samples/examples/react-events/project.json
+++ b/packages/lit-dev-content/samples/examples/react-events/project.json
@@ -3,7 +3,7 @@
   "order": 1,
   "title": "React events",
   "description": "Listen to react events from web components.",
-  "section": "@lit-labs/react",
+  "section": "@lit/react",
   "files": {
     "app.tsx": {"contentType": "text/typescript-jsx"},
     "click-roulette.ts": {},
@@ -13,7 +13,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/examples/react-refs/app.tsx
+++ b/packages/lit-dev-content/samples/examples/react-refs/app.tsx
@@ -1,6 +1,6 @@
 import React from 'https://esm.sh/react@18';
 import {createRoot} from 'https://esm.sh/react-dom@18/client';
-import {createComponent} from '@lit-labs/react';
+import {createComponent} from '@lit/react';
 import {FlyingTriangles as FlyingTrianglesWC} from './flying-triangles.js';
 
 /*

--- a/packages/lit-dev-content/samples/examples/react-refs/project.json
+++ b/packages/lit-dev-content/samples/examples/react-refs/project.json
@@ -3,7 +3,7 @@
   "order": 3,
   "title": "Refs",
   "description": "Interact with Web Component APIs via Refs.",
-  "section": "@lit-labs/react",
+  "section": "@lit/react",
   "files": {
     "app.tsx": {"contentType": "text/typescript-jsx"},
     "flying-triangles.ts": {},
@@ -13,7 +13,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@lit-labs/react\": \"^1.1.1\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3\",\n    \"@lit/react\": \"^1\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/examples/react-slots/app.tsx
+++ b/packages/lit-dev-content/samples/examples/react-slots/app.tsx
@@ -1,7 +1,7 @@
 import React from 'https://esm.sh/react@18';
 import {createRoot} from 'https://esm.sh/react-dom@18/client';
 import {SimpleSlots as SimpleSlotsWC} from './simple-slots.js';
-import {createComponent} from '@lit-labs/react';
+import {createComponent} from '@lit/react';
 
 const SimpleSlots = createComponent({
   react: React,

--- a/packages/lit-dev-content/samples/examples/react-slots/project.json
+++ b/packages/lit-dev-content/samples/examples/react-slots/project.json
@@ -13,7 +13,7 @@
     },
     "index.html": {},
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^2\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3\",\n    \"@types/react\": \"18.2.7\",\n    \"@types/react-dom\": \"^18\",\n    \"@types/react-dom/client\": \"^18\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/samples/v3-base.json
+++ b/packages/lit-dev-content/samples/v3-base.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "package.json": {
-      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0-pre.1\",\n    \"@lit/reactive-element\": \"^2.0.0-pre.1\",\n    \"lit-element\": \"^4.0.0-pre.1\",\n    \"lit-html\": \"^3.0.0-pre.1\"\n  }\n}",
+      "content": "{\n  \"dependencies\": {\n    \"lit\": \"^3.0.0\",\n    \"@lit/reactive-element\": \"^2.0.0\",\n    \"lit-element\": \"^4.0.0\",\n    \"lit-html\": \"^3.0.0\"\n  }\n}",
       "hidden": true
     }
   }

--- a/packages/lit-dev-content/site/_data/playground_examples.js
+++ b/packages/lit-dev-content/site/_data/playground_examples.js
@@ -13,7 +13,7 @@ const topSectionOrder = [
   'Template concepts',
   'Directives',
   'Managing Data',
-  '@lit-labs/react',
+  '@lit/react',
   '@lit-labs/motion'
 ];
 


### PR DESCRIPTION
- Updated v3 base project json for to use Lit 3 stable (it was on prerelease).
- Update hard-coded versions in project/package.json for motion and react examples.
- Update react examples to use graduated package, and update the section heading to drop labs.