### PR TITLE
[docs] update ContextRequestEvent signature

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/data/context.md
+++ b/packages/lit-dev-content/site/docs/v3/data/context.md
@@ -503,6 +503,10 @@ The `context-request` bubbles and is composed.
 
     The context object this event is requesting a value for
 
+- `readonly contextTarget: Element`
+
+    The original context target of the requester
+
 - `readonly callback: ContextCallback<ContextType<C>>`
 
     The function to call to provide a context value

--- a/packages/lit-dev-content/site/docs/v3/data/context.md
+++ b/packages/lit-dev-content/site/docs/v3/data/context.md
@@ -505,7 +505,7 @@ The `context-request` bubbles and is composed.
 
 - `readonly contextTarget: Element`
 
-    The original context target of the requester
+    The DOM element that initiated the context request
 
 - `readonly callback: ContextCallback<ContextType<C>>`
 


### PR DESCRIPTION
Document changes to `ContextRequestEvent` in @lit/context 

https://github.com/lit/lit/pull/4734
https://github.com/lit/lit/blob/main/packages/context/src/lib/context-request-event.ts#L51-L65