### PR TITLE
[docs] remove Lit 2 reference in Lit 3 reactive controller docs

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/composition/controllers.md
+++ b/packages/lit-dev-content/site/docs/v3/composition/controllers.md
@@ -8,8 +8,6 @@ versionLinks:
   v2: composition/controllers/
 ---
 
-Lit 2 introduces a new concept for code reuse and composition called _reactive controllers_.
-
 A reactive controller is an object that can hook into a component's [reactive update cycle](/docs/v3/components/lifecycle/#reactive-update-cycle). Controllers can bundle state and behavior related to a feature, making it reusable across multiple component definitions.
 
 You can use controllers to implement features that require their own state and access to the component's lifecycle, such as:


### PR DESCRIPTION
### Context

I found it a bit jarring to have the reactive controller page start with "Lit 2 introduces ..." when we're on the Lit 3 version of the site.

### Fix

The following two sentences explain what a reactive controller is, so I've removed the Lit 2 sentence, and I don't think it loses any information from the top of the page.

### Risks

Docs only update. Main risk if I've removed valuable information from the page. I don't think I have.