### PR TITLE
Update integration tests to use v4 of upload-artifact

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
       # below, since that will delete the output files.
       - name: Upload screenshot-diffs.zip artifact
         if: ${{ always() && steps.test.outcome == 'failure' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: screenshot-diffs
           path: packages/lit-dev-tests/test-results/**/*.png
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload screenshot-goldens.zip artifact
         if: ${{ always() && steps.test.outcome == 'failure' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: screenshot-goldens
           path: packages/lit-dev-tests/src/playwright/**/**.png


### PR DESCRIPTION
See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

The docs at https://github.com/actions/upload-artifact/tree/v4/ suggest that name, path, and if-no-files-found are still present as options.