### PR TITLE
[doc] document that `asyncReplace` and `asyncAppend` accept an optional mapper function

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/directives.md
@@ -1933,7 +1933,7 @@ asyncReplace(iterable: AsyncIterable, mapper?: Function)
 <td class="no-wrap-cell vcenter-cell">Usable location</td>
 <td class="wide-cell">
 
-Child expression
+Any expression
 
 </td>
 </tr>

--- a/packages/lit-dev-content/site/docs/v2/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/directives.md
@@ -1831,7 +1831,7 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 <td class="wide-cell">
 
 ```ts
-asyncAppend(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
+asyncAppend(iterable: AsyncIterable, mapper?: Function)
 ```
 
 </td>
@@ -1924,7 +1924,7 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 <td class="wide-cell">
 
 ```ts
-asyncReplace(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
+asyncReplace(iterable: AsyncIterable, mapper?: Function)
 ```
 
 </td>

--- a/packages/lit-dev-content/site/docs/v2/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/directives.md
@@ -1831,7 +1831,7 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 <td class="wide-cell">
 
 ```ts
-asyncAppend(iterable: AsyncIterable)
+asyncAppend(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
 ```
 
 </td>
@@ -1924,7 +1924,7 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 <td class="wide-cell">
 
 ```ts
-asyncReplace(iterable: AsyncIterable)
+asyncReplace(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
 ```
 
 </td>

--- a/packages/lit-dev-content/site/docs/v2/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/directives.md
@@ -1832,7 +1832,7 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 
 ```ts
 asyncAppend(
-  iterable: AsyncIterable,
+  iterable: AsyncIterable<Item>,
   mapper?: (item: Item, index?: number) => unknown
 )
 ```
@@ -1928,7 +1928,7 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 
 ```ts
 asyncReplace(
-  iterable: AsyncIterable,
+  iterable: AsyncIterable<Item>,
   mapper?: (item: Item, index?: number) => unknown
 )
 ```

--- a/packages/lit-dev-content/site/docs/v2/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/directives.md
@@ -1831,7 +1831,10 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 <td class="wide-cell">
 
 ```ts
-asyncAppend(iterable: AsyncIterable, mapper?: Function)
+asyncAppend(
+  iterable: AsyncIterable,
+  mapper?: (item: Item, index?: number) => unknown
+)
 ```
 
 </td>
@@ -1924,7 +1927,10 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 <td class="wide-cell">
 
 ```ts
-asyncReplace(iterable: AsyncIterable, mapper?: Function)
+asyncReplace(
+  iterable: AsyncIterable,
+  mapper?: (item: Item, index?: number) => unknown
+)
 ```
 
 </td>

--- a/packages/lit-dev-content/site/docs/v2/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v2/templates/directives.md
@@ -1832,8 +1832,8 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 
 ```ts
 asyncAppend(
-  iterable: AsyncIterable<Item>,
-  mapper?: (item: Item, index?: number) => unknown
+  iterable: AsyncIterable<I>,
+  mapper?: (item: I, index?: number) => unknown
 )
 ```
 
@@ -1928,8 +1928,8 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 
 ```ts
 asyncReplace(
-  iterable: AsyncIterable<Item>,
-  mapper?: (item: Item, index?: number) => unknown
+  iterable: AsyncIterable<I>,
+  mapper?: (item: I, index?: number) => unknown
 )
 ```
 

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1933,7 +1933,7 @@ asyncReplace(iterable: AsyncIterable, mapper?: Function)
 <td class="no-wrap-cell vcenter-cell">Usable location</td>
 <td class="wide-cell">
 
-Child expression
+Any expression
 
 </td>
 </tr>

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1831,7 +1831,7 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 <td class="wide-cell">
 
 ```ts
-asyncAppend(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
+asyncAppend(iterable: AsyncIterable, mapper?: Function)
 ```
 
 </td>
@@ -1924,7 +1924,7 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 <td class="wide-cell">
 
 ```ts
-asyncReplace(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
+asyncReplace(iterable: AsyncIterable, mapper?: Function)
 ```
 
 </td>

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1831,7 +1831,7 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 <td class="wide-cell">
 
 ```ts
-asyncAppend(iterable: AsyncIterable)
+asyncAppend(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
 ```
 
 </td>
@@ -1924,7 +1924,7 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 <td class="wide-cell">
 
 ```ts
-asyncReplace(iterable: AsyncIterable)
+asyncReplace(iterable: AsyncIterable, mapper?: (item: Item, index?: number) => unknown)
 ```
 
 </td>

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1832,7 +1832,7 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 
 ```ts
 asyncAppend(
-  iterable: AsyncIterable,
+  iterable: AsyncIterable<Item>,
   mapper?: (item: Item, index?: number) => unknown
 )
 ```
@@ -1928,7 +1928,7 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 
 ```ts
 asyncReplace(
-  iterable: AsyncIterable,
+  iterable: AsyncIterable<Item>,
   mapper?: (item: Item, index?: number) => unknown
 )
 ```

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1831,7 +1831,10 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 <td class="wide-cell">
 
 ```ts
-asyncAppend(iterable: AsyncIterable, mapper?: Function)
+asyncAppend(
+  iterable: AsyncIterable,
+  mapper?: (item: Item, index?: number) => unknown
+)
 ```
 
 </td>
@@ -1924,7 +1927,10 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 <td class="wide-cell">
 
 ```ts
-asyncReplace(iterable: AsyncIterable, mapper?: Function)
+asyncReplace(
+  iterable: AsyncIterable,
+  mapper?: (item: Item, index?: number) => unknown
+)
 ```
 
 </td>

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1832,8 +1832,8 @@ import {asyncAppend} from 'lit/directives/async-append.js';
 
 ```ts
 asyncAppend(
-  iterable: AsyncIterable<Item>,
-  mapper?: (item: Item, index?: number) => unknown
+  iterable: AsyncIterable<I>,
+  mapper?: (item: I, index?: number) => unknown
 )
 ```
 
@@ -1928,8 +1928,8 @@ import {asyncReplace} from 'lit/directives/async-replace.js';
 
 ```ts
 asyncReplace(
-  iterable: AsyncIterable<Item>,
-  mapper?: (item: Item, index?: number) => unknown
+  iterable: AsyncIterable<I>,
+  mapper?: (item: I, index?: number) => unknown
 )
 ```
 


### PR DESCRIPTION
The `mapper` function optional argument isn't documented. It's shown in the example for `asyncAppend`, but isn't included in the type signature.

This is a documentation only change to document the optional map function.

### Test plan

Look at preview url.

In the first commit I added a more full type, but it overflows the page! Opted to simplify to just `Function` until https://github.com/lit/lit.dev/issues/1293 is fixed.