### PR TITLE
Add aria-label to the version selector component to raise a11y score

### DIFF
--- a/packages/lit-dev-content/site/_includes/site-nav.html
+++ b/packages/lit-dev-content/site/_includes/site-nav.html
@@ -2,7 +2,7 @@
    <a href="{{ site.baseurl }}/docs/">Documentation</a>
 
    <litdev-version-selector>
-      <select name="version" autocomplete="off">
+      <select name="version" autocomplete="off" aria-label="Lit version selector">
         {% for version, versionData in versions %}
           <option value="{{ version }}"
             {% if version == selectedVersion %}


### PR DESCRIPTION
### Why

I was running a Chrome lighthouse audit on the new Learn page (#1160) and noted this was bringing down the accessibility score.

### How

Add `aria-label` to label the version selector.

### Impact

Raises Accessibility Lighthouse score from 92 -> 96 on the home page, and 96 -> 100 on /tutorials. Tested by manually running the lighthouse audit.