### PR TITLE
[playground] fix react slot playground location in table of contents

### DIFF
--- a/packages/lit-dev-content/samples/examples/react-slots/project.json
+++ b/packages/lit-dev-content/samples/examples/react-slots/project.json
@@ -3,7 +3,7 @@
   "order": 2,
   "title": "Slots",
   "description": "Project React Components onto web component slots.",
-  "section": "@lit-labs/react",
+  "section": "@lit/react",
   "files": {
     "app.tsx": {"contentType": "text/typescript-jsx"},
     "simple-slots.ts": {},


### PR DESCRIPTION
### Context

This playground was left behind from the `lit-labs` -> `lit` renaming. This PR fixes it.


### Before

Note that https://lit.dev/playground/#sample=examples/react-slots is at the very bottom of the playgrounds list (separate from the other react examples).

### After

The slot react example will move up to be grouped with its peers.