### PR TITLE
docs(controllers): add controller registration to his host

### DIFF
--- a/packages/lit-dev-content/samples/v3-docs/controllers/names/names-controller.ts
+++ b/packages/lit-dev-content/samples/v3-docs/controllers/names/names-controller.ts
@@ -11,6 +11,7 @@ export class NamesController {
 
   constructor(host: ReactiveControllerHost) {
     this.host = host;
+    host.addController(this);
     this.task = new Task<[Names.Kind], Names.Result>(host,
       async ([kind]: [Names.Kind]) => {
         if (!kind?.trim()) {


### PR DESCRIPTION
Hello, this PR intent to fix a small issue on the controllers with asynchronous task playground.
The controller should register himself to the host otherwise when we remove "my-element" from the DOM the hostDisconnected lifecycle hook will never be called.