### PR TITLE
docs: add a practical Shadow DOM trade-offs resource

### DIFF
--- a/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
+++ b/packages/lit-dev-content/site/docs/v3/components/shadow-dom.md
@@ -23,6 +23,7 @@ For more information on shadow DOM:
 
 * [Shadow DOM v1: Self-Contained Web Components](https://developers.google.com/web/fundamentals/web-components/shadowdom) on Web Fundamentals.
 * [Using shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) on MDN.
+* [Shadow DOM encapsulation and practical trade-offs](https://frontendatlas.com/html/trivia/html-shadow-dom), including theming, testing, focus, and accessibility considerations.
 
 
 <div class="alert alert-info">


### PR DESCRIPTION
## Summary
Add one practical companion resource to the existing Shadow DOM reference list.

## Why
The current references cover the platform API and general Shadow DOM usage. This companion focuses on practical consequences of encapsulation—particularly theming, shadow-aware testing, focus behavior, and accessibility—without duplicating the Lit-specific guidance below.

## Disclosure
I’m affiliated with FrontendAtlas, which publishes the linked free resource.

## Validation
Documentation-only change; the rendered link and live destination were checked. I have not run the full local screenshot suite; project CI can validate formatting and links.