### PR TITLE
[docs] mention that server should import custom element definitions to server render them

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/ssr/server-usage.md
+++ b/packages/lit-dev-content/site/docs/v3/ssr/server-usage.md
@@ -26,7 +26,7 @@ Typically `value` is a `TemplateResult` produced by a Lit template expression, l
 html`<h1>Hello</h1>`
 ```
 
-The template can contain custom elements. If they are defined on the server, they'll be rendered in turn, along with their templates.
+The template can contain custom elements. If the custom elements are defined on the server, they'll be rendered in turn, along with their templates.
 
 ```ts
 import {render} from '@lit-labs/ssr';

--- a/packages/lit-dev-content/site/docs/v3/ssr/server-usage.md
+++ b/packages/lit-dev-content/site/docs/v3/ssr/server-usage.md
@@ -26,10 +26,12 @@ Typically `value` is a `TemplateResult` produced by a Lit template expression, l
 html`<h1>Hello</h1>`
 ```
 
-The template can contain custom elements, which are rendered in turn, along with their templates.
+The template can contain custom elements. If they are defined on the server, they'll be rendered in turn, along with their templates.
 
 ```ts
 import {render} from '@lit-labs/ssr';
+// Import `my-element` on the server to server render it.
+import './my-element.js';
 
 const result = render(html`
   <h1>Hello SSR!</h1>
@@ -40,6 +42,8 @@ const result = render(html`
 To render a single element, you render a template that only contains that element:
 
 ```ts
+import './my-element.js';
+
 const result = render(html`<my-element></my-element>`);
 ```
 


### PR DESCRIPTION
Context: https://github.com/lit/lit/discussions/4406

While investigating the user issue, I noticed that we don't seem to explicitly mention or show that LitElements should be defined on the server.

`@lit-labs/ssr` patches `customElements.define` to be able to reference the class for a given tag. If the tag doesn't have a `LitElement` defined for it, then the element will not have it's declarative shadow DOM rendered on the server.

### Fix

Add a small change to the documentation which explicitly shows an import to the custom element on the server.