### PR TITLE
docs(controllers): remove needless non-null assertion operator

### DIFF
--- a/packages/lit-dev-content/samples/v2-docs/controllers/names/names-controller.ts
+++ b/packages/lit-dev-content/samples/v2-docs/controllers/names/names-controller.ts
@@ -6,7 +6,7 @@ export class NamesController {
   host: ReactiveControllerHost;
   value?: string[];
   readonly kinds = Names.kinds;
-  private task!: Task<[Names.Kind], Names.Result>;
+  private task: Task<[Names.Kind], Names.Result>;
   private _kind: Names.Kind = '';
 
   constructor(host: ReactiveControllerHost) {

--- a/packages/lit-dev-content/samples/v3-docs/controllers/names/names-controller.ts
+++ b/packages/lit-dev-content/samples/v3-docs/controllers/names/names-controller.ts
@@ -6,7 +6,7 @@ export class NamesController {
   host: ReactiveControllerHost;
   value?: string[];
   readonly kinds = Names.kinds;
-  private task!: Task<[Names.Kind], Names.Result>;
+  private task: Task<[Names.Kind], Names.Result>;
   private _kind: Names.Kind = '';
 
   constructor(host: ReactiveControllerHost) {


### PR DESCRIPTION
This PR fixes a small issue in the docs:
- a needless non-nullish assertion (since the this.task property is assigned in the constructor, `!` is not necessary)

Btw, I really like Lit controllers! I am primarily working with Stencil, and the need for code reuse lead me to create a pattern I called "Stencil Controllers" - that was before I knew that Lit had a very similar feature, with a very similar name - what a coincidence!