### PR TITLE
[docs] Fix 'property' has no initializer issue in TypeScript property samples

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/components/properties.md
+++ b/packages/lit-dev-content/site/docs/v2/components/properties.md
@@ -16,7 +16,7 @@ Lit components receive input and store their state as JavaScript class fields or
 ```ts
 class MyElement extends LitElement {
   @property()
-  name: string;
+  name?: string;
 }
 ```
 
@@ -83,7 +83,7 @@ Use the `@property` decorator with a class field declaration to declare a reacti
 ```ts
 class MyElement extends LitElement {
   @property({type: String})
-  mode: string;
+  mode?: string;
 
   @property({attribute: false})
   data = {};

--- a/packages/lit-dev-content/site/docs/v3/components/properties.md
+++ b/packages/lit-dev-content/site/docs/v3/components/properties.md
@@ -16,7 +16,7 @@ Lit components receive input and store their state as JavaScript class fields or
 ```ts
 class MyElement extends LitElement {
   @property()
-  name: string;
+  name?: string;
 }
 ```
 
@@ -83,7 +83,7 @@ Use the `@property` decorator with a class field declaration to declare a reacti
 ```ts
 class MyElement extends LitElement {
   @property({type: String})
-  mode: string;
+  mode?: string;
 
   @property({attribute: false})
   data = {};


### PR DESCRIPTION
Fixes: https://github.com/lit/lit.dev/issues/1273

### Context

When looking at our documentation, the very first TypeScript example shows: https://lit.dev/docs/components/properties/

```ts
class MyElement extends LitElement {
  @property()
  name: string;
}
```

This results in a TypeScript error: `Property 'name' has no initializer and is not definitely assigned in the constructor.`.

This can be globally resolved by relaxing the TypeScript compiler via `"strictPropertyInitialization": false`, but we should prefer documentation that is as explicit/strict as possible.

We have [an example](https://lit.dev/playground/#sample=examples/properties-custom-converter) in the playground where it makes sense to not initialize a property. So I've added that syntax to our `properties.md` docs.


Fix:
```ts
class MyElement extends LitElement {
  @property()
  name?: string;
}
```

This clearly states that the property should be a string, but it can also be undefined if no-one initialized it.


### Risk & Tests

This is a low risk content only change – tested by checking out preview URL.