### PR TITLE
Fix typo

### DIFF
--- a/packages/lit-dev-content/site/blog/2024-10-08-signals.md
+++ b/packages/lit-dev-content/site/blog/2024-10-08-signals.md
@@ -149,7 +149,7 @@ skipping unnecessary work and improving performance.
 
 ## Future Work
 
-This is just the beginning or our exploration of signals integration for Lit.
+This is just the beginning of our exploration of signals integration for Lit.
 Coming soon, we will add more utilities to `@lit-labs/signals` for incrementally
 rendering changes from collections, easily running side-effects in components,
 and using signals for reactive properties.


### PR DESCRIPTION
Trivial typo: 'or' -> 'of'.