### PR TITLE
Fix code-language-switch a11y lighthouse audit

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-code-language-switch.ts
+++ b/packages/lit-dev-content/src/components/litdev-code-language-switch.ts
@@ -134,8 +134,8 @@ export class LitDevCodeLanguageSwitch extends LitElement {
         title=${mode === 'ts' ? 'Disable TypeScript' : 'Enable TypeScript'}
         @click=${this._toggleLanguageAndAdjustScroll}
       >
-        <span id="jsLabel">JS</span>
-        <span id="tsLabel">TS</span>
+        <span id="jsLabel" aria-hidden="true">JS</span>
+        <span id="tsLabel" aria-hidden="true">TS</span>
         <span id="toggle"></span>
       </button>
     `;


### PR DESCRIPTION
### Context

The code language switch was triggering the following audit issue: https://dequeuniversity.com/rules/axe/4.7/label-content-name-mismatch

Basically it wanted the `aria-label` to contain `JS TS` within it. This didn't make much sense to me, so I looked up the switch accessibility pattern https://www.w3.org/WAI/ARIA/apg/patterns/switch/

### Fix

Use the same accessibility pattern as https://www.w3.org/WAI/ARIA/apg/patterns/switch/examples/switch-button/ and hide the inner text content. This prevents redundant announcement of state by screen readers.

We can hide the `JS` and `TS` text from the accessibility tree as our switch already provides full information via `aria-label`, and `aria-checked`. This then passes the audit because we no longer need to include the string `JS TS` in the aria label.

### Testing

Tested by looking at the accessibility tree developer console. The switch has the label `Toggle TypeScript`, and checked state of `true` or `false`.

Lighthouse audit is now passing for this component.