### PR TITLE
Add details to unsafeHTML docs

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1454,7 +1454,7 @@ Untrusted content rendered with this directive could lead to [cross-site
 scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting), CSS
 injection, data exfiltration, etc. vulnerabilities. `unsafeHTML` uses
 `innerHTML` to parse the HTML string, so the security implications are the same
-`innerHTML`, [as documented on
+ as `innerHTML`, [as documented on
 MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations).
 
 </div>

--- a/packages/lit-dev-content/site/docs/v3/templates/directives.md
+++ b/packages/lit-dev-content/site/docs/v3/templates/directives.md
@@ -1448,8 +1448,14 @@ parse such a string as HTML and render it in a Lit template.
 
 Note, the string passed to `unsafeHTML` must be developer-controlled and not
 include untrusted content. Examples of untrusted content include query string
-parameters and values from user inputs. Untrusted content rendered with this
-directive could lead to [cross-site scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerabilities.
+parameters and values from user inputs.
+
+Untrusted content rendered with this directive could lead to [cross-site
+scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting), CSS
+injection, data exfiltration, etc. vulnerabilities. `unsafeHTML` uses
+`innerHTML` to parse the HTML string, so the security implications are the same
+`innerHTML`, [as documented on
+MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations).
 
 </div>
 


### PR DESCRIPTION
This might help people understand the security implications of unsafeHTML a little better - ie, it won't run `<script>`, but there are still other ways to execute JS.