### PR TITLE
[site] Update footer to adhere to OpenJS standards

### DIFF
--- a/packages/lit-dev-content/site/_includes/footer.html
+++ b/packages/lit-dev-content/site/_includes/footer.html
@@ -1,22 +1,5 @@
 <footer>
   <div id="footerTop">
-    <a
-      href="https://openjsf.org/"
-      target="_blank"
-      rel="noopener"
-      title="OpenJS Foundation"
-    >
-      <lazy-svg
-        loading="visible"
-        id="footerOpenJSLogo"
-        href="{{
-          site.baseurl
-        }}/images/openjs_foundation-logo-horizontal-color.svg"
-        label="OpenJS logo"
-      >
-      </lazy-svg>
-    </a>
-
     <div id="footerLitLogoWrapper">
       <lazy-svg
         loading="visible"
@@ -141,8 +124,51 @@
   </div>
 
   <div id="footerBottom">
+    <div id="footerCopyright">
+      <a
+        href="https://openjsf.org/"
+        target="_blank"
+        rel="noopener"
+        title="OpenJS Foundation"
+        ><lazy-svg
+          loading="visible"
+          id="footerOpenJSLogo"
+          href="{{
+            site.baseurl
+          }}/images/openjs_foundation-logo-horizontal-color.svg"
+          label="OpenJS logo"
+        ></lazy-svg
+      ></a>
+      <p>
+        <a href="https://openjsf.org">The OpenJS Foundation</a> |
+        <a href="https://terms-of-use.openjsf.org">Terms of Use</a> |
+        <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> |
+        <a href="https://bylaws.openjsf.org">Bylaws</a> |
+        <a href="https://code-of-conduct.openjsf.org">Code of Conduct</a> |
+        <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> |
+        <a href="https://trademark-list.openjsf.org">Trademark List</a> |
+        <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a>
+      </p>
+    </div>
     <p>
-      Copyright (c) The Lit Project. Code licensed under
+      Copyright <a href="https://openjsf.org">OpenJS Foundation</a> and the Lit
+      Project. All rights reserved. The
+      <a href="https://openjsf.org">OpenJS Foundation</a> has registered
+      trademarks and uses trademarks. For a list of trademarks of the
+      <a href="https://openjsf.org">OpenJS Foundation</a>, please see our
+      <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> and
+      <a href="https://trademark-list.openjsf.org">Trademark List</a>.
+      Trademarks and logos not indicated on the
+      <a href="https://trademark-list.openjsf.org"
+        >list of OpenJS Foundation trademarks</a
+      >
+      are trademarks&trade; or registered&reg; trademarks of their respective
+      holders. Use of them does not imply any affiliation with or endorsement by
+      them.
+    </p>
+
+    <p>
+      Code licensed under
       <a href="https://spdx.org/licenses/BSD-3-Clause.html">BSD-3-Clause</a>.
       Documentation licensed under
       <a href="https://spdx.org/licenses/CC-BY-3.0">CC-BY-3.0</a>.

--- a/packages/lit-dev-content/site/css/footer.css
+++ b/packages/lit-dev-content/site/css/footer.css
@@ -24,7 +24,8 @@
 }
 
 #footerOpenJSLogo {
-  height: 2.5em;
+  width: 10rem;
+  height: 6rem;
 }
 
 #footerSocialLinks {
@@ -49,22 +50,37 @@
 }
 
 #footerBottom {
-  height: var(--footer-bottom-height);
-  padding: 0 0.5em;
-  display: flex;
+  /* height: var(--footer-bottom-height); */
+  font-size: .825rem;
+  padding: 2rem 4rem;
   align-items: center;
   justify-content: center;
-  text-align: center;
   line-height: 1.7em;
 }
 
-#footerBottom > p > a {
-  color: var(--sys-color-primary);
+#footerBottom p {
+  font-size: inherit;
+  margin-top: 0;
+}
+
+#footerBottom a {
+  /* color: var(--sys-color-primary); */
   font-weight: 600;
 }
 
-#footerBottom > p > a:hover {
+#footerBottom a:hover {
   text-decoration: underline;
+}
+
+#footerCopyright {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#footerCopyright > * {
+  margin: 0;
 }
 
 @media (max-width: 864px) {

--- a/packages/lit-dev-content/site/css/global.css
+++ b/packages/lit-dev-content/site/css/global.css
@@ -23,7 +23,7 @@ html {
      content begins (e.g. other sticky elements, scroll-margin-top). */
   --header-height: calc(var(--header-nav-height) + var(--banner-height));
   --footer-top-height: 12rem;
-  --footer-bottom-height: 6rem;
+  --footer-bottom-height: 10rem;
   --content-max-width: 76rem;
   -webkit-font-smoothing: antialiased;
 }

--- a/packages/lit-dev-content/site/docs/v3/resources/community.md
+++ b/packages/lit-dev-content/site/docs/v3/resources/community.md
@@ -9,33 +9,4 @@ versionLinks:
   v2: resources/community/
 ---
 
-There are many great resources and locations to learn about Lit,
-share what you've built, and more. Participation in our community is subject to the Lit
-[Code of Conduct](https://github.com/lit/lit/blob/master/CODE_OF_CONDUCT.md)—be
-excellent to each other!
-
-*   **Join us on [Discord](/discord/)!**
-    Chat about Lit, get help, or share your project in the Lit Discord server.
-
-*   **Follow us at [@buildWithLit on X (formerly Twitter)](https://twitter.com/buildWithLit)**
-    for the latest on Lit and web components. Many
-    of our team members can also be found tweeting about Lit,
-    and the latest developments in the web platform.
-
-*   **Follow us on [Bluesky](https://bsky.app/profile/lit.dev)**
-    for updates and news from the Lit team.
-
-*   **Talk about Lit on [GitHub Discussions](https://github.com/lit/lit/discussions).** For longer questions or ideas about Lit, or to see what others are talking about, GitHub discussions are a great way to connect with the team and community.
-
-*   **Import the [Lit Community Calendar](/community-calendar/)** to keep up to date on official community events like the weekly Open Eng Meeting and Community Calls. Add it to your Google Calendar by pressing the "+ Google Calendar" button at the bottom right corner of the calendar page.
-
-*   **Find answers on [StackOverflow](https://stackoverflow.com/questions/tagged/lit+or+lit-html+or+lit-element).**
-    Search the [`lit`, `lit-element`, and `lit-html`](https://stackoverflow.com/questions/tagged/lit+or+lit-html+or+lit-element) tags when
-    looking for answers. You can also find help on underlying web standards with
-    tags like [`web-component`](https://stackoverflow.com/tags/web-component),
-    and try your hand at answering other people’s queries.
-
-*   **Watch Lit videos on [YouTube](/youtube/).** The Lit team has a dedicated YouTube channel with tutorials and update streams.
-
-
-
+There are many great resources and locations to learn about Lit


### PR DESCRIPTION
Fixes #1455 for real this time, including the standard OpenJS footer text.

The footer now looks like: <img width="1341" height="547" alt="Image" src="https://github.com/user-attachments/assets/603eceb9-ab24-4535-ae22-730dc8a58ebc" />