### PR TITLE
[search] update algolia version and send clicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,6 +327,50 @@
         "@algolia/cache-common": "4.14.2"
       }
     },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.1.tgz",
+      "integrity": "sha512-73pnrUixMVnfjgldxhRi5eYLraMt95/MhQHevoFtqwy+t2hfayxYBZXJ2k6JJDld8UmjcWwq3wXnvZJCOm7vZA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-abtesting/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-abtesting/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-abtesting/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@algolia/client-account": {
       "version": "4.14.2",
       "license": "MIT",
@@ -354,6 +398,50 @@
         "@algolia/transporter": "4.14.2"
       }
     },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.1.tgz",
+      "integrity": "sha512-eu5vhmyYgzZjFIPmkoLo/TU4s+IdsjQ+bEfLj2jcMvyfBD4DcqySKp03TrXjdrHPGO2I3fF7dPZOoCgEi1j2/g==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@algolia/client-personalization": {
       "version": "4.14.2",
       "license": "MIT",
@@ -363,6 +451,50 @@
         "@algolia/transporter": "4.14.2"
       }
     },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.1.tgz",
+      "integrity": "sha512-rHHX/30R3Kkx2aZeR7/8+jU0s6h1cNPMAKOvcMUGVmoiuh46F1sxzmiswHLg6CuLrQ0ikhpdhn3ehFSJwHgp2Q==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@algolia/client-search": {
       "version": "4.14.2",
       "license": "MIT",
@@ -370,6 +502,50 @@
         "@algolia/client-common": "4.14.2",
         "@algolia/requester-common": "4.14.2",
         "@algolia/transporter": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.1.tgz",
+      "integrity": "sha512-sHNZ8b5tK7TvXMiiKK+89UsXnFthnAZc0vpwvDKygdTqvsfmfJPhthx36eHTAVYfh7NnA1+eqZsT/hMUGeZFkQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/logger-common": {
@@ -383,6 +559,94 @@
         "@algolia/logger-common": "4.14.2"
       }
     },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.1.tgz",
