### PR TITLE
[playground] New context example with element that both consumes and provides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -654,47 +654,11 @@
       }
     },
     "node_modules/@lit/context": {
-      "version": "1.0.0-pre.0",
-      "license": "BSD-3-Clause",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.0.tgz",
+      "integrity": "sha512-fCyv4dsH05wCNm3AKbB+PdYbXGJd/XT8OOwo4hVmD4COq5wOWJlQreGAMDvmHZ7osqxuu06Y4nmP6ooXpN7ErA==",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.1",
-        "lit": "^3.0.0-pre.1"
-      }
-    },
-    "node_modules/@lit/context/node_modules/@lit/reactive-element": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.2.tgz",
-      "integrity": "sha512-SVOwLAWUQg3Ji1egtOt1UiFe4zdDpnWHyc5qctSceJ5XIu0Uc76YmGpIjZgx9YJ0XtdW0Jm507sDvjOu+HnB8w==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2"
-      }
-    },
-    "node_modules/@lit/context/node_modules/lit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.0.tgz",
-      "integrity": "sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.1.0"
-      }
-    },
-    "node_modules/@lit/context/node_modules/lit-element": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.2.tgz",
-      "integrity": "sha512-/W6WQZUa5VEXwC7H9tbtDMdSs9aWil3Ou8hU6z2cOKWbsm/tXPAcsoaHVEtrDo0zcOIE5GF6QgU55tlGL2Nihg==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2",
-        "@lit/reactive-element": "^2.0.0",
-        "lit-html": "^3.1.0"
-      }
-    },
-    "node_modules/@lit/context/node_modules/lit-html": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.0.tgz",
-      "integrity": "sha512-FwAjq3iNsaO6SOZXEIpeROlJLUlrbyMkn4iuv4f4u1H40Jw8wkeR/OUXZUHUoiYabGk8Y4Y0F/rgq+R4MrOLmA==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
       }
     },
     "node_modules/@lit/localize": {
@@ -8380,7 +8344,7 @@
         "@lit-labs/motion": "^1.0.1",
         "@lit-labs/react": "^1.0.8",
         "@lit-labs/task": "^3.0.2",
-        "@lit/context": "^1.0.0 || 1.0.0-pre.0",
+        "@lit/context": "^1.1.0",
         "@lit/localize": "^0.10.0",
         "@lit/react": "^1.0.0 || 1.0.0-pre.0",
         "@lit/task": "^1.0.0 || 1.0.0-pre.0",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -197,7 +197,7 @@
     "@lit-labs/motion": "^1.0.1",
     "@lit-labs/react": "^1.0.8",
     "@lit-labs/task": "^3.0.2",
-    "@lit/context": "^1.0.0 || 1.0.0-pre.0",
+    "@lit/context": "^1.1.0",
     "@lit/localize": "^0.10.0",
     "@lit/react": "^1.0.0 || 1.0.0-pre.0",
     "@lit/task": "^1.0.0 || 1.0.0-pre.0",

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/index.html
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/index.html
@@ -5,7 +5,7 @@
   }
 </style>
 <p>
-  Example taken from:
+  Example inspired by:
   <a
     href="https://react.dev/learn/passing-data-deeply-with-context"
     target="_blank"

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/index.html
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/index.html
@@ -1,0 +1,15 @@
+<script type="module" src="./my-app.js"></script>
+<style>
+  :root {
+    font-family: sans-serif;
+  }
+</style>
+<p>
+  Example taken from:
+  <a
+    href="https://react.dev/learn/passing-data-deeply-with-context"
+    target="_blank"
+    >https://react.dev/learn/passing-data-deeply-with-context</a
+  >
+</p>
+<my-app></my-app>

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/level-context.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/level-context.ts
@@ -1,3 +1,5 @@
 import {createContext} from '@lit/context';
 
-export const levelContext = createContext<number>(Symbol('level'));
+export type Level = {level: number; prefix: string};
+
+export const levelContext = createContext<Level>(Symbol('prefix'));

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/level-context.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/level-context.ts
@@ -1,0 +1,3 @@
+import {createContext} from '@lit/context';
+
+export const levelContext = createContext<number>(Symbol('level'));

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/level-context.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/level-context.ts
@@ -1,5 +1,5 @@
 import {createContext} from '@lit/context';
 
-export type Level = {level: number; prefix: string};
+export type Level = {level: number; color: string};
 
