### PR TITLE
chore: tighten the wireit files dependency on building unversioned docs command

### DIFF
--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -156,8 +156,7 @@
         "../lit-dev-tools-esm:build"
       ],
       "files": [
-        "site/docs/**",
-        "!site/docs/unversioned"
+        "site/docs/v3/**"
       ],
       "output": [
         "site/docs/unversioned/**"


### PR DESCRIPTION
### Context

Instead of watching all files under `/docs/`, the `build:unversioned-docs` command only needs to look at the files within the latest version directory.

This will result in slightly less work.

### Test plan

Unversioned docs checked in preview URL.