### PR TITLE
[codex] Fix Rollup docs import examples

### DIFF
--- a/packages/lit-dev-content/site/docs/v2/tools/production.md
+++ b/packages/lit-dev-content/site/docs/v2/tools/production.md
@@ -68,12 +68,14 @@ npm i --save-dev rollup \
 `rollup.config.js:`
 ```js
 // Import rollup plugins
-import html from '@web/rollup-plugin-html';
+import {rollupPluginHTML as html} from '@web/rollup-plugin-html';
 import {copy} from '@web/rollup-plugin-copy';
 import resolve from '@rollup/plugin-node-resolve';
-import {terser} from '@rollup/plugin-terser';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
+import terser from '@rollup/plugin-terser';
+import pkgMinifyHTML from 'rollup-plugin-minify-html-literals';
 import summary from 'rollup-plugin-summary';
+
+const minifyHTML = pkgMinifyHTML.default;
 
 export default {
   plugins: [
@@ -135,14 +137,16 @@ npm i --save-dev rollup \
 `rollup.config.js:`
 ```js
 // Import rollup plugins
-import html from '@web/rollup-plugin-html';
+import {rollupPluginHTML as html} from '@web/rollup-plugin-html';
 import polyfillsLoader from '@web/rollup-plugin-polyfills-loader';
 import {copy} from '@web/rollup-plugin-copy';
 import resolve from '@rollup/plugin-node-resolve';
 import {getBabelOutputPlugin} from '@rollup/plugin-babel';
 import {terser} from 'rollup-plugin-terser';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
+import pkgMinifyHTML from 'rollup-plugin-minify-html-literals';
 import summary from 'rollup-plugin-summary';
+
+const minifyHTML = pkgMinifyHTML.default;
 
 // Configure an instance of @web/rollup-plugin-html
 const htmlPlugin = html({

--- a/packages/lit-dev-content/site/docs/v3/tools/production.md
+++ b/packages/lit-dev-content/site/docs/v3/tools/production.md
@@ -68,12 +68,14 @@ npm i --save-dev rollup \
 `rollup.config.js:`
 ```js
 // Import rollup plugins
-import html from '@web/rollup-plugin-html';
+import {rollupPluginHTML as html} from '@web/rollup-plugin-html';
 import {copy} from '@web/rollup-plugin-copy';
 import resolve from '@rollup/plugin-node-resolve';
-import {terser} from '@rollup/plugin-terser';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
+import terser from '@rollup/plugin-terser';
+import pkgMinifyHTML from 'rollup-plugin-minify-html-literals';
 import summary from 'rollup-plugin-summary';
+
+const minifyHTML = pkgMinifyHTML.default;
 
 export default {
   plugins: [


### PR DESCRIPTION
## What changed

This updates the Rollup production docs so the example imports match the current package export shapes.

## Why

The current snippets fail in a modern ESM setup:

- `@web/rollup-plugin-html` no longer provides a default export in the form used by the docs.
- `@rollup/plugin-terser` should be imported as a default export.
- `rollup-plugin-minify-html-literals` needs CommonJS interop in these examples.

## Scope

- Fix the modern-only Rollup example in v2 and v3 docs.
- Fix the v2 modern+legacy Rollup example for the same import issues.
- Leave `rollup-plugin-summary` unchanged because its documented import already works.

## Validation

- Reproduced the current import failures in a clean temp project with current package versions.
- Verified the replacement imports load under Node 22 ESM.
