### PR TITLE
feat: update Lion web URL

### DIFF
--- a/packages/lit-dev-content/site/home/5-who-is-using.html
+++ b/packages/lit-dev-content/site/home/5-who-is-using.html
@@ -82,7 +82,7 @@
         </div>
       </a>
 
-      <a target="_blank" rel="noopener" href="https://lion-web.netlify.app/#:~:text=LitElement">
+      <a target="_blank" rel="noopener" href="https://lion.js.org/#:~:text=LitElement">
         <lazy-svg
           svg-role="img"
           label="ING"

--- a/packages/lit-dev-content/site/tutorials/content/word-viewer/00.md
+++ b/packages/lit-dev-content/site/tutorials/content/word-viewer/00.md
@@ -47,7 +47,7 @@ favorites:
 
  * [&lt;Model Viewer>](https://modelviewer.dev/) - Like an `<img>` tag but for
    3D!!!!
- * [Lion component library](https://lion-web.netlify.app/components/) -
+ * [Lion component library](https://lion.js.org/components/) -
    Fundamental white label web components for building  your design system.
  * [Shoelace](https://shoelace.style/) - A forward-thinking library of web
    components.

--- a/packages/lit-dev-tests/known-good-urls.txt
+++ b/packages/lit-dev-tests/known-good-urls.txt
@@ -9,7 +9,7 @@ https://core.clarity.design/
 https://auro.alaskaair.com/#:~:text=Using%20LitElement%20as%20a%20base
 https://spdx.org/licenses/CC-BY-3.0
 https://www.npmjs.com/package/lit
-https://lion-web.netlify.app/#:~:text=LitElement
+https://lion.js.org/#:~:text=LitElement
 https://hilla.dev/#:~:text=Lit
 https://github.com/lit/lit/
 https://opensource.adobe.com/spectrum-web-components/#:~:text=LitElement


### PR DESCRIPTION
This PR will update all Lion's website URLs found.

Lion's website recently moved to a new address: [lion.js.org](https://lion.js.org)
See: https://github.com/ing-bank/lion/commit/bc175b5609ffedc83060d9b7f6bbdf2be49c2837