### PR TITLE
[example/until] replace call to jsonplaceholder with a static text

### DIFF
--- a/packages/lit-dev-content/samples/examples/directive-until/my-element.ts
+++ b/packages/lit-dev-content/samples/examples/directive-until/my-element.ts
@@ -3,11 +3,8 @@ import {customElement, state} from 'lit/decorators.js';
 import {until} from 'lit/directives/until.js';
 
 const fetchData = async () => {
-  const response = await fetch('https://jsonplaceholder.typicode.com/todos/2');
-  const json = await response.json();
-  // Add some delay for demo purposes
-  await new Promise<void>((r) => setTimeout(() => r(), 1000));
-  return json.title;
+  await new Promise<void>((r) => setTimeout(() => r(), 2000));
+  return 'Lorem Ipsum';
 }
 
 @customElement('my-element')


### PR DESCRIPTION
Currently the `until` directive playground example is broken due to the reliance on jsonplaceholder which is not stable.
Instead, simply await a timeout of 2 seconds, and return some static text.