### PR TITLE
SSR: Fix SSR Table in authoring.md to reflect more recent info

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/ssr/authoring.md
+++ b/packages/lit-dev-content/site/docs/v3/ssr/authoring.md
@@ -103,16 +103,16 @@ Whether a method is called on the server is subject to change while Lit SSR is p
 | Method | Called on server | Notes |
 |-|-|-|
 | `constructor()` | Yes ⚠️ | |
-| `connectedCallback()` | No | |
+| `connectedCallback()` | No ⚠️ | Called when `renderOptions.connectedCallback === true` |
 | `disconnectedCallback()` | No | |
 | `attributeChangedCallback()` | No | |
 | `adoptedCallback()` | No | |
 | `hasChanged()` | Yes ⚠️ | Called when property is set |
 | `shouldUpdate()` | No | |
 | `willUpdate()` | Yes ⚠️ | Called before `render()` |
-| `update()` | No | |
+| `update()` | Yes | |
 | `render()` | Yes ⚠️ | |
-| `firstUpdate()` | No | |
+| `firstUpdated()` | No | |
 | `updated()` | No | |
 
 ### ReactiveController


### PR DESCRIPTION
- Adds note about `connectedCallback` - https://github.com/lit/lit/blob/ada3ffce30cdb6a2f9a9d476767eaf747a0b2667/packages/labs/ssr/src/lib/lit-element-renderer.ts#L150-L153
- Fixes `firstUpdate` to `firstUpdated` - https://lit.dev/docs/components/lifecycle/#firstupdated
- Fixes `update` to reflect it *is* called during SSR. https://github.com/lit/lit/blob/ada3ffce30cdb6a2f9a9d476767eaf747a0b2667/packages/labs/ssr/src/lib/lit-element-renderer.ts#L180