### PR TITLE
[SSR] (docs) show Lit `html` dependency in SSR docs examples

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/ssr/server-usage.md
+++ b/packages/lit-dev-content/site/docs/v2/ssr/server-usage.md
@@ -30,6 +30,7 @@ The template can contain custom elements, which are rendered in turn, along with
 
 ```ts
 import {render} from '@lit-labs/ssr';
+import {html} from 'lit';
 
 const result = render(html`
   <h1>Hello SSR!</h1>
@@ -68,6 +69,7 @@ This is the preferred way to handle SSR results when integrating with a streamin
 ```ts
 import {render} from '@lit-labs/ssr';
 import {RenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
+import {html} from 'lit';
 
 // Using Koa to stream
 app.use(async (ctx) => {
@@ -87,9 +89,10 @@ app.use(async (ctx) => {
 ```ts
 import {render} from '@lit-labs/ssr';
 import {collectResult} from '@lit-labs/ssr/lib/render-result.js';
+import {html} from 'lit';
 
 const result = render(html`<my-element></my-element>`);
-const html = await collectResult(result);
+const contents = await collectResult(result);
 ```
 
 #### `collectResultSync()`
@@ -103,10 +106,11 @@ Because this function doesn't support async rendering, it's recommended to only 
 ```ts
 import {render} from '@lit-labs/ssr';
 import {collectResultSync} from '@lit-labs/ssr/lib/render-result.js';
+import {html} from 'lit';
 
 const result = render(html`<my-element></my-element>`);
 // Throws if `result` contains a Promise!
-const html = collectResultSync(result);
+const contents = collectResultSync(result);
 ```
 
 ### Render options

--- a/packages/lit-dev-content/site/docs/v3/ssr/server-usage.md
+++ b/packages/lit-dev-content/site/docs/v3/ssr/server-usage.md
@@ -30,6 +30,7 @@ The template can contain custom elements. If the custom elements are defined on 
 
 ```ts
 import {render} from '@lit-labs/ssr';
+import {html} from 'lit';
 // Import `my-element` on the server to server render it.
 import './my-element.js';
 
@@ -42,6 +43,7 @@ const result = render(html`
 To render a single element, you render a template that only contains that element:
 
 ```ts
+import {html} from 'lit';
 import './my-element.js';
 
 const result = render(html`<my-element></my-element>`);
@@ -72,6 +74,7 @@ This is the preferred way to handle SSR results when integrating with a streamin
 ```ts
 import {render} from '@lit-labs/ssr';
 import {RenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
+import {html} from 'lit';
 
 // Using Koa to stream
 app.use(async (ctx) => {
@@ -91,9 +94,10 @@ app.use(async (ctx) => {
 ```ts
 import {render} from '@lit-labs/ssr';
 import {collectResult} from '@lit-labs/ssr/lib/render-result.js';
+import {html} from 'lit';
 
 const result = render(html`<my-element></my-element>`);
-const html = await collectResult(result);
+const contents = await collectResult(result);
 ```
 
 #### `collectResultSync()`
@@ -107,10 +111,11 @@ Because this function doesn't support async rendering, it's recommended to only 
 ```ts
 import {render} from '@lit-labs/ssr';
 import {collectResultSync} from '@lit-labs/ssr/lib/render-result.js';
+import {html} from 'lit';
 
 const result = render(html`<my-element></my-element>`);
 // Throws if `result` contains a Promise!
-const html = collectResultSync(result);
+const contents = collectResultSync(result);
 ```
 
 ### Render options


### PR DESCRIPTION
Not sure if intentional, but noticed that the SSR examples weren't showing where the `html` tagged template comes from, which presumably was meant to be from the lit package, e.g.
```js
import {html} from 'lit';
```

> _As a side-effect, there was already an `const html = ...` variable being used in the examples, so just to avoid confusion, renamed it to `const contents = ...`, but I am happy to change it whatever you would prefer._