### PR TITLE
Add task behavior of empty args array

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/data/task.md
+++ b/packages/lit-dev-content/site/docs/v3/data/task.md
@@ -241,7 +241,7 @@ By default, Tasks will run any time the arguments change. This is controlled by 
 
 #### Auto-run
 
-In _auto-run_ mode, the task will call the `args` function when the host has updated, compare the args to the previous args, and invoke the task function if they have changed. A task without `args` defined is in manual mode.
+In _auto-run_ mode, the task will call the `args` function when the host has updated, compare the args to the previous args, and invoke the task function if they have changed. A task with an empty `args` array runs once. A task without `args` defined is in manual mode.
 
 #### Manual mode
 


### PR DESCRIPTION
It wasn't clear to me how to create a no arguments task that auto runs.

I found a reference for how it works in https://github.com/lit/lit/pull/2336 and thought it would be worth including in the documentation to clarify the different handling between no arguments and an empty array of arguments.