### PR TITLE
fix select dropdown menu colors on chrome-linux

### DIFF
--- a/packages/lit-dev-content/site/css/header.css
+++ b/packages/lit-dev-content/site/css/header.css
@@ -111,6 +111,12 @@
   color: var(--sys-color-on-primary);
 }
 
+#desktopNav .navItem.active option,
+#desktopNav .navItem option {
+  /* Chrome linux allows setting colors so let's leave as-is */
+  color: initial;
+}
+
 #mobileMenuButton {
   display: none;
 }


### PR DESCRIPTION
Apparently you can style the options on chrome linux

| before | after |
| - | - |
| <img width="208" alt="image" src="https://github.com/lit/lit.dev/assets/5981958/4dbb17eb-08d7-4349-ab67-4b06eef7c197"> | <img width="210" alt="image" src="https://github.com/lit/lit.dev/assets/5981958/63fd06c7-d009-461e-ae3a-35c3389c8320"> |
