### PR TITLE
Documentation for queryAssignedNodes

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
@@ -187,7 +187,9 @@ get _slottedChildren() {
 }
 ```
 
-You can also use the `slotchange` event to take action when the assigned nodes change.
+The nodes are assigned after the slot is rendered, so you need to check them in `updated`, or if you want to use them in rendering, you can use `slotchange`.
+
+You can use the `slotchange` event to take action when nodes are first assigned or change.
 The following example extracts the text content of all of the slotted children.
 
 ```js

--- a/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
@@ -176,11 +176,7 @@ You can specify fallback content for a slot. The fallback content is shown when 
 
 ## Accessing slotted children { #accessing-slotted-children }
 
-{% aside "info" %}
-
 To access children assigned to slots in your shadow root, you can use the standard `slot.assignedNodes` or `slot.assignedElements` methods with the `slotchange` event.
-
-{% endaside %}
 
 For example, you can create a getter to access assigned elements for a particular slot:
 
@@ -191,7 +187,11 @@ get _slottedChildren() {
 }
 ```
 
+{% aside "info" "no-header" %}
+
 The elements are assigned only after the slot is rendered, so if you need to access assigned elements at startup, you need to wait for `firstUpdated` or `updated`. If you want to access assigned elements when your render changes, you can use `slotchange`.
+
+{% endaside %}
 
 You can use the `slotchange` event to take action when nodes are first assigned or change.
 The following example extracts the text content of all of the slotted children.

--- a/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
@@ -187,9 +187,11 @@ get _slottedChildren() {
 }
 ```
 
-{% aside "info" "no-header" %}
+{% aside "info" %}
 
-The elements are assigned only after the slot is rendered, so if you need to access assigned elements at startup, you need to wait for `firstUpdated` or `updated`. If you want to access assigned elements when your render changes, you can use `slotchange`.
+The elements are assigned only after the slot is rendered.
+
+If you need to access assigned elements at startup, you need to wait for `firstUpdated` or `updated`. If you want to access assigned elements when your render changes, you can use `slotchange`.
 
 {% endaside %}
 

--- a/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
@@ -176,7 +176,11 @@ You can specify fallback content for a slot. The fallback content is shown when 
 
 ## Accessing slotted children { #accessing-slotted-children }
 
+{% aside "info" %}
+
 To access children assigned to slots in your shadow root, you can use the standard `slot.assignedNodes` or `slot.assignedElements` methods with the `slotchange` event.
+
+{% endaside %}
 
 For example, you can create a getter to access assigned elements for a particular slot:
 
@@ -187,7 +191,7 @@ get _slottedChildren() {
 }
 ```
 
-The nodes are assigned after the slot is rendered, so you need to check them in `updated`, or if you want to use them in rendering, you can use `slotchange`.
+The elements are assigned only after the slot is rendered, so if you need to access assigned elements at startup, you need to wait for `firstUpdated` or `updated`. If you want to access assigned elements when your render changes, you can use `slotchange`.
 
 You can use the `slotchange` event to take action when nodes are first assigned or change.
 The following example extracts the text content of all of the slotted children.


### PR DESCRIPTION
I read the docs many times before I realized that the nodes I'm querying would not be present until AFTER an update / `slotchanged`. There is no "initial render" moment for these queries to work on their own.

This PR makes that a bit clearer in the docs ✨ 

Based on the discussion on Discord: https://discord.com/channels/1012791295170859069/1291879150654849048/1291879150654849048

Thank you @sorvell and Tony 👏 