### PR TITLE
[docs] Update CDN suggestion in lit-html v1 docs

### DIFF
--- a/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
@@ -24,7 +24,7 @@ npm install lit-html
 You can also load lit-html directly from CDNs with good module support like [esm.run](https://esm.run) or [esm.sh](https://esm.sh):
 
 ```js
-import {html, render} from 'https://esm.run/lit-html';
+import {html, render} from 'https://esm.run/lit-html@1';
 ```
 
 ### Online editors

--- a/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
+++ b/packages/lit-dev-content/site/docs/v1/lit-html/getting-started.md
@@ -19,12 +19,12 @@ lit-html is distributed on npm, in the [lit-html package].
 npm install lit-html
 ```
 
-### unpkg.com
+### CDNs
 
-You can also load lit-html directly from the unpkg.com CDN:
+You can also load lit-html directly from CDNs with good module support like [esm.run](https://esm.run) or [esm.sh](https://esm.sh):
 
 ```js
-import {html, render} from 'https://unpkg.com/lit-html?module';
+import {html, render} from 'https://esm.run/lit-html';
 ```
 
 ### Online editors


### PR DESCRIPTION
We still have a section that points to unpkg.com using `?module` which has trouble with modern JS syntax. See https://github.com/lit/lit/issues/4316 and linked issues in unpkg repo.

Since this is in the old v1 doc, we can also suggest the version be pinned.. but opted to just provide alternative CDNs.