### PR TITLE
[site] Fix footer logos not rendering in Safari/WebKit

### DIFF
--- a/packages/lit-dev-content/site/_includes/footer.html
+++ b/packages/lit-dev-content/site/_includes/footer.html
@@ -4,7 +4,7 @@
       <lazy-svg
         loading="visible"
         id="footerLitLogo"
-        href="{{ site.baseurl }}/images/logo.svg"
+        href="{{ site.baseurl }}/images/logo.svg#full"
         label="Lit"
       >
       </lazy-svg>
@@ -126,19 +126,12 @@
   <div id="footerBottom">
     <div id="footerCopyright">
       <a
+        id="footerOpenJSLogo"
         href="https://openjsf.org/"
         target="_blank"
         rel="noopener"
         title="OpenJS Foundation"
-        ><lazy-svg
-          loading="visible"
-          id="footerOpenJSLogo"
-          href="{{
-            site.baseurl
-          }}/images/openjs_foundation-logo-horizontal-color.svg"
-          label="OpenJS logo"
-        ></lazy-svg
-      ></a>
+        >{% inlineSvg 'images/openjs_foundation-logo-horizontal-color.svg', 'OpenJS logo' %}</a>
       <p>
         <a href="https://openjsf.org">The OpenJS Foundation</a> |
         <a href="https://terms-of-use.openjsf.org">Terms of Use</a> |

--- a/packages/lit-dev-content/site/css/footer.css
+++ b/packages/lit-dev-content/site/css/footer.css
@@ -113,4 +113,9 @@
   #footerBottom {
     font-size: 0.8em;
   }
+
+  #footerCopyright {
+    flex-direction: column;
+    margin-bottom: 1rem;
+  }
 }

--- a/packages/lit-dev-content/site/css/footer.css
+++ b/packages/lit-dev-content/site/css/footer.css
@@ -23,7 +23,7 @@
   height: 4em;
 }
 
-#footerOpenJSLogo {
+#footerOpenJSLogo svg {
   width: 10rem;
   height: 6rem;
 }


### PR DESCRIPTION
Safari requires a #fragment when referencing external SVGs via `<use>`— a bare href like logo.svg is not supported. Fixed the Lit footer logo by adding the existing #full fragment to its href.

The OpenJS logo has an additional complication: it uses a linearGradient with url() references, which Safari cannot resolve across the <use> shadow tree boundary even with a valid fragment. Replaced lazy-svg with inlineSvg so the SVG becomes part of the host document, where url() resolves correctly.

After fix is applied (demonstrated in Safari desktop):

<img width="2048" height="1151" alt="image" src="https://github.com/user-attachments/assets/f97c5c9c-a183-4263-9203-c24fe972b8fa" />

Also fixes the layout so the links display properly on mobile devices:

Before:

<img width="304" height="537" alt="image" src="https://github.com/user-attachments/assets/49c84a9f-b872-445d-ad45-83f90e8f2c53" />

After:

<img width="308" height="541" alt="image" src="https://github.com/user-attachments/assets/b38449da-008f-44cb-a4fb-ca00c51a242c" />

Resolves #1470