### PR TITLE
fix(docs): fix getUpdateComplete example in lifecycle

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/components/lifecycle.md
+++ b/packages/lit-dev-content/site/docs/v3/components/lifecycle.md
@@ -497,8 +497,9 @@ It's recommended to override the `getUpdateComplete()` method instead of the `up
 ```js
 class MyElement extends LitElement {
   async getUpdateComplete() {
-    await super.getUpdateComplete();
+    const result = await super.getUpdateComplete();
     await this._myChild.updateComplete;
+    return result;
   }
 }
 ```


### PR DESCRIPTION
I copied the example into my code and got an type error. This aligns the docs with the type description.