-export const levelContext = createContext<Level>(Symbol('prefix'));
+export const levelContext = createContext<Level>(Symbol('level'));

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-app.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-app.ts
@@ -6,12 +6,12 @@ import './my-heading.js';
 @customElement('my-app')
 export class MyApp extends LitElement {
   render() {
-    // <my-heading> adjusts what heading tag to use based on the level context
-    // provided to it and prefixes with a provided numbering.
-
     // <my-section> serves as both context provider and consumer. It provides a
     // level value that is 1 greater than what's provided to it. This allows
     // nested <my-section> to provide a different value based on its depth.
+
+    // <my-heading> adjusts what heading tag to use and the color based on the
+    // level context.
     return html`
       <my-section>
         <my-heading>Heading level 1</my-heading>
@@ -51,6 +51,9 @@ export class MyApp extends LitElement {
             <my-heading>Heading level 3</my-heading>
             <my-section>
               <my-heading>Heading level 4</my-heading>
+              <my-section>
+                <my-heading>Heading level 5</my-heading>
+              </my-section>
             </my-section>
           </my-section>
         </my-section>

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-app.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-app.ts
@@ -1,0 +1,37 @@
+import {html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import './my-section.js';
+import './my-heading.js';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    // <my-heading> adjusts what heading tag to use based on the level context
+    // provided to it.
+
+    // <my-section> serves as both context provider and consumer. It provides a
+    // level value that is 1 greater than what's provided to it. This allows
+    // nested <my-section> to provide a different value based on its depth.
+
+    return html`
+      <my-section>
+        <my-heading>This is h1</my-heading>
+        <my-section>
+          <my-heading>This is h2</my-heading>
+          <my-heading>This is h2</my-heading>
+          <my-heading>This is h2</my-heading>
+          <my-section>
+            <my-heading>This is h3</my-heading>
+            <my-heading>This is h3</my-heading>
+            <my-heading>This is h3</my-heading>
+            <my-section>
+              <my-heading>This is h4</my-heading>
+              <my-heading>This is h4</my-heading>
+              <my-heading>This is h4</my-heading>
+            </my-section>
+          </my-section>
+        </my-section>
+      </my-section>
+    `;
+  }
+}

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-app.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-app.ts
@@ -7,27 +7,59 @@ import './my-heading.js';
 export class MyApp extends LitElement {
   render() {
     // <my-heading> adjusts what heading tag to use based on the level context
-    // provided to it.
+    // provided to it and prefixes with a provided numbering.
 
     // <my-section> serves as both context provider and consumer. It provides a
     // level value that is 1 greater than what's provided to it. This allows
     // nested <my-section> to provide a different value based on its depth.
-
     return html`
       <my-section>
-        <my-heading>This is h1</my-heading>
+        <my-heading>Heading level 1</my-heading>
         <my-section>
-          <my-heading>This is h2</my-heading>
-          <my-heading>This is h2</my-heading>
-          <my-heading>This is h2</my-heading>
+          <my-heading>Heading level 2</my-heading>
+        </my-section>
+        <my-section>
+          <my-heading>Heading level 2</my-heading>
           <my-section>
-            <my-heading>This is h3</my-heading>
-            <my-heading>This is h3</my-heading>
-            <my-heading>This is h3</my-heading>
+            <my-heading>Heading level 3</my-heading>
+          </my-section>
+          <my-section>
+            <my-heading>Heading level 3</my-heading>
             <my-section>
-              <my-heading>This is h4</my-heading>
-              <my-heading>This is h4</my-heading>
-              <my-heading>This is h4</my-heading>
+              <my-heading>Heading level 4</my-heading>
+            </my-section>
+          </my-section>
+        </my-section>
+        <my-section>
+          <my-heading>Heading level 2</my-heading>
+          <my-section>
+            <my-heading>Heading level 3</my-heading>
+            <my-section>
+              <my-heading>Heading level 4</my-heading>
+            </my-section>
+            <my-section>
+              <my-heading>Heading level 4</my-heading>
+            </my-section>
+          </my-section>
+        </my-section>
+      </my-section>
+      <my-section>
+        <my-heading>Heading level 1</my-heading>
+        <my-section>
+          <my-heading>Heading level 2</my-heading>
+          <my-section>
+            <my-heading>Heading level 3</my-heading>
+            <my-section>
+              <my-heading>Heading level 4</my-heading>
+            </my-section>
+          </my-section>
+        </my-section>
+        <my-section>
+          <my-heading>Heading level 2</my-heading>
+          <my-section>
+            <my-heading>Heading level 3</my-heading>
+            <my-section>
+              <my-heading>Heading level 4</my-heading>
             </my-section>
           </my-section>
         </my-section>

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
@@ -7,7 +7,7 @@ export class MyHeading extends LitElement {
   _levelContext = new ContextConsumer(this, {context: levelContext});
 
   get _tag() {
-    switch (this._levelContext.value) {
+    switch (this._levelContext.value.level) {
       case 1:
         return literal`h1`;
       case 2:
@@ -29,5 +29,4 @@ export class MyHeading extends LitElement {
     return html`<${this._tag}><slot></slot></${this._tag}>`;
   }
 }
-
 customElements.define('my-heading', MyHeading);

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
@@ -1,5 +1,6 @@
 import {LitElement} from 'lit';
 import {html, literal} from 'lit/static-html.js';
+import {styleMap} from 'lit/directives/style-map.js';
 import {ContextConsumer} from '@lit/context';
 import {levelContext} from './level-context.js';
 
@@ -7,18 +8,18 @@ export class MyHeading extends LitElement {
   _levelContext = new ContextConsumer(this, {context: levelContext});
 
   get _tag() {
-    switch (this._levelContext.value.level) {
-      case 1:
+    switch (this._levelContext.value?.level) {
+      case 0:
         return literal`h1`;
-      case 2:
+      case 1:
         return literal`h2`;
-      case 3:
+      case 2:
         return literal`h3`;
-      case 4:
+      case 3:
         return literal`h4`;
-      case 5:
+      case 4:
         return literal`h5`;
-      case 6:
+      case 5:
         return literal`h6`;
       default:
         return literal`p`;
@@ -26,7 +27,12 @@ export class MyHeading extends LitElement {
   }
 
   render() {
-    return html`<${this._tag}><slot></slot></${this._tag}>`;
+    return html`
+      <${this._tag}
+        style=${styleMap({color: this._levelContext.value?.color})}
+      >
+        <slot></slot>
+      </${this._tag}>`;
   }
 }
 customElements.define('my-heading', MyHeading);

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
@@ -1,0 +1,33 @@
+import {LitElement} from 'lit';
+import {html, literal} from 'lit/static-html.js';
+import {ContextConsumer} from '@lit/context';
+import {levelContext} from './level-context.js';
+
+export class MyHeading extends LitElement {
+  _levelContext = new ContextConsumer(this, {context: levelContext});
+
+  get _tag() {
+    switch (this._levelContext.value) {
+      case 1:
+        return literal`h1`;
+      case 2:
+        return literal`h2`;
+      case 3:
+        return literal`h3`;
+      case 4:
+        return literal`h4`;
+      case 5:
+        return literal`h5`;
+      case 6:
+        return literal`h6`;
+      default:
+        return literal`p`;
+    }
+  }
+
+  render() {
+    return html`<${this._tag}><slot></slot></${this._tag}>`;
+  }
+}
+
+customElements.define('my-heading', MyHeading);

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
@@ -8,21 +8,11 @@ export class MyHeading extends LitElement {
   _levelContext = new ContextConsumer(this, {context: levelContext});
 
   get _tag() {
-    switch (this._levelContext.value?.level) {
-      case 0:
-        return literal`h1`;
-      case 1:
-        return literal`h2`;
-      case 2:
-        return literal`h3`;
-      case 3:
-        return literal`h4`;
-      case 4:
-        return literal`h5`;
-      case 5:
-        return literal`h6`;
-      default:
-        return literal`p`;
+    const level = this._levelContext.value?.level;
+    if (typeof level === 'number' && level >= 0 && level <= 5) {
+      return unsafeStatic(`h${level + 1}`);
+    } else {
+      return literal`p`;
     }
   }
 

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
@@ -1,0 +1,34 @@
+import {LitElement} from 'lit';
+import {html, literal} from 'lit/static-html.js';
+import {customElement} from 'lit/decorators.js';
+import {consume} from '@lit/context';
+import {levelContext} from './level-context.js';
+
+@customElement('my-heading')
+export class MyHeading extends LitElement {
+  @consume({context: levelContext})
+  private _level: number | undefined;
+
+  private get _tag() {
+    switch (this._level) {
+      case 1:
+        return literal`h1`;
+      case 2:
+        return literal`h2`;
+      case 3:
+        return literal`h3`;
+      case 4:
+        return literal`h4`;
+      case 5:
+        return literal`h5`;
+      case 6:
+        return literal`h6`;
+      default:
+        return literal`p`;
+    }
+  }
+
+  render() {
+    return html`<${this._tag}><slot></slot></${this._tag}>`;
+  }
+}

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
@@ -1,27 +1,29 @@
 import {LitElement} from 'lit';
 import {html, literal} from 'lit/static-html.js';
 import {customElement} from 'lit/decorators.js';
+import {styleMap} from 'lit/directives/style-map.js';
 import {consume} from '@lit/context';
 import {levelContext, type Level} from './level-context.js';
 
 @customElement('my-heading')
 export class MyHeading extends LitElement {
+  // Consume the level and color from parent provider
   @consume({context: levelContext})
   private _level?: Level;
 
   private get _tag() {
     switch (this._level?.level) {
-      case 1:
+      case 0:
         return literal`h1`;
-      case 2:
+      case 1:
         return literal`h2`;
-      case 3:
+      case 2:
         return literal`h3`;
-      case 4:
+      case 3:
         return literal`h4`;
-      case 5:
+      case 4:
         return literal`h5`;
-      case 6:
+      case 5:
         return literal`h6`;
       default:
         return literal`p`;
@@ -29,6 +31,9 @@ export class MyHeading extends LitElement {
   }
 
   render() {
-    return html`<${this._tag}>${this._level?.prefix} <slot></slot></${this._tag}>`;
+    return html`
+      <${this._tag} style=${styleMap({color: this._level?.color})}>
+        <slot></slot>
+      </${this._tag}>`;
   }
 }

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
@@ -2,15 +2,15 @@ import {LitElement} from 'lit';
 import {html, literal} from 'lit/static-html.js';
 import {customElement} from 'lit/decorators.js';
 import {consume} from '@lit/context';
-import {levelContext} from './level-context.js';
+import {levelContext, type Level} from './level-context.js';
 
 @customElement('my-heading')
 export class MyHeading extends LitElement {
   @consume({context: levelContext})
-  private _level: number | undefined;
+  private _level?: Level;
 
   private get _tag() {
-    switch (this._level) {
+    switch (this._level?.level) {
       case 1:
         return literal`h1`;
       case 2:
@@ -29,6 +29,6 @@ export class MyHeading extends LitElement {
   }
 
   render() {
-    return html`<${this._tag}><slot></slot></${this._tag}>`;
+    return html`<${this._tag}>${this._level?.prefix} <slot></slot></${this._tag}>`;
   }
 }

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.ts
@@ -1,5 +1,5 @@
 import {LitElement} from 'lit';
-import {html, literal} from 'lit/static-html.js';
+import {html, literal, unsafeStatic} from 'lit/static-html.js';
 import {customElement} from 'lit/decorators.js';
 import {styleMap} from 'lit/directives/style-map.js';
 import {consume} from '@lit/context';
@@ -12,21 +12,11 @@ export class MyHeading extends LitElement {
   private _level?: Level;
 
   private get _tag() {
-    switch (this._level?.level) {
-      case 0:
-        return literal`h1`;
-      case 1:
-        return literal`h2`;
-      case 2:
-        return literal`h3`;
-      case 3:
-        return literal`h4`;
-      case 4:
-        return literal`h5`;
-      case 5:
-        return literal`h6`;
-      default:
-        return literal`p`;
+    const level = this._level?.level;
+    if (typeof level === 'number' && level >= 0 && level <= 5) {
+      return unsafeStatic(`h${level + 1}`);
+    } else {
+      return literal`p`;
     }
   }
 

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-section.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-section.ts
@@ -5,20 +5,36 @@ import {levelContext} from './level-context.js';
 
 @customElement('my-section')
 export class MySection extends LitElement {
-  // Serve as a context provider with an initial value of 1.
+  // Serve as a context provider with an initial level 1 and numbering prefix
+  // based on its numbering among siblings.
   private _provider = new ContextProvider(this, {
     context: levelContext,
-    initialValue: 1,
+    initialValue: {
+      level: 1,
+      prefix: String(this._siblingNumber) + '.',
+    },
   });
 
   // Consumes level context from a parent provider. If a parent provider is
-  // found, update own provider value to be 1 greater than provided value.
+  // found, update own provider level to be 1 greater than provided value and
+  // append its sibling number.
   private _consumer = new ContextConsumer(this, {
     context: levelContext,
-    callback: (value) => {
-      this._provider.setValue(value + 1);
+    callback: ({level, prefix}) => {
+      this._provider.setValue({
+        level: level + 1,
+        prefix: prefix + String(this._siblingNumber) + '.',
+      });
     },
   });
+
+  private get _siblingNumber() {
+    return (
+      Array.from(this.parentNode!.children)
+        .filter((el) => el instanceof MySection)
+        .indexOf(this) + 1
+    );
+  }
 
   render() {
     return html`<section><slot></slot></section>`;
@@ -27,8 +43,7 @@ export class MySection extends LitElement {
   static styles = css`
     :host {
       display: block;
-      border: 1px solid black;
-      padding: 1rem;
+      margin-left: 1rem;
     }
   `;
 }

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-section.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-section.ts
@@ -3,38 +3,29 @@ import {customElement} from 'lit/decorators.js';
 import {ContextProvider, ContextConsumer} from '@lit/context';
 import {levelContext} from './level-context.js';
 
+const COLORS = ['blue', 'orange', 'green', 'purple'];
+
 @customElement('my-section')
 export class MySection extends LitElement {
-  // Serve as a context provider with an initial level 1 and numbering prefix
-  // based on its numbering among siblings.
+  // Serve as a context provider with an initial level 1 and the color for that
+  // level
   private _provider = new ContextProvider(this, {
     context: levelContext,
-    initialValue: {
-      level: 1,
-      prefix: String(this._siblingNumber) + '.',
-    },
+    initialValue: {level: 0, color: COLORS[0]},
   });
 
   // Consumes level context from a parent provider. If a parent provider is
   // found, update own provider level to be 1 greater than provided value and
-  // append its sibling number.
+  // its corresponding color.
   private _consumer = new ContextConsumer(this, {
     context: levelContext,
-    callback: ({level, prefix}) => {
+    callback: ({level}) => {
       this._provider.setValue({
         level: level + 1,
-        prefix: prefix + String(this._siblingNumber) + '.',
+        color: COLORS[(level + 1) % COLORS.length],
       });
     },
   });
-
-  private get _siblingNumber() {
-    return (
-      Array.from(this.parentNode!.children)
-        .filter((el) => el instanceof MySection)
-        .indexOf(this) + 1
-    );
-  }
 
   render() {
     return html`<section><slot></slot></section>`;
@@ -43,7 +34,7 @@ export class MySection extends LitElement {
   static styles = css`
     :host {
       display: block;
-      margin-left: 1rem;
+      text-align: center;
     }
   `;
 }

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-section.ts
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-section.ts
@@ -1,0 +1,34 @@
+import {html, css, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {ContextProvider, ContextConsumer} from '@lit/context';
+import {levelContext} from './level-context.js';
+
+@customElement('my-section')
+export class MySection extends LitElement {
+  // Serve as a context provider with an initial value of 1.
+  private _provider = new ContextProvider(this, {
+    context: levelContext,
+    initialValue: 1,
+  });
+
+  // Consumes level context from a parent provider. If a parent provider is
+  // found, update own provider value to be 1 greater than provided value.
+  private _consumer = new ContextConsumer(this, {
+    context: levelContext,
+    callback: (value) => {
+      this._provider.setValue(value + 1);
+    },
+  });
+
+  render() {
+    return html`<section><slot></slot></section>`;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      border: 1px solid black;
+      padding: 1rem;
+    }
+  `;
+}

--- a/packages/lit-dev-content/samples/examples/context-consume-provide/project.json
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/project.json
@@ -1,0 +1,13 @@
+{
+  "extends": "/samples/base.json",
+  "title": "Context Consume and Provide",
+  "description": "Showcase an element both consuming and providing the same context.",
+  "section": "Managing Data",
+  "files": {
+    "my-app.ts": {},
+    "my-section.ts": {},
+    "my-heading.ts": {},
+    "level-context.ts": {},
+    "index.html": {}
+  }
+}


### PR DESCRIPTION
Example is taken from the React doc https://react.dev/learn/passing-data-deeply-with-context
 which is also an excellent resource for describing what context does and when to use it.

My only concern with this is that it's such a direct copy of the React doc example, even if I attribute to them at the top of the preview page.

`my-heading.ts` gets a manually made `.js` file because we don't have a good transform for the `@consume()` decorator.

latest preview link: http://localhost:5415/playground/#sample=examples/context-consume-provide