### PR TITLE
add type=module to lit-element-hydrate-support.js script tag examples

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/ssr/client-usage.md
+++ b/packages/lit-dev-content/site/docs/v2/ssr/client-usage.md
@@ -48,7 +48,7 @@ For example:
     <!-- App components rendered with declarative shadow DOM placed here. -->
 
     <!-- ssr-client lit-element-hydrate-support should be loaded first. -->
-    <script src="/node_modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"></script>
+    <script type="module" src="/node_modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"></script>
 
     <!-- As component definition loads, your pre-rendered components will
         come to life and become interactive. -->

--- a/packages/lit-dev-content/site/docs/v3/ssr/client-usage.md
+++ b/packages/lit-dev-content/site/docs/v3/ssr/client-usage.md
@@ -48,7 +48,7 @@ For example:
     <!-- App components rendered with declarative shadow DOM placed here. -->
 
     <!-- ssr-client lit-element-hydrate-support should be loaded first. -->
-    <script src="/node_modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"></script>
+    <script type="module" src="/node_modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"></script>
 
     <!-- As component definition loads, your pre-rendered components will
         come to life and become interactive. -->


### PR DESCRIPTION
Noticed that in a couple examples for showing how to add [hydration support for LitElement](https://lit.dev/docs/ssr/client-usage/#loading-@lit-labsssr-clientlit-element-hydrate-support.js), the snippets are missing a `type="module"` attribute on the `<script>` tag
```html
<script src="/node_modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"></script>
```

If I use the example as is, the browser throws an error
![Screenshot 2023-11-21 at 8 34 45 AM](https://github.com/lit/lit.dev/assets/895923/668555f5-bda8-41d6-a61f-f9d7388fd747)
![Screenshot 2023-11-21 at 9 13 28 AM](https://github.com/lit/lit.dev/assets/895923/3cca72ea-63f6-444c-8d9b-13ec2a78be19)


Adding `type="module"` fixes the issue
```html
<script type="module" src="/node_modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"></script>
```