### PR TITLE
[docs] make code samples in component lifecycle consistent

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/v2/components/lifecycle.md
@@ -58,7 +58,7 @@ In `connectedCallback()` you should setup tasks that should only occur when the 
 ```js
 connectedCallback() {
   super.connectedCallback()
-  addEventListener('keydown', this._handleKeydown);
+  window.addEventListener('keydown', this._handleKeydown);
 }
 ```
 ### disconnectedCallback() {#disconnectedcallback}

--- a/packages/lit-dev-content/site/docs/v3/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/v3/components/lifecycle.md
@@ -58,7 +58,7 @@ In `connectedCallback()` you should setup tasks that should only occur when the 
 ```js
 connectedCallback() {
   super.connectedCallback()
-  addEventListener('keydown', this._handleKeydown);
+  window.addEventListener('keydown', this._handleKeydown);
 }
 ```
 ### disconnectedCallback() {#disconnectedcallback}


### PR DESCRIPTION
In the description of `disconnectedCallback`, `window.removeEventListener` is used. However, the prefix `window.` is omitted in the `connectedCallback` description. To improve consistency between the two sample codes, `window.` has been added to the `connectedCallback` description.