### PR TITLE
[docs] Add multiple versions of lit resolution section

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/tools/development.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/development.md
@@ -91,6 +91,8 @@ If you’re publishing a library that uses Lit, follow our [publishing best prac
 
 ##### Resolving multiple versions of Lit
 
+It is possible to follow the steps below, and not be able to de-duplicate Lit, e.g., a library you depend on is bundling a specific version of Lit. In these cases the warning can be ignored.
+
 If you’re seeing a `Multiple versions of Lit loaded` development mode warning, there are a couple things you can try:
 
 1. Find out which Lit libraries have multiple versions loaded by checking the following variables in your browser console: `window.litElementVersions`, `window.reactiveElementVersions`, and `window.litHtmlVersions`.
@@ -99,9 +101,9 @@ If you’re seeing a `Multiple versions of Lit loaded` development mode warning,
 
 3. Try to use `npm dedupe` to de-duplicate Lit. Use `npm ls` to verify if the duplicated Lit package was successfully de-duped.
 
-4. If there is still duplication, you may need to delete your package lock and `node_modules`. Then install the version of `lit` you want explicitly, followed by your dependencies.
+4. It is possible to nudge `npm` to hoist particular versions of the core Lit packages by installing them as direct dependencies of your project with `npm i @lit/reactive-element@latest lit-element@latest lit-html@latest`. Replace `latest` with the version you want to de-dupe to.
 
-It is possible to follow these steps, and not be able to de-duplicate Lit, e.g., a library you depend on is bundling a specific version of Lit. In these cases the warning can be ignored.
+5. If there is still duplication, you may need to delete your package lock and `node_modules`. Then install the version of `lit` you want explicitly, followed by your dependencies.
 
 If you want to silence the warning, add the following code early in your application before Lit has been loaded to initialize the global `litIssuedWarnings` set, and preemptively add the warning to the set.
 

--- a/packages/lit-dev-content/site/docs/v3/tools/development.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/development.md
@@ -107,17 +107,6 @@ If you’re seeing a `Multiple versions of Lit loaded` development mode warning,
 
 5. If there is still duplication, you may need to delete your package lock and `node_modules`. Then install the version of `lit` you want explicitly, followed by your dependencies.
 
-If you want to silence the warning, add the following code early in your application before Lit has been loaded to initialize the global `litIssuedWarnings` set, and preemptively add the warning to the set.
-
-```html
-<script>
-  window.litIssuedWarnings = new Set();
-  // By adding the Lit warning to this global set, Lit will no longer emit the multiple versions warning.
-  window.litIssuedWarnings.add(
-    'Multiple versions of Lit loaded. Loading multiple versions is not recommended. See https://lit.dev/msg/multiple-versions for more information.'
-  );
-</script>
-```
 
 ## Local dev servers { #devserver }
 

--- a/packages/lit-dev-content/site/docs/v3/tools/development.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/development.md
@@ -78,6 +78,43 @@ class MyElement extends LitElement {
 
 It's best for code size if the code to control warnings is eliminated in your own production builds.
 
+#### Multiple versions of Lit warning {#multiple-lit-versions}
+
+If Lit is being used as an internal dependency of elements, elements can use different versions of Lit and are completely interoperable.
+We also take care to ensure that Lit 2 and Lit 3 are mostly compatible with each other. For example, you can pass a Lit 2 template into a Lit 3 render function and vice-versa.
+
+So, why the warning? Lit is sometimes compared to frameworks which often break if components using different framework versions are mixed together. Thus, it's easier to accidentally install multiple duplicated versions of Lit without realizing.
+
+Loading multiple compatible versions of Lit is non-optimal because extra duplicated bytes must be sent to the user.
+
+If you’re publishing a library that uses Lit, follow our [publishing best practices](https://lit.dev/docs/tools/publishing/#don't-bundle-minify-or-optimize-modules) so consumers of your library are able to de-duplicate Lit in their projects.
+
+##### Resolving multiple versions of Lit
+
+If you’re seeing a `Multiple versions of Lit loaded` development mode warning, there are a couple things you can try:
+
+1. Find out which Lit libraries have multiple versions loaded by checking the following variables in your browser console: `window.litElementVersions`, `window.reactiveElementVersions`, and `window.litHtmlVersions`.
+
+2. Use `npm ls` (note, you can specify exact libraries to look for, e.g. `npm ls @lit/reactive-element`) to narrow down which dependencies are loading multiple different versions of Lit.
+
+3. Try to use `npm dedupe` to de-duplicate Lit. Use `npm ls` to verify if the duplicated Lit package was successfully de-duped.
+
+4. If there is still duplication, you may need to delete your package lock and `node_modules`. Then install the version of `lit` you want explicitly, followed by your dependencies.
+
+It is possible to follow these steps, and not be able to de-duplicate Lit, e.g., a library you depend on is bundling a specific version of Lit. In these cases the warning can be ignored.
+
+If you want to silence the warning, add the following code early in your application before Lit has been loaded to initialize the global `litIssuedWarnings` set, and preemptively add the warning to the set.
+
+```html
+<script>
+  window.litIssuedWarnings = new Set();
+  // By adding the Lit warning to this global set, Lit will no longer emit the multiple versions warning.
+  window.litIssuedWarnings.add(
+    'Multiple versions of Lit loaded. Loading multiple versions is not recommended. See https://lit.dev/msg/multiple-versions for more information.'
+  );
+</script>
+```
+
 ## Local dev servers { #devserver }
 
 Lit is packaged as JavaScript modules, and it uses bare module specifiers that are not yet natively supported in most browsers. Bare specifiers are commonly used, and you may want to use them in your own code as well. For example:

--- a/packages/lit-dev-content/site/docs/v3/tools/development.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/development.md
@@ -80,6 +80,8 @@ It's best for code size if the code to control warnings is eliminated in your ow
 
 #### Multiple versions of Lit warning {#multiple-lit-versions}
 
+A dev mode only warning is triggered when multiple versions, or even multiple copies of the same version, of any of the Lit core packages – `lit-html`, `lit-element`, `@lit/reactive-element` – are detected.
+
 If Lit is being used as an internal dependency of elements, elements can use different versions of Lit and are completely interoperable.
 We also take care to ensure that Lit 2 and Lit 3 are mostly compatible with each other. For example, you can pass a Lit 2 template into a Lit 3 render function and vice-versa.
 

--- a/packages/lit-dev-content/site/docs/v3/tools/requirements.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/requirements.md
@@ -49,3 +49,22 @@ All modern browsers update automatically and users are highly likely to have a r
 ## Note on legacy browsers {#note-on-legacy-browsers}
 
 Lit 3 is not tested on legacy browsers, specifically Internet Explorer 11 and Classic Edge are not supported due to non-standard DOM behavior. If you must support legacy browsers, consider using Lit 2 with additional compilation and/or polyfills as described in [Building for legacy browsers](/docs/v2/tools/requirements#building-for-legacy-browsers).
+
+## Multiple versions of Lit {#multiple-lit-versions}
+
+If Lit is being used as an internal dependency of elements, elements can use different versions of Lit.
+We also take care to ensure that Lit 2 and Lit 3 are mostly interoperable with each other. For example, you can pass a Lit 2 template into a Lit 3 render function and vice-versa.
+
+Because having multiple compatible versions of Lit loaded is non-optimal, due to shipping extra duplicated bytes to the user, we raise a development mode warning.
+
+### Resolving multiple versions of Lit
+
+If you’re publishing a library that uses Lit, follow our [publishing best practices](https://lit.dev/docs/tools/publishing/#don't-bundle-minify-or-optimize-modules) so consumers of your library are able to de-duplicate Lit in their projects.
+
+If you’re seeing a `Multiple versions of Lit loaded` development mode warning, there are a couple things you can try.
+
+1. Find out which Lit libraries have multiple versions loaded by checking the following variables in your browser console: `window.litElementVersions`, `window.reactiveElementVersions`, and `window.litHtmlVersions`.
+
+2. Use `npm ls` (note, you can specify exact libraries to look for, e.g. `npm ls @lit/reactive-element`) to narrow down which dependencies are loading multiple different versions of Lit.
+
+3. Try to use `npm dedupe` to de-duplicate Lit. Use `npm ls` to verify if the duplicated Lit package was successfully de-duped.

--- a/packages/lit-dev-content/site/docs/v3/tools/requirements.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/requirements.md
@@ -50,37 +50,3 @@ All modern browsers update automatically and users are highly likely to have a r
 
 Lit 3 is not tested on legacy browsers, specifically Internet Explorer 11 and Classic Edge are not supported due to non-standard DOM behavior. If you must support legacy browsers, consider using Lit 2 with additional compilation and/or polyfills as described in [Building for legacy browsers](/docs/v2/tools/requirements#building-for-legacy-browsers).
 
-## Multiple versions of Lit {#multiple-lit-versions}
-
-If Lit is being used as an internal dependency of elements, elements can use different versions of Lit.
-We also take care to ensure that Lit 2 and Lit 3 are mostly interoperable with each other. For example, you can pass a Lit 2 template into a Lit 3 render function and vice-versa.
-
-Because having multiple compatible versions of Lit loaded is non-optimal, due to shipping extra duplicated bytes to the user, we raise a development mode warning.
-
-If you’re publishing a library that uses Lit, follow our [publishing best practices](https://lit.dev/docs/tools/publishing/#don't-bundle-minify-or-optimize-modules) so consumers of your library are able to de-duplicate Lit in their projects.
-
-### Resolving multiple versions of Lit
-
-If you’re seeing a `Multiple versions of Lit loaded` development mode warning, there are a couple things you can try.
-
-1. Find out which Lit libraries have multiple versions loaded by checking the following variables in your browser console: `window.litElementVersions`, `window.reactiveElementVersions`, and `window.litHtmlVersions`.
-
-2. Use `npm ls` (note, you can specify exact libraries to look for, e.g. `npm ls @lit/reactive-element`) to narrow down which dependencies are loading multiple different versions of Lit.
-
-3. Try to use `npm dedupe` to de-duplicate Lit. Use `npm ls` to verify if the duplicated Lit package was successfully de-duped.
-
-4. If there is still duplication, you may need to delete your package lock and `node_modules`. Then install the version of `lit` you want explicitly, followed by your dependencies.
-
-It is possible to follow these steps, and not be able to de-duplicate Lit. For example, a library you depend on may bundle a specific version of Lit in a way that cannot be de-duplicated. In these cases the warning can be ignored.
-
-If the warning is distracting and you want to silence it, add the following code early in your application before Lit has been loaded to initialize the global `litIssuedWarnings` set, and preemptively add the warning to the set.
-
-```html
-<script>
-  window.litIssuedWarnings = new Set();
-  // By adding the Lit warning to this global set, Lit will no longer emit the multiple versions warning.
-  window.litIssuedWarnings.add(
-    'Multiple versions of Lit loaded. Loading multiple versions is not recommended. See https://lit.dev/msg/multiple-versions for more information.'
-  );
-</script>
-```

--- a/packages/lit-dev-content/site/docs/v3/tools/requirements.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/requirements.md
@@ -57,9 +57,9 @@ We also take care to ensure that Lit 2 and Lit 3 are mostly interoperable with e
 
 Because having multiple compatible versions of Lit loaded is non-optimal, due to shipping extra duplicated bytes to the user, we raise a development mode warning.
 
-### Resolving multiple versions of Lit
-
 If you’re publishing a library that uses Lit, follow our [publishing best practices](https://lit.dev/docs/tools/publishing/#don't-bundle-minify-or-optimize-modules) so consumers of your library are able to de-duplicate Lit in their projects.
+
+### Resolving multiple versions of Lit
 
 If you’re seeing a `Multiple versions of Lit loaded` development mode warning, there are a couple things you can try.
 

--- a/packages/lit-dev-content/site/docs/v3/tools/requirements.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/requirements.md
@@ -68,3 +68,19 @@ If you’re seeing a `Multiple versions of Lit loaded` development mode warning,
 2. Use `npm ls` (note, you can specify exact libraries to look for, e.g. `npm ls @lit/reactive-element`) to narrow down which dependencies are loading multiple different versions of Lit.
 
 3. Try to use `npm dedupe` to de-duplicate Lit. Use `npm ls` to verify if the duplicated Lit package was successfully de-duped.
+
+4. If there is still duplication, you may need to delete your package lock and `node_modules`. Then install the version of `lit` you want explicitly, followed by your dependencies.
+
+It is possible to follow these steps, and not be able to de-duplicate Lit. For example, a library you depend on may bundle a specific version of Lit in a way that cannot be de-duplicated. In these cases the warning can be ignored.
+
+If the warning is distracting and you want to silence it, add the following code early in your application before Lit has been loaded to initialize the global `litIssuedWarnings` set, and preemptively add the warning to the set.
+
+```html
+<script>
+  window.litIssuedWarnings = new Set();
+  // By adding the Lit warning to this global set, Lit will no longer emit the multiple versions warning.
+  window.litIssuedWarnings.add(
+    'Multiple versions of Lit loaded. Loading multiple versions is not recommended. See https://lit.dev/msg/multiple-versions for more information.'
+  );
+</script>
+```

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -10,7 +10,7 @@ export const pageRedirects = new Map([
   ['/slack-invite',                   'https://discord.com/invite/buildWithLit'],
   ['/youtube',                        'https://www.youtube.com/@buildWithLit'],
   ['/msg/dev-mode',                   '/docs/tools/development/#development-and-production-builds'],
-  ['/msg/multiple-versions',          '/docs/tools/requirements/#multiple-lit-versions'],
+  ['/msg/multiple-versions',          '/docs/tools/development/#multiple-lit-versions'],
   ['/msg/polyfill-support-missing',   '/docs/v2/tools/requirements/#polyfills'],
   ['/msg/class-field-shadowing',      '/docs/components/properties/#avoiding-issues-with-class-fields'],
   // TODO(aomarks) Should we add something specifically about this issue?

--- a/packages/lit-dev-server/src/redirects.ts
+++ b/packages/lit-dev-server/src/redirects.ts
@@ -10,8 +10,7 @@ export const pageRedirects = new Map([
   ['/slack-invite',                   'https://discord.com/invite/buildWithLit'],
   ['/youtube',                        'https://www.youtube.com/@buildWithLit'],
   ['/msg/dev-mode',                   '/docs/tools/development/#development-and-production-builds'],
-  // TODO(sorvell) https://github.com/lit/lit.dev/issues/455
-  ['/msg/multiple-versions',          '/docs/tools/requirements/'],
+  ['/msg/multiple-versions',          '/docs/tools/requirements/#multiple-lit-versions'],
   ['/msg/polyfill-support-missing',   '/docs/v2/tools/requirements/#polyfills'],
   ['/msg/class-field-shadowing',      '/docs/components/properties/#avoiding-issues-with-class-fields'],
   // TODO(aomarks) Should we add something specifically about this issue?


### PR DESCRIPTION
Fixes: https://github.com/lit/lit.dev/issues/455

### Context

We have a developer warning that warns when multiple versions of Lit have been loaded. This doesn't currently link to documentation that gives clear actionable steps for resolving the warning.

This results in us needing to resolve the issues on a case by case basis via Discord.

### Fix

Add a section that discusses the multiple versions of Lit warning, as well as some resolution sections.

### Test plan

Docs only change. Can be tested by navigating to:

https://pr1261-1d82c04---lit-dev-5ftespv5na-uc.a.run.app/msg/multiple-versions
https://pr1261-1d82c04---lit-dev-5ftespv5na-uc.a.run.app/docs/tools/requirements/#multiple-lit-versions