### PR TITLE
fix version-selector align

### DIFF
--- a/packages/lit-dev-content/src/components/litdev-version-selector.ts
+++ b/packages/lit-dev-content/src/components/litdev-version-selector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {LitElement, html} from 'lit';
+import {LitElement, html, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
 
 /**
@@ -12,6 +12,12 @@ import {customElement} from 'lit/decorators.js';
  */
 @customElement('litdev-version-selector')
 export class LitDevVersionSelector extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+    }
+  `;
+
   override render() {
     return html`<slot @change=${this._onSelect}></slot>`;
   }


### PR DESCRIPTION
A small improvement but I saw it and fixed it :slightly_smiling_face: 

Before:
![image](https://github.com/lit/lit.dev/assets/12148533/48a71691-2cfb-4e5f-91f3-3861bdf91de8)


After:
![image](https://github.com/lit/lit.dev/assets/12148533/af8fc344-05bd-4963-8d6b-859ea0f45e14)


You see in the before screenshot the version selector is too much on the bottom of the button. It is not perfectly aligned in the center.