### PR TITLE
[learn] Fix hard reload or initial load not respecting filter hash

### DIFF
--- a/packages/lit-dev-content/src/pages/learn.ts
+++ b/packages/lit-dev-content/src/pages/learn.ts
@@ -95,13 +95,14 @@ const initChipsFromURL = async (hash = window.location.hash) => {
     (chip as FilterChip).selected =
       kinds.length === 0 || kinds.includes(chipKind);
   });
+
+  // Do not update hash to prevent an infinite loop.
+  updateContentFromChips(false);
 };
 
-// Handles forwads and back navigation between hashes
+// Handle forwards and back navigation between hashes
 window.addEventListener('hashchange', async (event: HashChangeEvent) => {
   await initChipsFromURL(new URL(event.newURL).hash);
-  // Do not update hash to prevent an infinite loop.
-  await updateContentFromChips(false);
 });
 
 // Handles clicking a filter chip.


### PR DESCRIPTION
### Context

This fixes a bug where the filter chips can get out of sync with their card state.

To repro the bug:

 1. Open https://lit.dev/learn/#filter=tutorial
 2. Notice that it's not only tutorials.

Expect that only tutorials are shown if the hash is set to only show `tutorials`.

### Fix

Previously we would only update the state of the page after a `hashchange` event. But this would not trigger on initial page load.
Now we always update the content from the chip state after initializing chips from URL.

### Test

Test manually.