### PR TITLE
[learn] fix error being logged on learn page

### DIFF
--- a/packages/lit-dev-content/site/css/learn-catalog.css
+++ b/packages/lit-dev-content/site/css/learn-catalog.css
@@ -164,7 +164,6 @@ md-chip-set:not(:defined) {
 
 .card-header {
   aspect-ratio: 16/9;
-  background: url(/images/learn/banner-blue.png) rgba(50, 79, 255, 1);
   overflow: hidden;
 }
 


### PR DESCRIPTION
### Context

Fixes an error being thrown in the console: 

`GET https://lit.dev/images/learn/banner-blue.png 404 (Not Found)`

### Fix

We no longer use any background image because all cards contain their own explicit image. Remove the CSS that is triggering the load.

### Impact

I believe this gets the page to a lighthouse score of all 100's.