### PR TITLE
fix banner icon size on safari

### DIFF
--- a/packages/lit-dev-content/site/home/1-splash.html
+++ b/packages/lit-dev-content/site/home/1-splash.html
@@ -3,8 +3,8 @@
     We're now on Bluesky! Follow us
     <a href="https://bsky.app/profile/lit.dev">here</a>!
     <span class="emoji" style="vertical-align: middle;"><lazy-svg
-      height="1rem"
-      width="1rem"
+      height="16px"
+      width="16px"
       href="{{ site.baseurl }}/images/social/bluesky.svg#bluesky"
       label="Bluesky"
       loading="eager">


### PR DESCRIPTION
In safari the icon is HUGE

<img width="964" alt="image" src="https://github.com/user-attachments/assets/76c67500-2f55-4c0f-bc45-175fecc049c3" />
