### PR TITLE
[example] Fix JS version of new context example

### DIFF
--- a/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
+++ b/packages/lit-dev-content/samples/examples/context-consume-provide/my-heading.js
@@ -1,5 +1,5 @@
 import {LitElement} from 'lit';
-import {html, literal} from 'lit/static-html.js';
+import {html, literal, unsafeStatic} from 'lit/static-html.js';
 import {styleMap} from 'lit/directives/style-map.js';
 import {ContextConsumer} from '@lit/context';
 import {levelContext} from './level-context.js';


### PR DESCRIPTION
Missed an import after refactoring.