### PR TITLE
Add language-specific note about TypeScript decorators.

### DIFF
--- a/packages/lit-dev-content/site/css/global.css
+++ b/packages/lit-dev-content/site/css/global.css
@@ -80,3 +80,13 @@ a {
   height: 1px;
   overflow: hidden;
 }
+
+body[code-language-preference="ts"] [code-language]:not([code-language="ts"]) {
+  /* Hide JS content when preference is TS. */
+  display: none;
+}
+
+body[code-language-preference="js"] [code-language]:not([code-language="js"]) {
+  /* Hide TS content when preference is JS. */
+  display: none;
+}

--- a/packages/lit-dev-content/site/docs/v3/components/overview.md
+++ b/packages/lit-dev-content/site/docs/v3/components/overview.md
@@ -33,9 +33,8 @@ Here's a sample component:
 
 This example uses TypeScript decorators.
 
-See the [Decorators](/docs/components/decorators) documentation for more information on configuring TypeScript for decorators.
+See the [Decorators](/docs/v3/components/decorators) documentation for more information on configuring TypeScript for decorators.
 
 {% endaside %}
 
 </div>
-

--- a/packages/lit-dev-content/site/docs/v3/components/overview.md
+++ b/packages/lit-dev-content/site/docs/v3/components/overview.md
@@ -26,3 +26,16 @@ Creating a Lit component involves a number of concepts:
 Here's a sample component:
 
 {% playground-example "v3-docs/components/overview/simple-greeting" "simple-greeting.ts" %}
+
+<div code-language="ts">
+
+{% aside "info"%}
+
+This example uses TypeScript decorators.
+
+See the [Decorators](/docs/components/decorators) documentation for more information on configuring TypeScript for decorators.
+
+{% endaside %}
+
+</div>
+


### PR DESCRIPTION
Adds a small note to the component overview that points users to the TypeScript decorator docs.

This is hopefully a small improvement on pointing new readers towards docs that will help them enable decorators correctly. Some users get errors when copying code to their TypeScript projects because they are not enabling experimental decorators and that's what our samples use.

We would ideally note that the TypeScript samples use experimental decorators, and even have a switch between standard and experimental decorators in samples, but that's more work to do and possibly a lot of complexity if not done right. This is a small incremental fix in one place instead.

This adds the ability to have language-specific content to the site by adding selectors that hide content that doesn't match the users preferred code language.

This will only show when the user's preference is TypeScript:
```html
<div code-language="ts">...</div>
```