+      "integrity": "sha512-+fHd1U3gSeszCH03UtyUZmprpmcJH6aJKyUTOfY73lKKRR7hVofmV812ahScR0T4xUkBlGjTLeGnsKY0IG6K6Q==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.1.tgz",
+      "integrity": "sha512-+IuiUv3OSOFFKoXFMlZHfFzXGqEQbKhncpAcRSAtJmN4pupY4aNblvJ9Wv0SMm7/MSFRy2JLIoYWRSBpSV2yEg==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@algolia/requester-browser-xhr": {
       "version": "4.14.2",
       "license": "MIT",
@@ -393,6 +657,25 @@
     "node_modules/@algolia/requester-common": {
       "version": "4.14.2",
       "license": "MIT"
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.1.tgz",
+      "integrity": "sha512-4l1cba8t02rNkLeX/B7bmgDg3CwuRunmuCSgN2zORDtepjg9YAU1qcyRTyc/rAuNJ54AduRfoBplmKXjowYzbQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@algolia/requester-node-http": {
       "version": "4.14.2",
@@ -7285,6 +7568,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "dev": true,
@@ -8395,9 +8683,10 @@
         "@material/mwc-textfield": "^0.27.0",
         "@material/web": "^1.0.1",
         "@webcomponents/template-shadowroot": "^0.2.1",
-        "algoliasearch": "^4.14.2",
+        "algoliasearch": "^5.20.1",
         "lit": "^2.8.0",
         "postdoc-lib": "^1.0.3",
+        "search-insights": "^2.17.3",
         "tarts": "^1.0.0",
         "timeago.js": "^4.0.2",
         "tslib": "^2.2.0"
@@ -8431,6 +8720,78 @@
         "rollup-plugin-terser": "^7.0.2",
         "signal-utils": "^0.21.1",
         "slugify": "^1.3.6"
+      }
+    },
+    "packages/lit-dev-content/node_modules/@algolia/client-analytics": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.1.tgz",
+      "integrity": "sha512-BRiyL+AwPfGTlo3HbrFDMeTK2z5SaJmB8PBd1JI66d6MeP85+38Mux2FFw+nvDOfBwlGaN/uw2AQTOZ9r4JYtA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "packages/lit-dev-content/node_modules/@algolia/client-common": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.1.tgz",
+      "integrity": "sha512-Dk4RhklaAbqLzOeJO/MoIFUjcKYGECiAJYYqDzmE/sbXICk5Uo6dGlv8w4z09lmvsASpNUoMvGYHGBK+WkEGpA==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "packages/lit-dev-content/node_modules/@algolia/client-personalization": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.1.tgz",
+      "integrity": "sha512-TrUCJ0nVqE0PnOGoRG/RCirxWZ6pF+skZgaaESN2IBnJtk/In14xVmoj8Yzck81bGUY/UI+5dUUOOS7YTSVEhQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "packages/lit-dev-content/node_modules/@algolia/client-search": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.1.tgz",
+      "integrity": "sha512-YzHD0Nqp7AjvzbFrMIjhCUl6apHkWfZxKDSlMqf80mXkuG52wY289zFlvTfHjHK1nEiDslH3uHYAR/poOOa21Q==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "packages/lit-dev-content/node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.1.tgz",
+      "integrity": "sha512-+RaJa5MpJqPHaSbBw0nrHeyIAd5C4YC9C1LfDbZJqrn5ZwOvHMUTod852XmzX/1S8oi1jTynB4FjicmauZIKwA==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "packages/lit-dev-content/node_modules/@algolia/requester-node-http": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.1.tgz",
+      "integrity": "sha512-4npKo1qpLG5xusFoFUj4xIIR/6y3YoCuS/uhagv2blGFotDj+D6OLTML3Pp6JCVcES4zDbkoY7pmNBA8ARtidQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "packages/lit-dev-content/node_modules/@rollup/plugin-node-resolve": {
@@ -8483,6 +8844,29 @@
       "version": "1.20.2",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/lit-dev-content/node_modules/algoliasearch": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.1.tgz",
+      "integrity": "sha512-SiCOCVBCQUg/aWkfMnjT+8TQxNNFlPZTI7v8y4+aZXzJg6zDIzKy9KcYVS4sc+xk5cwW5hyJ+9z836f4+wvgzA==",
+      "dependencies": {
+        "@algolia/client-abtesting": "5.20.1",
+        "@algolia/client-analytics": "5.20.1",
+        "@algolia/client-common": "5.20.1",
+        "@algolia/client-insights": "5.20.1",
+        "@algolia/client-personalization": "5.20.1",
+        "@algolia/client-query-suggestions": "5.20.1",
+        "@algolia/client-search": "5.20.1",
+        "@algolia/ingestion": "1.20.1",
+        "@algolia/monitoring": "1.20.1",
+        "@algolia/recommend": "5.20.1",
+        "@algolia/requester-browser-xhr": "5.20.1",
+        "@algolia/requester-fetch": "5.20.1",
+        "@algolia/requester-node-http": "5.20.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "packages/lit-dev-content/node_modules/estree-walker": {
       "version": "2.0.2",

--- a/packages/lit-dev-content/package.json
+++ b/packages/lit-dev-content/package.json
@@ -202,9 +202,10 @@
     "@material/mwc-textfield": "^0.27.0",
     "@material/web": "^1.0.1",
     "@webcomponents/template-shadowroot": "^0.2.1",
-    "algoliasearch": "^4.14.2",
+    "algoliasearch": "^5.20.1",
     "lit": "^2.8.0",
     "postdoc-lib": "^1.0.3",
+    "search-insights": "^2.17.3",
     "tarts": "^1.0.0",
     "timeago.js": "^4.0.2",
     "tslib": "^2.2.0"

--- a/packages/lit-dev-content/src/components/algolia-search-controller.ts
+++ b/packages/lit-dev-content/src/components/algolia-search-controller.ts
@@ -7,12 +7,11 @@
 import {Task, TaskStatus} from '@lit-labs/task';
 import type {Hit} from '@algolia/client-search';
 export type {Hit} from '@algolia/client-search';
-import algoliasearch, {
-  SearchClient,
-  SearchIndex,
-} from 'algoliasearch/dist/algoliasearch-lite.esm.browser.js';
+import type {LiteClient} from 'algoliasearch/lite';
 import {ReactiveControllerHost} from 'lit';
 import {publicVars} from 'lit-dev-tools-esm/lib/configs.js';
+import aa from 'search-insights';
+import {liteClient} from 'algoliasearch/lite';
 
 const agloliaSearchControllerDefaultOptions = {
   appId: publicVars.algolia.appId,
@@ -25,13 +24,21 @@ const agloliaSearchControllerDefaultOptions = {
   attributesToSnippet: [] as string[],
 };
 
+type SearchOptions = Parameters<LiteClient['searchForHits']>[0] extends infer U
+  ? U extends {requests: (infer V)[]}
+    ? V extends {facet?: never}
+      ? V
+      : never
+    : never
+  : never;
+
 export type AlgoliaSearchControllerOptions =
   typeof agloliaSearchControllerDefaultOptions;
 
 export class AgloliaSearchController<T extends {}> {
   private _task;
-  private _client: SearchClient;
-  private _index: SearchIndex;
+  private _indexName: string;
+  private _client: LiteClient;
   private _hitsPerPage: number;
   private _distinct: number | boolean;
   private _lastValue: Hit<T>[] = [];
@@ -41,6 +48,7 @@ export class AgloliaSearchController<T extends {}> {
   private _attributesToRetrieve: string[];
   // https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/
   private _attributesToSnippet: string[];
+  private _queryId = '';
 
   public get value() {
     if (this._task.status !== TaskStatus.COMPLETE) {
@@ -57,8 +65,8 @@ export class AgloliaSearchController<T extends {}> {
     options?: Partial<AlgoliaSearchControllerOptions>
   ) {
     const opts = {...agloliaSearchControllerDefaultOptions, ...options};
-    this._client = algoliasearch(opts.appId, opts.searchOnlyKey);
-    this._index = this._client.initIndex(opts.index);
+    this._indexName = opts.index;
+    this._client = liteClient(opts.appId, opts.searchOnlyKey);
     this._hitsPerPage = opts.hitsPerPage;
     this._distinct = opts.distinct;
     this._attributesToHighlight = opts.attributesToHighlight;
@@ -69,6 +77,11 @@ export class AgloliaSearchController<T extends {}> {
       ([text]) => this._querySearch(text),
       () => [argsFn()]
     );
+
+    aa('init', {
+      appId: opts.appId,
+      apiKey: opts.searchOnlyKey,
+    });
   }
 
   /**
@@ -81,17 +94,56 @@ export class AgloliaSearchController<T extends {}> {
     if (trimmedQuery.length < 2) {
       return [];
     }
-    type SearchOptions = Parameters<typeof this._index.search>[1];
-    const searchOpts: SearchOptions = {
+    const request: SearchOptions = {
+      query: trimmedQuery,
+      indexName: this._indexName,
       page: 0,
       hitsPerPage: this._hitsPerPage,
       distinct: this._distinct,
       attributesToHighlight: this._attributesToHighlight,
       attributesToRetrieve: this._attributesToRetrieve,
       attributesToSnippet: this._attributesToSnippet,
+      clickAnalytics: true,
     };
 
-    const results = await this._index.search<T>(trimmedQuery, searchOpts);
-    return results.hits;
+    const response = await this._client.searchForHits<T>({
+      requests: [request],
+    });
+
+    if (!response.results.length) {
+      this._queryId = '';
+
+      return [];
+    }
+
+    const results = response.results[0];
+    this._queryId = results.queryID!;
+
+    return results.hits.map((hitRaw, i) => {
+      const hit = hitRaw as Hit<T> & {position: number};
+      hit.position = i + 1;
+      return hit;
+    });
+  }
+
+  /**
+   * Call this method when a user clicks on a search result to send a click
+   * event to Algolia.
+   *
+   * @param id The objectID of the clicked object.
+   * @param position The position of the clicked object in the the search results. (1 indexed)
+   */
+  objectClicked(id: string, position: number) {
+    if (!this._queryId) {
+      return;
+    }
+
+    aa('clickedObjectIDsAfterSearch', {
+      eventName: 'Search Modal Selection',
+      queryID: this._queryId,
+      index: this._indexName,
+      objectIDs: [id],
+      positions: [position],
+    });
   }
 }

--- a/packages/lit-dev-content/src/components/litdev-search-option.ts
+++ b/packages/lit-dev-content/src/components/litdev-search-option.ts
@@ -37,6 +37,9 @@ export class LitdevSearchOption extends LitElement {
   @property({type: Boolean})
   isExternal = false;
 
+  position = 0;
+  objectID = '';
+
   static styles = css`
     :host {
       display: block;

--- a/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
+++ b/packages/lit-dev-server/src/middleware/content-security-policy-middleware.ts
@@ -102,6 +102,7 @@ export const contentSecurityPolicyMiddleware = (
     `connect-src ${[
       `'self'`,
       'https://www.google-analytics.com/',
+      'https://*.algolia.io/',
       'https://*.algolia.net/',
       'https://*.algolianet.com/',
       opts.githubApiOrigin,


### PR DESCRIPTION
Updated algolia search version, and introduced search-insights for anonymized click analytics. Specifically does not use cookies and does not store any identifiable data. Reason for introduction is because I realized I am only updating our site based on searches with no results, but not searches with no clicks.

This causes the problem that we had results for `componentDidMount` which linked to this page https://lit.dev/docs/frameworks/react/#how-it-works which is a bad result. Something like that could have been caught with click data.